### PR TITLE
workflows: promote runSync to a compile-gated corpus pair (#90)

### DIFF
--- a/docs/getting-started/workflows.md
+++ b/docs/getting-started/workflows.md
@@ -145,16 +145,13 @@ let sub = client.events.on(.workflowStatus) { (event: WorkflowStatusEvent) in
 
 For short, latency-sensitive workflows, opt the workflow into synchronous invocation by setting `syncCallable = true` in the workflow TOML or via `primitive workflows update --sync-callable true`. Clients can then `await` the final result in one round-trip:
 
-```typescript
-const result = await client.workflows.runSync({
-  workflowKey: "validate-coupon",
-  input: { code: "WELCOME10" },
-  timeoutMs: 5000,    // server caps at 30s
-});
-if (result.status === "completed") {
-  console.log(result.output);
-}
-```
+::: code-group
+
+<<< ../../examples/workflows/workflow-run-sync.ts#example{ts} [JavaScript]
+
+<<< ../../examples/workflows/workflow-run-sync.swift#example{swift} [Swift]
+
+:::
 
 The promise resolves for every terminal outcome; only network errors reject. Long-running workflows should use asynchronous `start()` instead.
 

--- a/examples/workflows/workflow-run-sync.swift
+++ b/examples/workflows/workflow-run-sync.swift
@@ -1,0 +1,19 @@
+import JsBaoClient
+
+// Run a syncCallable workflow and await its terminal result in one round-trip.
+func validateCoupon(client: JsBaoClient, code: String) async throws {
+  // #region example
+  let result = try await client.workflows.runSync(
+    workflowKey: "validate-coupon",
+    input: ["code": code],
+    timeoutMs: 5000 // default 5000; server caps at 30000
+  )
+  // RunSyncWorkflowResult: runId, runKey, status, output?, error?, run?, existing?
+  // status: "completed" | "failed" | "terminated" | "timeout" | "apply_pending"
+  // Resolves for every terminal outcome — only transport errors throw.
+  if result.status == "completed" {
+    print(result.output ?? "")
+  }
+  // #endregion example
+  _ = result
+}

--- a/examples/workflows/workflow-run-sync.ts
+++ b/examples/workflows/workflow-run-sync.ts
@@ -1,0 +1,19 @@
+import type { JsBaoClient } from "js-bao-wss-client";
+
+// Run a syncCallable workflow and await its terminal result in one round-trip.
+export async function validateCoupon(client: JsBaoClient, code: string) {
+  // #region example
+  const result = await client.workflows.runSync({
+    workflowKey: "validate-coupon",
+    input: { code },
+    timeoutMs: 5000, // default 5000; server caps at 30000
+  });
+  // → { runId, runKey, status, output?, error?, run?, existing? }
+  // status: "completed" | "failed" | "terminated" | "timeout" | "apply_pending"
+  // Resolves for every terminal outcome — only transport errors reject.
+  if (result.status === "completed") {
+    console.log(result.output);
+  }
+  // #endregion example
+  return result;
+}

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.swift.md
@@ -1078,6 +1078,24 @@ Server-side constraints on a `syncCallable` workflow:
 
 Long-running workflows should keep using `start()` plus the WebSocket / polling lifecycle.
 
+Call `workflows.runSync` and await the final envelope:
+
+```swift
+  let result = try await client.workflows.runSync(
+    workflowKey: "validate-coupon",
+    input: ["code": code],
+    timeoutMs: 5000 // default 5000; server caps at 30000
+  )
+  // RunSyncWorkflowResult: runId, runKey, status, output?, error?, run?, existing?
+  // status: "completed" | "failed" | "terminated" | "timeout" | "apply_pending"
+  // Resolves for every terminal outcome — only transport errors throw.
+  if result.status == "completed" {
+    print(result.output ?? "")
+  }
+```
+
+`runSync` also accepts `runKey`, `contextDocId`, and `meta` — the same idempotency and scoping fields as `start`.
+
 
 ## Workflow lifecycle
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md
@@ -1055,20 +1055,14 @@ Server-side constraints on a `syncCallable` workflow:
 
 Long-running workflows should keep using `start()` plus the WebSocket / polling lifecycle.
 
-{{#lang ts}}
-Call `client.workflows.runSync()` and `await` the final envelope:
+Call `workflows.runSync` and await the final envelope:
 
-```typescript
-const sync = await client.workflows.runSync({
-  workflowKey: "validate-token",
-  input: { token },
-  timeoutMs: 5000,                 // default 5000; server caps at 30000
-  // signal: abortSignal,            // optional AbortSignal
-});
-// → { runId, runKey, status, output?, error?, run?, existing? }
-// status: "completed" | "failed" | "terminated" | "timeout" | "apply_pending"
-// Promise resolves for every terminal outcome — only transport errors reject.
-```
+{{ example: workflows/workflow-run-sync }}
+
+`runSync` also accepts `runKey`, `contextDocId`, and `meta` — the same idempotency and scoping fields as `start`.
+
+{{#lang ts}}
+An optional `signal` (`AbortSignal`) is accepted as well.
 {{/lang}}
 
 ## Workflow lifecycle

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.ts.md
@@ -1083,19 +1083,25 @@ Server-side constraints on a `syncCallable` workflow:
 
 Long-running workflows should keep using `start()` plus the WebSocket / polling lifecycle.
 
-Call `client.workflows.runSync()` and `await` the final envelope:
+Call `workflows.runSync` and await the final envelope:
 
 ```typescript
-const sync = await client.workflows.runSync({
-  workflowKey: "validate-token",
-  input: { token },
-  timeoutMs: 5000,                 // default 5000; server caps at 30000
-  // signal: abortSignal,            // optional AbortSignal
-});
-// → { runId, runKey, status, output?, error?, run?, existing? }
-// status: "completed" | "failed" | "terminated" | "timeout" | "apply_pending"
-// Promise resolves for every terminal outcome — only transport errors reject.
+  const result = await client.workflows.runSync({
+    workflowKey: "validate-coupon",
+    input: { code },
+    timeoutMs: 5000, // default 5000; server caps at 30000
+  });
+  // → { runId, runKey, status, output?, error?, run?, existing? }
+  // status: "completed" | "failed" | "terminated" | "timeout" | "apply_pending"
+  // Resolves for every terminal outcome — only transport errors reject.
+  if (result.status === "completed") {
+    console.log(result.output);
+  }
 ```
+
+`runSync` also accepts `runKey`, `contextDocId`, and `meta` — the same idempotency and scoping fields as `start`.
+
+An optional `signal` (`AbortSignal`) is accepted as well.
 
 ## Workflow lifecycle
 


### PR DESCRIPTION
## What the issue reported
`workflows.runSync` was documented with JS-only inline fences (workflows.md ~L149, WORKFLOWS guide ~L1059) — un-compile-checked and invisible to the Swift guide build — even though Swift now has `runSync`.

## Verified against source
- Swift: `runSync(workflowKey:input:runKey:contextDocId:meta:timeoutMs:) async throws -> RunSyncWorkflowResult` (`API/WorkflowsAPI.swift:137`), result statuses `completed|failed|terminated|timeout|apply_pending`, only transport errors throw.
- JS: `RunSyncWorkflowOptions` carries the same fields plus `signal` (AbortSignal) — JS-only, kept as a ts-scoped guide note (Swift cancels via the surrounding `Task`, per the source doc comment).

## What changed
- New corpus pair `examples/workflows/workflow-run-sync.{ts,swift}` (compiled by `pnpm check:examples` on both languages).
- `docs/getting-started/workflows.md` — the "From Your App (Synchronous)" fence → code-group corpus includes.
- `AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md` — the ts-scoped fence → unscoped `{{ example: workflows/workflow-run-sync }}` + a neutral note on `runKey`/`contextDocId`/`meta`; guides re-rendered.

## Validation
`pnpm check:examples` (parity + both compiles + TOML + CLI + stamp) and `npx vitepress build docs` green.

Fixes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)