### PR TITLE
guides.json: enforce ≤100-char description budget (#83)

### DIFF
--- a/guides/latest/guides.json
+++ b/guides/latest/guides.json
@@ -68,7 +68,7 @@
     {
       "topic": "blobs",
       "file": "AGENT_GUIDE_TO_PRIMITIVE_BLOBS.ts.md",
-      "description": "Document-scoped blob storage — uploads, downloads, offline queue, caching, and permissions for files attached to documents",
+      "description": "Document-scoped blob storage — upload, download, offline queue, caching, and permissions",
       "keywords": [
         "blobs",
         "files",
@@ -242,7 +242,7 @@
     {
       "topic": "databases",
       "file": "AGENT_GUIDE_TO_PRIMITIVE_DATABASES.ts.md",
-      "description": "Server-side database storage with CEL-based access control, registered operations, triggers, real-time subscriptions, and group permissions",
+      "description": "Server-side databases — CEL access rules, registered operations, triggers, realtime subscriptions",
       "keywords": [
         "databases",
         "database",
@@ -333,7 +333,7 @@
     {
       "topic": "documents",
       "file": "AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.ts.md",
-      "description": "Local-first collaborative documents — models and CRUD, opening/finding documents, sharing and permissions, collections, and access requests",
+      "description": "Local-first collaborative documents — models, CRUD, sharing, collections, access requests",
       "keywords": [
         "documents",
         "models",
@@ -401,7 +401,7 @@
     {
       "topic": "workflows",
       "file": "AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.ts.md",
-      "description": "Creating multi-step automation pipelines with AI/LLM calls, integrations, email, blobs, analytics, cron scheduling, synchronous invocation, and database operations",
+      "description": "Multi-step automation pipelines — LLM calls, integrations, cron, sync runs, database steps",
       "keywords": [
         "workflows",
         "automation",
@@ -600,7 +600,7 @@
     {
       "topic": "app-secrets",
       "file": "AGENT_GUIDE_TO_PRIMITIVE_APP_SECRETS.md",
-      "description": "Server-side credential store — managing secrets with the CLI and referencing them from integrations, workflows, and database rules as {{ secrets.KEY }}",
+      "description": "Server-side credential store — manage secrets via the CLI, reference as {{ secrets.KEY }}",
       "keywords": [
         "secrets",
         "app secrets",
@@ -809,7 +809,7 @@
     {
       "topic": "configuration",
       "file": "AGENT_GUIDE_TO_PRIMITIVE_CONFIGURATION.md",
-      "description": "Managing backend configuration as code — the TOML sync loop, directory map, environments, secrets, and headless CI auth",
+      "description": "Backend configuration as code — TOML sync loop, directory map, environments, headless CI auth",
       "keywords": [
         "configuration",
         "config",
@@ -840,7 +840,7 @@
     {
       "topic": "access-control",
       "file": "AGENT_GUIDE_TO_PRIMITIVE_ACCESS_CONTROL.md",
-      "description": "Writing CEL access rules — identity context, per-surface rule contexts (database ops, subscriptions, workflows), and rule sets for management operations",
+      "description": "CEL access rules — identity context, per-surface rule contexts, management rule sets",
       "keywords": [
         "access control",
         "CEL",
@@ -866,7 +866,7 @@
     {
       "topic": "invitations",
       "file": "AGENT_GUIDE_TO_PRIMITIVE_INVITATIONS.ts.md",
-      "description": "App membership — access modes (public/invite-only/domain), the waitlist, invitations and quotas, custom invitation emails, and deferred grants that resolve when someone becomes a user",
+      "description": "App membership — access modes, waitlist, invitations and quotas, custom emails, deferred grants",
       "keywords": [
         "invitations",
         "invite",
@@ -903,7 +903,7 @@
     {
       "topic": "blob-buckets",
       "file": "AGENT_GUIDE_TO_PRIMITIVE_BLOB_BUCKETS.ts.md",
-      "description": "General-purpose blob bucket storage — bucket configuration, access policies, TTL tiers, signed URLs, and workflow integration",
+      "description": "Blob buckets — configuration, access policies, TTL tiers, signed URLs, workflow integration",
       "keywords": [
         "blob bucket",
         "buckets",
@@ -936,7 +936,7 @@
     {
       "topic": "deploying",
       "file": "AGENT_GUIDE_TO_PRIMITIVE_DEPLOYING.ts.md",
-      "description": "Shipping Primitive apps to production — web deploys (cf-deploy, environments) and iOS distribution (signing, devices, TestFlight, App Store via Fastlane)",
+      "description": "Ship to production — web deploys (cf-deploy) and iOS distribution (TestFlight, App Store)",
       "keywords": [
         "deploy",
         "deploying",

--- a/scripts/sync-guides-json.mjs
+++ b/scripts/sync-guides-json.mjs
@@ -82,6 +82,19 @@ for (const g of manifest.guides) {
   }
 }
 
+// `description` is the primary signal an agent uses to pick a guide from
+// `primitive guides list`, where it renders in a fixed-width, ellipsized
+// table column. Budget each one to ≤100 chars (front-load the discriminating
+// part — the column shows roughly the first 48) so the selection signal
+// survives the table; full text stays available via `guides list --json`.
+const DESCRIPTION_BUDGET = 100;
+for (const g of manifest.guides) {
+  const len = (g.description ?? "").length;
+  if (len > DESCRIPTION_BUDGET) {
+    problems.push(`✘ ${g.topic}: description is ${len} chars (budget ${DESCRIPTION_BUDGET})`);
+  }
+}
+
 // relatedGuides/prerequisites are hand-maintained topic references — verify
 // each names a topic that exists in this manifest. A guide removal/rename
 // otherwise leaves dangling references that the CLI surfaces to agents, who


### PR DESCRIPTION
## What the issue reported
`primitive guides list` renders each guide's `description` in a fixed-width table column; over-budget descriptions get ellipsized and lose selection signal. Asked for a ≤100-char budget plus a CI check.

## Verified against source
- The stamped js-bao-wss CLI (PR #986 as merged) shipped the DESCRIPTION column at **width 48 + ellipsis** (not the 100 anticipated when the issue was filed); `--json` carries full text. The 100-char budget is therefore a docs-side discipline, confirmed with the sponsor: keep 100, front-load the first ~48 chars.
- The offender set had grown from 4 (at filing) to **10 of 18** descriptions (max 183 chars).

## What changed
- `guides/latest/guides.json` — trimmed all 10 over-budget descriptions to ≤100 with the discriminating signal front-loaded; detail remains in `keywords`/`useCases`.
- `scripts/sync-guides-json.mjs` — new budget check (runs in both update and `--check` mode, so it gates in `pnpm check:examples`): any `guides[].description` over 100 chars fails with the topic and length.

## Validation
- `node scripts/sync-guides-json.mjs --check` passes; verified the gate trips correctly on a synthetic 182-char description.
- `pnpm check:examples` green end to end.

Fixes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)