### PR TITLE
databases: promote subscribe examples to compile-gated corpus pairs (#89)

### DIFF
--- a/docs/getting-started/working-with-databases.md
+++ b/docs/getting-started/working-with-databases.md
@@ -375,28 +375,15 @@ Each subscription has:
 
 ### Subscribing from Your App
 
-`databases.subscribe(databaseId, subscriptionKey, { onChange })` returns an `unsub()` function:
+`databases.subscribe` takes the database id, the subscription key, and an `onChange` handler, and returns an unsubscribe function:
 
-```typescript
-const unsub = client.databases.subscribe(databaseId, "my-open-tickets", {
-  onChange: (event) => {
-    if (event.isOrigin) {
-      // This same tab wrote it — we already updated the UI optimistically.
-      return;
-    }
-    for (const change of event.changes) {
-      // change.op:         "save" | "patch" | "delete" | "increment" | ...
-      // change.changeType: "enter" | "update" | "leave"
-      // change.data, change.previousData (subject to the select projection)
-      if (change.op === "delete") removeTicket(change.id);
-      else upsertTicket(change.data);
-    }
-  },
-});
+::: code-group
 
-// Later
-unsub();
-```
+<<< ../../examples/databases/db-subscribe.ts#example{ts} [JavaScript]
+
+<<< ../../examples/databases/db-subscribe.swift#example{swift} [Swift]
+
+:::
 
 The usual pattern is **load + subscribe**: run a query operation once for current state, then subscribe for future changes.
 
@@ -423,12 +410,13 @@ filter = "record.data.teamId == params.teamId"
 teamId = { type = "string", required = true }
 ```
 
-```typescript
-const unsub = client.databases.subscribe(databaseId, "tickets-by-team", {
-  params: { teamId: "eng" },
-  onChange: (event) => { /* ... */ },
-});
-```
+::: code-group
+
+<<< ../../examples/databases/db-subscribe-params.ts#example{ts} [JavaScript]
+
+<<< ../../examples/databases/db-subscribe-params.swift#example{swift} [Swift]
+
+:::
 
 ### Server-Side Writes
 

--- a/examples/databases/db-subscribe-params.swift
+++ b/examples/databases/db-subscribe-params.swift
@@ -1,0 +1,23 @@
+import JsBaoClient
+
+// Bind values to a parameterized subscription — the bound `params.*` are
+// visible to the subscription's `access` and `filter` CEL.
+func watchTeamTickets(
+  client: JsBaoClient,
+  databaseId: String,
+  handleChange: @escaping (DatabaseChangeEvent) -> Void
+) -> () -> Void {
+  // #region example
+  let unsub = client.databases.subscribe(
+    databaseId: databaseId,
+    subscriptionKey: "tickets-by-team",
+    options: DatabaseSubscribeOptions(
+      params: ["teamId": "eng"],
+      onChange: { event in
+        for change in event.changes { handleChange(change) }
+      }
+    )
+  )
+  // #endregion example
+  return unsub
+}

--- a/examples/databases/db-subscribe-params.ts
+++ b/examples/databases/db-subscribe-params.ts
@@ -1,0 +1,19 @@
+import type { JsBaoClient } from "js-bao-wss-client";
+
+// Bind values to a parameterized subscription — the bound `params.*` are
+// visible to the subscription's `access` and `filter` CEL.
+export function watchTeamTickets(
+  client: JsBaoClient,
+  databaseId: string,
+  handleChange: (change: unknown) => void
+) {
+  // #region example
+  const unsub = client.databases.subscribe(databaseId, "tickets-by-team", {
+    params: { teamId: "eng" },
+    onChange: (event) => {
+      for (const change of event.changes) handleChange(change);
+    },
+  });
+  // #endregion example
+  return unsub;
+}

--- a/examples/databases/db-subscribe.swift
+++ b/examples/databases/db-subscribe.swift
@@ -1,0 +1,34 @@
+import JsBaoClient
+
+// React to server-side database changes in real time. The subscription
+// (key, access rule, filter, select) is defined in TOML; the client binds
+// to it and receives matching deltas until unsubscribed.
+func watchOpenTickets(
+  client: JsBaoClient,
+  databaseId: String,
+  removeTicket: @escaping (String) -> Void,
+  upsertTicket: @escaping (Any?) -> Void
+) {
+  // #region example
+  let unsub = client.databases.subscribe(
+    databaseId: databaseId,
+    subscriptionKey: "my-open-tickets",
+    options: DatabaseSubscribeOptions(onChange: { event in
+      // event.originConnectionId, event.originUserId, event.isOrigin, event.isOriginUser
+      if event.isOrigin {
+        // This same tab wrote it — the UI is already updated optimistically.
+        return
+      }
+      for change in event.changes {
+        // change.op:         "save" | "patch" | "delete" | "increment" | ...
+        // change.changeType: "enter" | "update" | "leave"
+        // change.data, change.previousData (subject to the select projection)
+        if change.op == "delete" { removeTicket(change.id) } else { upsertTicket(change.data) }
+      }
+    })
+  )
+
+  // Later — required for cleanup
+  unsub()
+  // #endregion example
+}

--- a/examples/databases/db-subscribe.ts
+++ b/examples/databases/db-subscribe.ts
@@ -1,0 +1,33 @@
+import type { JsBaoClient } from "js-bao-wss-client";
+
+// React to server-side database changes in real time. The subscription
+// (key, access rule, filter, select) is defined in TOML; the client binds
+// to it and receives matching deltas until unsubscribed.
+export function watchOpenTickets(
+  client: JsBaoClient,
+  databaseId: string,
+  removeTicket: (id: string) => void,
+  upsertTicket: (data: unknown) => void
+) {
+  // #region example
+  const unsub = client.databases.subscribe(databaseId, "my-open-tickets", {
+    onChange: (event) => {
+      // event.originConnectionId, event.originUserId, event.isOrigin, event.isOriginUser
+      if (event.isOrigin) {
+        // This same tab wrote it — the UI is already updated optimistically.
+        return;
+      }
+      for (const change of event.changes) {
+        // change.op:         "save" | "patch" | "delete" | "increment" | ...
+        // change.changeType: "enter" | "update" | "leave"
+        // change.data, change.previousData (subject to the select projection)
+        if (change.op === "delete") removeTicket(change.id);
+        else upsertTicket(change.data);
+      }
+    },
+  });
+
+  // Later — required for cleanup
+  unsub();
+  // #endregion example
+}

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.template.md
@@ -1244,35 +1244,11 @@ The two phases see different contexts:
 
 `subscribe()` returns an `unsub()` function (synchronously). There is no event-emitter API.
 
-```typescript
-const unsub = client.databases.subscribe(databaseId, "my-open-tickets", {
-  onChange: (event) => {
-    // event.type === "db.change"
-    // event.databaseId, event.subscriptionKey, event.timestamp
-    // event.originConnectionId, event.originUserId, event.isOrigin, event.isOriginUser
-    if (event.isOrigin) return;  // this tab wrote it; UI already updated
-    for (const change of event.changes) {
-      // change.op:         "save" | "patch" | "delete" | "increment" | "addToSet" | "removeFromSet"
-      // change.changeType: "enter" | "update" | "leave"
-      // change.modelName, change.id
-      // change.data, change.previousData  (subject to the subscription's `select`)
-      applyChange(change);
-    }
-  },
-});
-
-// Later — REQUIRED for cleanup
-unsub();
-```
+{{ example: databases/db-subscribe }}
 
 Parameterized:
 
-```typescript
-const unsub = client.databases.subscribe(databaseId, "tickets-by-team", {
-  params: { teamId: "eng" },
-  onChange: (event) => { ... },
-});
-```
+{{ example: databases/db-subscribe-params }}
 
 The client auto-reissues `db.subscribe` on WebSocket reconnect — no app code needed.
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.ts.md
@@ -1344,33 +1344,36 @@ The two phases see different contexts:
 `subscribe()` returns an `unsub()` function (synchronously). There is no event-emitter API.
 
 ```typescript
-const unsub = client.databases.subscribe(databaseId, "my-open-tickets", {
-  onChange: (event) => {
-    // event.type === "db.change"
-    // event.databaseId, event.subscriptionKey, event.timestamp
-    // event.originConnectionId, event.originUserId, event.isOrigin, event.isOriginUser
-    if (event.isOrigin) return;  // this tab wrote it; UI already updated
-    for (const change of event.changes) {
-      // change.op:         "save" | "patch" | "delete" | "increment" | "addToSet" | "removeFromSet"
-      // change.changeType: "enter" | "update" | "leave"
-      // change.modelName, change.id
-      // change.data, change.previousData  (subject to the subscription's `select`)
-      applyChange(change);
-    }
-  },
-});
+  const unsub = client.databases.subscribe(databaseId, "my-open-tickets", {
+    onChange: (event) => {
+      // event.originConnectionId, event.originUserId, event.isOrigin, event.isOriginUser
+      if (event.isOrigin) {
+        // This same tab wrote it — the UI is already updated optimistically.
+        return;
+      }
+      for (const change of event.changes) {
+        // change.op:         "save" | "patch" | "delete" | "increment" | ...
+        // change.changeType: "enter" | "update" | "leave"
+        // change.data, change.previousData (subject to the select projection)
+        if (change.op === "delete") removeTicket(change.id);
+        else upsertTicket(change.data);
+      }
+    },
+  });
 
-// Later — REQUIRED for cleanup
-unsub();
+  // Later — required for cleanup
+  unsub();
 ```
 
 Parameterized:
 
 ```typescript
-const unsub = client.databases.subscribe(databaseId, "tickets-by-team", {
-  params: { teamId: "eng" },
-  onChange: (event) => { ... },
-});
+  const unsub = client.databases.subscribe(databaseId, "tickets-by-team", {
+    params: { teamId: "eng" },
+    onChange: (event) => {
+      for (const change of event.changes) handleChange(change);
+    },
+  });
 ```
 
 The client auto-reissues `db.subscribe` on WebSocket reconnect — no app code needed.


### PR DESCRIPTION
## What the issue reported
`databases.subscribe` was documented with JS-only inline fences (working-with-databases.md "Subscribing from Your App" + "Parameterized Subscriptions"; DATABASES guide "Subscribing from the client") even though Swift now has realtime subscriptions.

## Verified against source
- Swift: `subscribe(databaseId:subscriptionKey:options:) -> () -> Void` with `DatabaseSubscribeOptions(params:onChange:)`; `DatabaseChangePayload` carries `changes`, `timestamp`, and the origin-attribution fields (`originConnectionId`/`originUserId`/`isOrigin`/`isOriginUser`); `DatabaseChangeEvent` carries `op`/`changeType`/`modelName`/`id`/`data`/`previousData` (`API/DatabasesAPI.swift:79`, `Types/DatabasesTypes.swift`). Re-subscribes on reconnect via `DatabaseSubscriptionRegistry`, matching the existing prose.
- JS shape unchanged; the guide's "Wrong" anti-pattern fence and the change-envelope interface block stay inline (shape fragments, per the corpus rules).

## What changed
- New corpus pairs `examples/databases/db-subscribe.{ts,swift}` and `db-subscribe-params.{ts,swift}`.
- `docs/getting-started/working-with-databases.md` — both fences → code-group corpus includes; intro line de-JS-ified.
- `AGENT_GUIDE_TO_PRIMITIVE_DATABASES.template.md` — both fences → `{{ example: … }}`; guides re-rendered (the Swift guide build now shows Swift subscribe code for the first time).

## Validation
`pnpm check:examples` (parity + both compiles + TOML + CLI + stamp) and `npx vitepress build docs` green.

Fixes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)