### PR TITLE
docs: add Analytics and Defining Your Models pages (closes #47)

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -402,6 +402,7 @@ export default defineConfig({
         text: 'Data Persistence',
         items: [
           { text: 'Choosing Your Data Model', link: '/getting-started/choosing-your-data-model' },
+          { text: 'Defining Your Models', link: '/getting-started/defining-your-models' },
           { text: 'Working with Documents', link: '/getting-started/working-with-documents' },
           { text: 'Working with Databases', link: '/getting-started/working-with-databases' },
           { text: 'Blobs and Files', link: '/getting-started/blobs-and-files' },
@@ -413,6 +414,7 @@ export default defineConfig({
         items: [
           { text: 'Workflows and Prompts', link: '/getting-started/workflows-and-prompts' },
           { text: 'API Integrations', link: '/getting-started/api-integrations' },
+          { text: 'Analytics', link: '/getting-started/analytics' },
         ],
         collapsed: false,
       },

--- a/docs/getting-started/admin-console.md
+++ b/docs/getting-started/admin-console.md
@@ -63,6 +63,7 @@ The Primitive Admin Console is a web-based dashboard for managing your apps, use
 - View usage metrics and event counts
 - Monitor daily active users
 - Track custom events
+- See [Analytics](./analytics.md) for the emit and query APIs that feed this view
 
 ## When to Use the Console vs. the CLI
 
@@ -83,3 +84,4 @@ In practice, many developers use the console for exploring and testing, and the 
 - **[Primitive CLI](./primitive-cli.md)** — Command-line alternative for all admin tasks
 - **[Workflows and Prompts](./workflows-and-prompts.md)** — Define the workflows you'll test in the console
 - **[API Integrations](./api-integrations.md)** — Configure the integrations you'll manage in the console
+- **[Analytics](./analytics.md)** — Emit and query the events that show up under Analytics

--- a/docs/getting-started/analytics.md
+++ b/docs/getting-started/analytics.md
@@ -1,0 +1,244 @@
+# Analytics
+
+Primitive includes a built-in analytics pipeline. Events are buffered on the client, batched over WebSocket, persisted server-side, and made available through CLI commands, REST endpoints, the Admin Console, and workflow steps. The platform tracks daily/weekly/monthly active users and the full document, permission, workflow, prompt, and integration lifecycle automatically — your app can ship with analytics on day one and add custom events later.
+
+This page covers what's tracked out of the box, how to emit your own events, and how to read analytics back from the client, the CLI, and from workflows.
+
+## What's Tracked Automatically
+
+You get a working analytics pipeline by initializing `JsBaoClient` with default options. No `logEvent` calls required.
+
+### Client-Side Auto Events
+
+The client emits these lifecycle events automatically. All are enabled by default.
+
+| Action | Feature | When it fires |
+|---|---|---|
+| `user_active_daily` | `session` | First authenticated activity on a UTC day |
+| `user_returned` | `session` | Tab becomes visible after `minResumeMs` (default 5 min) hidden |
+| `session_end` | `session` | `beforeunload` or `client.destroy()` (records `duration_ms`) |
+| `sync_error` | `sync` | Outbound sync fails (rate-limited, default 30s minimum interval) |
+| `blob_upload_started` / `_succeeded` / `_failed` | `blobs` | Blob upload lifecycle |
+| `prompt_started` / `_succeeded` / `_failed` | `llm`, `gemini` | LLM call lifecycle |
+
+### Server-Side Events
+
+The platform emits these from the server. No client code required.
+
+| Category | Examples |
+|---|---|
+| Documents | `document.created`, `document.viewed`, `document.opened`, `document.updated`, `document.deleted`, `document.tag_added`, `document.tag_removed` |
+| Permissions | `permission.granted`, `permission.revoked`, `permission.pending.cancelled`, `ownership.transferred` |
+| Invitations | `invitation.sent`, `invitation.cancelled`, `invitation.declined` |
+| Auth & Users | `session.refreshed`, `user.removed`, `user.role_changed`, `token.created`, `token.revoked` |
+| Workflows / Prompts | `workflow.started`, `workflow.completed`, `workflow.failed`, `prompt.executed` |
+| Integrations | `integration.invoke` |
+
+Workflow and prompt events also record `duration_ms` and LLM token counts (`input_tokens`, `output_tokens`, `total_tokens`) when available.
+
+### Auto-Populated Fields
+
+Every event — auto or custom — gets these fields populated automatically: `tenant_id`, `route`, `device_type`, `os_name`, `os_version`, `browser_name`, `browser_version`, `plan`, `connection_id`.
+
+### Offline Persistence
+
+Events are persisted to IndexedDB while offline (1 MiB cap, oldest dropped when full) and flushed on reconnect. A rate limiter caps emission at 300 events/minute with a 60-token burst. No code required.
+
+## Emitting Custom Events
+
+Use `client.analytics.logEvent()` for app-specific events:
+
+```typescript
+client.analytics.logEvent({
+  action: "photo_uploaded",
+  feature: "gallery",
+  user_ulid: currentUserUlid,
+});
+```
+
+`action` and `user_ulid` are required. Use the verb_noun convention for action names (`photo_uploaded`, `report_generated`, `settings_changed`) and group related events under a `feature` so per-feature dashboards work.
+
+### Adding Context
+
+Pass a `context_json` object for per-event debug data. It's serialized and **truncated to 1 KiB**, so keep it small — don't dump request bodies or full reports.
+
+```typescript
+client.analytics.logEvent({
+  action: "search_executed",
+  feature: "search",
+  user_ulid: currentUserUlid,
+  context_json: {
+    query: "quarterly report",
+    resultCount: 42,
+  },
+});
+```
+
+### Pre-Auth Events
+
+Events without an authenticated user are dropped silently. To track activity on landing pages and sign-up flows, use the `ANALYTICS_UNAUTHENTICATED_USER` constant:
+
+```typescript
+import { ANALYTICS_UNAUTHENTICATED_USER } from "js-bao-wss-client";
+
+client.analytics.logEvent({
+  action: "landing_page_view",
+  feature: "onboarding",
+  user_ulid: ANALYTICS_UNAUTHENTICATED_USER,
+});
+```
+
+Use sparingly — most analytics should be tied to real users.
+
+### Snapshots
+
+`logSnapshot()` records a single state snapshot. The user is auto-resolved; if no user is signed in the call is a no-op (no error).
+
+```typescript
+client.analytics.logSnapshot({ screen: "settings", tab: "billing" });
+```
+
+This emits an event with `action: "_snapshot"`, `feature: "_state"`, and your payload as `context_json`.
+
+### Plan and App Version Overrides
+
+If your app reports plan/version dynamically (e.g. after an in-app upgrade), set them once on the client and they flow into every subsequent event:
+
+```typescript
+client.analytics.setPlanOverride("pro");
+client.analytics.setAppVersionOverride("2.1.4");
+
+// Pass null/undefined to clear an override
+client.analytics.setPlanOverride(null);
+```
+
+### What to Avoid
+
+- **Don't log without `user_ulid`** — TypeScript will catch it, and the runtime drops the event silently.
+- **Don't log high-frequency telemetry** (mouse moves, scroll, keystrokes) — the rate limiter caps at 300 events/min and will drop the rest.
+- **Don't add your own `beforeunload` flush** — the client already does this and emits `session_end` for you.
+
+## Configuring Auto Events
+
+Pass an `analyticsAutoEvents` option to the client constructor to fine-tune the lifecycle events. Sub-options accept either a boolean or a granular `{ start, success, failure }` shape for the upload/LLM events.
+
+```typescript
+import { JsBaoClient } from "js-bao-wss-client";
+
+const client = new JsBaoClient({
+  appId: "app-123",
+  apiUrl: "https://api.example.com",
+  wsUrl: "wss://ws.example.com",
+  analyticsAutoEvents: {
+    dailyAuth: true,
+    returnActive: true,
+    minResumeMs: 5 * 60 * 1000,
+    sessionEnd: true,
+    syncErrors: { enabled: true, minIntervalMs: 30_000 },
+    blobUploads: { start: false, success: true, failure: true },
+    llm: { start: false, success: true, failure: true },
+    gemini: false,
+  },
+});
+```
+
+## Querying Analytics
+
+There are four ways to read analytics back: the CLI (terminal-friendly, scriptable), REST (admin-only), workflows (server-side, scheduled), and the Admin Console (visual).
+
+### From the CLI
+
+All commands support `--json` for machine-readable output. Most accept a `--window-days` flag.
+
+```bash
+# DAU / WAU / MAU + growth (default 28-day window)
+primitive analytics overview
+primitive analytics overview --window-days 28 --json
+
+# Active-user series
+primitive analytics daily-active --window-days 28
+primitive analytics rolling-active --window-days 7
+
+# Cohort retention (no window flag — full matrix)
+primitive analytics cohort-retention
+
+# Top users
+primitive analytics top-users --window-days 7 --limit 20
+
+# Search and per-user
+primitive analytics user-search --query user@example.com
+primitive analytics user-detail <user-ulid>
+primitive analytics user-snapshot <user-ulid>
+
+# Raw event feed
+primitive analytics events --window-days 7 --page 0
+
+# Group by: action | feature | route | country | deviceType | plan | day
+primitive analytics events-grouped --group-by feature --window-days 14
+
+# Workflow / prompt / integration analytics
+primitive analytics workflows --limit 5
+primitive analytics prompts --limit 5
+primitive analytics integrations
+```
+
+### From the REST API
+
+All endpoints require `admin` permission on the app.
+
+```text
+GET /app/{appId}/api/analytics/overview/dau?windowDays=28
+GET /app/{appId}/api/analytics/overview/wau?windowDays=28
+GET /app/{appId}/api/analytics/overview/mau?windowDays=28
+GET /app/{appId}/api/analytics/overview/growth?windowDays=28
+
+GET /app/{appId}/api/analytics/daily-active?windowDays=28
+GET /app/{appId}/api/analytics/rolling-active?windowDays=7
+GET /app/{appId}/api/analytics/cohort-retention
+
+GET /app/{appId}/api/analytics/users/top?windowDays=30&limit=10
+GET /app/{appId}/api/analytics/users/search?q=...&limit=25
+GET /app/{appId}/api/analytics/users/{userUlid}/detail
+GET /app/{appId}/api/analytics/users/{userUlid}/snapshot
+
+GET /app/{appId}/api/analytics/events?windowDays=7&page=0
+GET /app/{appId}/api/analytics/events/grouped?windowDays=7&groupBy=action
+
+GET /app/{appId}/api/analytics/integrations?windowDays=30
+GET /app/{appId}/api/analytics/workflows/top?windowDays=30&limit=10
+GET /app/{appId}/api/analytics/prompts/top?windowDays=30&limit=10
+```
+
+### From a Workflow
+
+Workflows can run analytics queries as a step. This is the simplest way to ship a recurring digest, an admin email, or a Slack post that summarizes activity. See [Workflows and Prompts](./workflows-and-prompts.md#analytics-query-step) for the full step reference.
+
+```toml
+[[steps]]
+name = "top-users-weekly"
+type = "analytics.query"
+queryType = "top-users"
+windowDays = 7
+limit = 25
+```
+
+The runner is **default-deny** — non-admin callers are rejected before the upstream call. Lock down workflows that contain `analytics.query` steps with `accessRule = "hasRole('admin')"` (or fire them via cron). Each run is capped at 50 analytics queries.
+
+### From the Admin Console
+
+The **Analytics** section of the [Admin Console](./admin-console.md) shows usage metrics, daily/weekly/monthly active users, and per-user breakdowns visually. Use it for ad-hoc exploration; use the CLI or a workflow when you need scripted or recurring queries.
+
+## Best Practices
+
+1. **Use verb_noun action names** — `photo_uploaded`, `report_generated`, `settings_changed`.
+2. **Group events with `feature`** — set consistently to enable per-feature dashboards (`gallery`, `settings`, `billing`).
+3. **Keep `context_json` small** — truncated to 1 KiB. Don't include full payloads.
+4. **Don't log per-frame telemetry** — design around meaningful actions, not continuous telemetry.
+5. **Use `setPlanOverride` / `setAppVersionOverride`** instead of passing `plan` / `app_version` on every call.
+6. **Lock down analytics workflows** — they read aggregate data; keep `accessRule = "hasRole('admin')"` on anything that surfaces analytics.
+
+## Next Steps
+
+- **[Workflows and Prompts](./workflows-and-prompts.md#analytics-query-step)** — Wire analytics into recurring workflows
+- **[Admin Console](./admin-console.md)** — Visual analytics dashboards
+- **[Primitive CLI](./primitive-cli.md)** — Full `primitive analytics` reference

--- a/docs/getting-started/defining-your-models.md
+++ b/docs/getting-started/defining-your-models.md
@@ -1,0 +1,227 @@
+# Defining Your Models
+
+Models are the typed shape of the data your app stores in **documents** (and the same shape used as `modelName` references in **database** operations). The current way to author models is **TOML-first**: declare them in `src/models/models.toml`, run `pnpm codegen`, and import the generated TypeScript classes from `@/models`.
+
+This page is the canonical reference for the model authoring loop. For document-level CRUD and querying, see [Working with Documents](./working-with-documents.md). For database operations and registered queries, see [Working with Databases](./working-with-databases.md).
+
+## Why TOML + Codegen
+
+Defining models in TOML, with codegen producing the TypeScript classes, gives you:
+
+- **Reviewable diffs** — your data model lives in one config file, versioned alongside your code. A schema change is one diff, not many.
+- **Strong typing for free** — the generator emits typed `*Attrs` interfaces, model classes, and traversal methods for declared relationships. You can't typo a field name.
+- **Auto-registration** — the generated `src/models/index.ts` barrel registers every model with `js-bao` exactly once at app startup. Nothing to remember to wire up.
+- **Sync validation at boot** — the barrel checks that `models.toml` and the generated classes match. If they're out of sync, the app throws at startup and tells you to re-run codegen.
+
+## The Authoring Loop
+
+A typical model change is three small steps:
+
+1. **Edit** `src/models/models.toml` — add a model, add a field, declare a relationship.
+2. **Run** `pnpm codegen` — regenerates `*.generated.ts` files and the `src/models/index.ts` barrel.
+3. **Import** the model from `@/models` and use it like any other class.
+
+```bash
+# After editing src/models/models.toml
+pnpm codegen
+```
+
+The `codegen` script is wired up in the project template — under the hood it runs `npx js-bao-codegen-v2 -i src/models/models.toml -o src/models`.
+
+::: warning Never edit generated files
+The codegen output — every `*.generated.ts` file and `src/models/index.ts` — is overwritten on each run. Make all changes in `models.toml`. If you need custom behavior on top of a generated class, define free functions in `src/lib/` rather than subclassing.
+:::
+
+## Authoring `models.toml`
+
+Each model is a top-level `[models.<name>]` block. Fields go under `[models.<name>.fields.<fieldName>]`. Relationships go under `[models.<name>.relationships.<relName>]`.
+
+Field option names use `snake_case` in TOML (the loader maps them to camelCase at runtime).
+
+```toml
+[models.todos.fields.id]
+type = "id"
+auto_assign = true
+indexed = true
+
+[models.todos.fields.title]
+type = "string"
+indexed = true
+
+[models.todos.fields.completed]
+type = "boolean"
+default = false
+
+[models.todos.fields.priority]
+type = "number"
+default = 0
+
+[models.todos.fields.due_date]
+type = "date"
+
+[models.todos.fields.tags]
+type = "stringset"
+max_count = 10
+```
+
+### Field Types
+
+| Type        | TypeScript    | Description                          | Common Options                  |
+| ----------- | ------------- | ------------------------------------ | ------------------------------- |
+| `id`        | `string`      | Unique identifier                    | `auto_assign = true`, `indexed` |
+| `string`    | `string`      | Text value                           | `indexed`, `default`, `unique`  |
+| `number`    | `number`      | Numeric value                        | `indexed`, `default`            |
+| `boolean`   | `boolean`     | True/false                           | `default`                       |
+| `date`      | `string`      | ISO-8601 timestamp string            | `indexed`                       |
+| `stringset` | `StringSet`   | Set-of-strings (tags, categories)    | `max_count`                     |
+
+### Field Options
+
+```toml
+[models.tasks.fields.id]
+type = "id"
+auto_assign = true     # server-assigns a ULID on save
+indexed = true         # required for fast lookup by id
+
+[models.tasks.fields.email]
+type = "string"
+unique = true          # single-field uniqueness — enables upsertOn
+indexed = true
+
+[models.tasks.fields.priority]
+type = "number"
+default = 0
+
+[models.tasks.fields.tags]
+type = "stringset"
+max_count = 10
+```
+
+### Unique Constraints
+
+Two ways to enforce uniqueness:
+
+**Single-field uniqueness** — set `unique = true` on the field. This also enables `upsertOn` for that field on save.
+
+```toml
+[models.users.fields.email]
+type = "string"
+unique = true
+indexed = true
+```
+
+**Composite (multi-field) uniqueness** — declare a named constraint under `[models.<name>.options]`.
+
+```toml
+[[models.categories.options.unique_constraints]]
+name = "name_parent_unique"
+fields = ["name", "parentId"]
+```
+
+The constraint `name` is what you pass to `upsertByUnique` / `findByUnique` at runtime.
+
+## Relationships
+
+Declare relationships in TOML and codegen emits typed traversal methods on the generated interfaces.
+
+```toml
+# Author hasMany Posts
+[models.authors.relationships.posts]
+type = "hasMany"
+model = "posts"
+related_id_field = "authorId"
+order_by_field = "createdAt"
+order_direction = "DESC"
+
+# Post refersTo Author
+[models.posts.relationships.author]
+type = "refersTo"
+model = "authors"
+related_id_field = "authorId"
+```
+
+After `pnpm codegen`, the generated interfaces include typed traversal methods:
+
+```typescript
+import { Author, Post } from "@/models";
+
+const author = await Author.queryOne({ id: authorId });
+const posts = await author.posts();        // PaginatedResult<Post>
+const firstPost = posts.data[0];
+const backRef = await firstPost.author();  // Author | null
+```
+
+| Relationship type | Returns                            | Required options                            |
+| ----------------- | ---------------------------------- | ------------------------------------------- |
+| `hasMany`         | `Promise<PaginatedResult<T>>`      | `model`, `related_id_field`                 |
+| `refersTo`        | `Promise<T \| null>`               | `model`, `related_id_field`                 |
+| `refersToMany`    | `Promise<T[]>`                     | `model`, `source_field` (an array of IDs)   |
+
+Optional ordering: `order_by_field` and `order_direction = "ASC" | "DESC"` apply to `hasMany` and `refersToMany`.
+
+## Using Generated Models
+
+Always import from the barrel, never directly from a `*.generated.ts` file:
+
+```typescript
+import { Todo, Author, Post } from "@/models";
+
+// Create
+const todo = new Todo({ title: "Review PR", priority: 2 });
+await todo.save();
+
+// Query
+const open = await Todo.query({ completed: false });
+```
+
+The barrel runs `attachAndRegisterModel` for every model exactly once — that's why importing from `@/models` is essential. Importing directly from `Todo.generated.ts` skips registration, which fails at runtime with "Model not properly initialized" on the first save or query.
+
+## Iterating on the Schema
+
+You're free to evolve the schema as the app grows. A few rules of thumb:
+
+- **Add new fields freely** — js-bao stores documents as Yjs CRDTs, so adding an optional field is a no-op for existing records.
+- **Adding `default` doesn't backfill** — existing records keep their absent values; `default` only applies to records created after the change. Read sites should treat the field as optional.
+- **Don't remove fields** — the underlying Yjs data is still there. Mark unused fields with a TOML comment instead, and stop reading them.
+- **Renaming a field is a breaking change** — pick a new field with a new name, write to both during a migration window, then stop writing the old one. Add `default` only for the new field.
+- **Adding a `unique = true` constraint to an existing field** can fail at save time if existing records collide. Inspect the data before tightening uniqueness.
+
+The `index.ts` barrel will throw at startup if `models.toml` and the generated classes drift apart. If you see that error, run `pnpm codegen` and commit the regenerated files.
+
+## Migrating an Existing Project
+
+If you have an older project that defines models with `defineModelSchema()` directly in TypeScript, the codegen CLI ships with a migration tool:
+
+```bash
+npx js-bao-codegen-v2 migrate
+```
+
+This scans your existing model files, generates `src/models/models.toml`, and produces a migration report classifying each model as `safe-to-delete` (fully captured in TOML) or `needs-manual-migration` (custom methods, function-valued defaults, etc. — these need manual review). After running migrate, run `pnpm codegen` and delete the original hand-authored files marked safe.
+
+## Models in Database Operations
+
+Database operations reference models by name in their `modelName` field. The same model names you declare in `models.toml` for documents are the canonical names used in database TOML configs:
+
+```toml
+# In src/models/models.toml — declared once
+[models.todos.fields.id]
+type = "id"
+auto_assign = true
+
+# In .primitive/sync/<env>/<appId>/database-types/personal.toml
+[[operations]]
+name = "list-todos"
+type = "query"
+modelName = "todos"        # references the same model
+access = "params.userId == user.userId"
+definition = '{"filter":{"userId":"$params.userId"}}'
+params = '{"userId":{"type":"string","required":true}}'
+```
+
+Databases themselves are still schemaless on the server — they accept any JSON for a given `modelName`. Sharing the same TOML-defined types means the client gets typed reads/writes for both storage systems without two sources of truth.
+
+## Next Steps
+
+- **[Working with Documents](./working-with-documents.md)** — CRUD, query, sharing, and sync for the data shapes defined here
+- **[Working with Databases](./working-with-databases.md)** — server-side operations that reference these models
+- **[Choosing Your Data Model](./choosing-your-data-model.md)** — when to put data in documents vs. databases

--- a/docs/getting-started/workflows-and-prompts.md
+++ b/docs/getting-started/workflows-and-prompts.md
@@ -228,6 +228,8 @@ All 16 analytics query types are available (overview, top-users, user-detail, ev
 
 Cache TTL overrides are available via `cacheTtlSeconds` — pass `0` or `null` to bypass the cache for a fresh read.
 
+For the full picture — what events are emitted, the client-side `logEvent` API, and the matching CLI/REST surface — see [Analytics](./analytics.md).
+
 ## Inbound Webhooks
 
 Inbound webhooks let external services (Stripe, GitHub, Slack, etc.) trigger workflows automatically. Each webhook has a public URL, signature verification, and automatic workflow triggering.

--- a/docs/getting-started/working-with-databases.md
+++ b/docs/getting-started/working-with-databases.md
@@ -4,8 +4,10 @@ A database is a server-side data store backed by a Cloudflare Durable Object wit
 
 ## Key Properties
 
-### Schemaless
+### Schemaless on the Server
 Save any JSON records without upfront schema definition. There's no `CREATE TABLE` step — collections are created implicitly when you first write to them, and you can add new fields at any time without migrations. This means you can iterate fast, ship changes without coordinating schema updates, and let your data model evolve naturally alongside your application.
+
+That said, registered operations refer to model collections by `modelName`. The recommended pattern is to declare those models once in `src/models/models.toml` so the same names — and the same field shapes — are typed end-to-end on the client, even though the server itself imposes no schema. See [Defining Your Models](./defining-your-models.md) for the TOML authoring loop.
 
 ### Organized by Type
 A **database type** is a named configuration (operations, triggers, access rules) shared across many database instances. Think of it as a template: if you have one database per tenant, project, or team, they all share the same type — update the type once, and every instance inherits the changes. When you create a database with a type that doesn't exist yet, the type is auto-created.
@@ -543,6 +545,7 @@ Timing is available on all operation types: query, mutation, count, aggregate, a
 ## Next Steps
 
 - **[Choosing Your Data Model](./choosing-your-data-model.md)** — When to use databases vs. documents
+- **[Defining Your Models](./defining-your-models.md)** — TOML model authoring shared with documents
 - **[Users and Groups](./users-and-groups.md)** — Set up groups for database access control
 - **[Scheduled and Real-Time Automation](./scheduled-and-realtime-automation.md)** — Subscriptions and cron-triggered workflows
 - **[Primitive CLI](./primitive-cli.md)** — Full CLI reference for database management

--- a/docs/getting-started/working-with-documents.md
+++ b/docs/getting-started/working-with-documents.md
@@ -74,71 +74,67 @@ Every user has a root document opened automatically by primitive-app. Use it onl
 
 ## Defining Models
 
-Models define the shape of your data. Each model corresponds to a record type — like `Task`, `Project`, or `Contact`.
+Models define the shape of your data. Each model corresponds to a record type — like `Task`, `Project`, or `Contact`. Models are authored in TOML and TypeScript classes are generated from that file.
 
-### Creating a Model
+The full authoring loop — field types, options, relationships, uniqueness, schema evolution, and the migration tool from older `defineModelSchema()`-based projects — is covered in [Defining Your Models](./defining-your-models.md). The summary below is enough to start using models in CRUD code on this page.
 
-**Step 1:** Create the model file:
+### Quick Reference
 
-```typescript
-// src/models/Task.ts
-import { BaseModel, defineModelSchema } from "js-bao";
+**Step 1:** Add the model to `src/models/models.toml`:
 
-const taskSchema = defineModelSchema({
-  name: "tasks",
-  fields: {
-    id: { type: "id", autoAssign: true, indexed: true },
-    title: { type: "string", indexed: true },
-    description: { type: "string", default: "" },
-    completed: { type: "boolean", default: false },
-    priority: { type: "number", default: 0 },
-    dueDate: { type: "date" },
-    tags: { type: "stringset", maxCount: 10 },
-  },
-});
+```toml
+[models.tasks.fields.id]
+type = "id"
+auto_assign = true
+indexed = true
 
-export class Task extends BaseModel {
-  static schema = taskSchema;
+[models.tasks.fields.title]
+type = "string"
+indexed = true
 
-  get isOverdue(): boolean {
-    if (!this.dueDate || this.completed) return false;
-    return new Date(this.dueDate) < new Date();
-  }
-}
+[models.tasks.fields.completed]
+type = "boolean"
+default = false
+
+[models.tasks.fields.priority]
+type = "number"
+default = 0
+
+[models.tasks.fields.due_date]
+type = "date"
+
+[models.tasks.fields.tags]
+type = "stringset"
+max_count = 10
 ```
 
-**Step 2:** Add the model to your config (`src/config/envConfig.ts`).
+**Step 2:** Run `pnpm codegen` to regenerate `src/models/Task.generated.ts` and the `src/models/index.ts` barrel.
 
-**Step 3:** Run `pnpm codegen` to generate TypeScript types and field accessors.
+**Step 3:** Import from the barrel and use the model:
+
+```typescript
+import { Task } from "@/models";
+
+const task = new Task({ title: "Review PR", priority: 2 });
+await task.save();
+```
 
 ::: warning
-Never edit auto-generated sections (marked with `// --- auto-generated ---`). They are overwritten by codegen.
+Never edit `*.generated.ts` files or `src/models/index.ts` — they are overwritten on every `pnpm codegen` run. Always import models from `@/models`, never directly from a generated file.
 :::
 
 ### Field Types
 
 | Type | TypeScript | Description |
 |---|---|---|
-| `id` | `string` | Unique identifier. Use `autoAssign: true` for auto-generated IDs |
+| `id` | `string` | Unique identifier. Use `auto_assign = true` for auto-generated IDs |
 | `string` | `string` | Text data |
 | `number` | `number` | Numeric data |
 | `boolean` | `boolean` | True/false |
 | `date` | `string` | Date/time as ISO-8601 string |
 | `stringset` | `StringSet` | Set of strings (tags, categories) |
 
-### Unique Constraints
-
-```typescript
-const categorySchema = defineModelSchema({
-  name: "categories",
-  fields: {
-    id: { type: "id", autoAssign: true, indexed: true },
-    name: { type: "string" },
-    parentId: { type: "string" },
-  },
-  uniqueConstraints: [["name", "parentId"]],
-});
-```
+See [Defining Your Models](./defining-your-models.md) for full field-option reference, unique constraints, and relationships.
 
 ## CRUD Operations
 
@@ -392,6 +388,7 @@ A `403` from `client.documents.get(documentId)` can include a `canRequestAccess`
 ## Next Steps
 
 - **[Choosing Your Data Model](./choosing-your-data-model.md)** — When to use documents vs. databases
+- **[Defining Your Models](./defining-your-models.md)** — TOML authoring, codegen, relationships, schema evolution
 - **[Sharing and Invitations](./sharing-and-invitations.md)** — Full sharing, invitations, and access requests
 - **[Working with Databases](./working-with-databases.md)** — Server-side structured storage
 - **[Blobs and Files](./blobs-and-files.md)** — File storage within documents


### PR DESCRIPTION
## Summary

Closes #47 — the docs sidebar had no top-level treatment for analytics or for the TOML model + codegen workflow, even though both are first-class in the demo app and platform.

- New **Defining Your Models** page under Data Persistence — covers the \`models.toml\` authoring loop end-to-end: field types, options, unique constraints, relationships, schema evolution, the migrate tool from older \`defineModelSchema\`-based projects, and how the same models are referenced by databases.
- New **Analytics** page under Platform Services — covers automatic events (client + server), custom \`logEvent\`/\`logSnapshot\`, pre-auth events, plan/version overrides, auto-event configuration, and querying via CLI/REST/workflow/Admin Console.
- Stale model-authoring example removed from Working with Documents (it still showed \`defineModelSchema()\`); now redirects to the new dedicated page.
- Working with Databases clarified: still schemaless on the server, but operations reference \`modelName\`s declared in \`models.toml\`.
- Admin Console and Workflows pages cross-link out to the new Analytics page so the previously-orphaned Analytics references have a landing place.
- VitePress sidebar updated to include both new pages.

## Test plan

- [x] \`pnpm docs:build\` succeeds; both \`analytics.html\` and \`defining-your-models.html\` are generated.
- [x] No links to \`guides/latest/\` from human docs (per repo convention).
- [ ] Reviewer: visually skim the two new pages on the deployed preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)