### PR TITLE
databases: make importCsv cross-platform (#91)

### DIFF
--- a/docs/getting-started/working-with-databases.md
+++ b/docs/getting-started/working-with-databases.md
@@ -314,7 +314,7 @@ This reads the `[models.*]` blocks and `[[operations]]` definitions and emits ty
 
 ## Bulk CSV Import
 
-Two paths for loading a lot of records. From app code, `client.databases.importCsv(databaseId, { csv, model, columnMap, ... })` imports a CSV string with column mapping, optional per-row transforms, and progress callbacks. From a terminal:
+Two paths for loading a lot of records. From a terminal:
 
 ```bash
 primitive databases import-csv <database-id> ./products.csv --model products \
@@ -323,6 +323,16 @@ primitive databases import-csv <database-id> ./products.csv --model products \
 ```
 
 The CLI loads rows through a registered batch save operation in batches; add `--dry-run` to preview counts without writing.
+
+From app code, `importCsv` imports a CSV string with column mapping, type coercion, optional per-row transforms, and progress callbacks:
+
+::: code-group
+
+<<< ../../examples/databases/db-import-csv.ts#example{ts} [JavaScript]
+
+<<< ../../examples/databases/db-import-csv.swift#example{swift} [Swift]
+
+:::
 
 ## Optional Filter Params
 

--- a/examples/databases/db-import-csv.swift
+++ b/examples/databases/db-import-csv.swift
@@ -1,0 +1,36 @@
+import Foundation
+import JsBaoClient
+
+// Bulk-load CSV rows through the database's registered save operation, with
+// column mapping, type coercion, per-row transforms, and progress callbacks.
+func importProducts(
+  client: JsBaoClient,
+  databaseId: String,
+  csvString: String
+) async throws {
+  // #region example
+  let result = try await client.databases.importCsv(
+    databaseId: databaseId,
+    options: CsvImportOptions(
+      csv: csvString, // provide csv or data (pre-parsed rows), not both
+      modelName: "products",
+      columnMap: ["Product Name": "name", "Unit Price": "price"],
+      transform: { row, _ in
+        guard let name = row["name"]?.stringValue, !name.isEmpty else {
+          return nil // return nil to skip a row
+        }
+        var out = row
+        out["importedAt"] = .string(ISO8601DateFormatter().string(from: Date()))
+        return out
+      },
+      types: ["price": .number],
+      idColumn: "sku",
+      onProgress: { progress in
+        print("\(progress.processed)/\(progress.total) processed")
+      }
+    )
+  )
+  // CsvImportResult: imported, failed, errors, indexesCreated, durationMs
+  // #endregion example
+  _ = result
+}

--- a/examples/databases/db-import-csv.ts
+++ b/examples/databases/db-import-csv.ts
@@ -1,0 +1,28 @@
+import type { JsBaoClient } from "js-bao-wss-client";
+
+// Bulk-load CSV rows through the database's registered save operation, with
+// column mapping, type coercion, per-row transforms, and progress callbacks.
+export async function importProducts(
+  client: JsBaoClient,
+  databaseId: string,
+  csvString: string
+) {
+  // #region example
+  const result = await client.databases.importCsv(databaseId, {
+    csv: csvString, // provide csv or data (pre-parsed rows), not both
+    modelName: "products",
+    columnMap: { "Product Name": "name", "Unit Price": "price" },
+    types: { price: "number" },
+    idColumn: "sku",
+    transform: (row, _index) => {
+      if (!row.name) return null; // return null to skip a row
+      return { ...row, importedAt: new Date().toISOString() };
+    },
+    onProgress: ({ processed, total }) => {
+      console.log(`${processed}/${total} processed`);
+    },
+  });
+  // result: { imported, failed, errors, indexesCreated, durationMs }
+  // #endregion example
+  return result;
+}

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.swift.md
@@ -957,6 +957,35 @@ primitive databases import-csv <database-id> <file.csv> --model products \
 
 The CLI imports through a registered batch (bulk) save operation — `--operation` defaults to `seed_save`, so the database type needs a save-like op (`{ modelName, id, data }`) by that name (or pass your own). `--batch-size` defaults to 5000, `--delimiter` to `,`; use `--dry-run` to report row/batch counts without writing and `--stop-on-error` to abort on the first failing chunk (default is best-effort continue).
 
+For programmatic imports with per-row `transform` or progress callbacks, use `importCsv` from app code:
+
+```swift
+  let result = try await client.databases.importCsv(
+    databaseId: databaseId,
+    options: CsvImportOptions(
+      csv: csvString, // provide csv or data (pre-parsed rows), not both
+      modelName: "products",
+      columnMap: ["Product Name": "name", "Unit Price": "price"],
+      transform: { row, _ in
+        guard let name = row["name"]?.stringValue, !name.isEmpty else {
+          return nil // return nil to skip a row
+        }
+        var out = row
+        out["importedAt"] = .string(ISO8601DateFormatter().string(from: Date()))
+        return out
+      },
+      types: ["price": .number],
+      idColumn: "sku",
+      onProgress: { progress in
+        print("\(progress.processed)/\(progress.total) processed")
+      }
+    )
+  )
+  // CsvImportResult: imported, failed, errors, indexesCreated, durationMs
+```
+
+Other options: `data` (pre-parsed rows, instead of `csv`), `delimiter`, `batchSize` (default 5000), `idGenerator` (per-row ID factory; the fallback chain is `idColumn` → `idGenerator` → generated ULID), `onBatchError` (return `false` to abort remaining batches), and `operationName` (the registered save op, default `"save"`, called as `{ modelName, id, data }`).
+
 
 ### Database design
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.template.md
@@ -1453,36 +1453,23 @@ primitive databases import-csv <database-id> <file.csv> --model products \
 
 The CLI imports through a registered batch (bulk) save operation — `--operation` defaults to `seed_save`, so the database type needs a save-like op (`{ modelName, id, data }`) by that name (or pass your own). `--batch-size` defaults to 5000, `--delimiter` to `,`; use `--dry-run` to report row/batch counts without writing and `--stop-on-error` to abort on the first failing chunk (default is best-effort continue).
 
+For programmatic imports with per-row `transform` or progress callbacks, use `importCsv` from app code:
+
+{{ example: databases/db-import-csv }}
+
+Other options: `data` (pre-parsed rows, instead of `csv`), `delimiter`, `batchSize` (default 5000), `idGenerator` (per-row ID factory; the fallback chain is `idColumn` → `idGenerator` → generated ULID), `onBatchError` (return `false` to abort remaining batches), and `operationName` (the registered save op, default `"save"`, called as `{ modelName, id, data }`).
+
 {{#lang ts}}
-For programmatic imports with per-row `transform` or progress callbacks, use `importCsv()` from app code:
+A generated model class can stand in for `modelName` — the import then filters columns to the model's schema and syncs its indexes afterwards (`syncIndexes`, reported as `indexesCreated`):
 
 ```typescript
 import { Product } from "./models";
 
-// With model class
 const result = await client.databases.importCsv(databaseId, {
   csv: csvString,
   model: Product,
   columnMap: { "Product Name": "name", "Unit Price": "price" },
 });
-
-// Without model class (csv string or pre-parsed data array)
-const result = await client.databases.importCsv(databaseId, {
-  csv: csvString,       // provide csv or data, not both
-  // data: parsedRows,  // alternative: pre-parsed array of objects
-  modelName: "products",
-  types: { price: "number", stock: "number" },
-  idColumn: "sku",
-  transform: (row, index) => {
-    if (!row.name) return null; // skip
-    return { ...row, importedAt: new Date().toISOString() };
-  },
-  batchSize: 10000,
-  onProgress: ({ processed, total, imported, failed }) => {
-    console.log(`${processed}/${total} processed`);
-  },
-});
-// result: { imported: number, failed: number, errors: [...], indexesCreated: number, durationMs: number }
 ```
 {{/lang}}
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.ts.md
@@ -1552,35 +1552,38 @@ primitive databases import-csv <database-id> <file.csv> --model products \
 
 The CLI imports through a registered batch (bulk) save operation — `--operation` defaults to `seed_save`, so the database type needs a save-like op (`{ modelName, id, data }`) by that name (or pass your own). `--batch-size` defaults to 5000, `--delimiter` to `,`; use `--dry-run` to report row/batch counts without writing and `--stop-on-error` to abort on the first failing chunk (default is best-effort continue).
 
-For programmatic imports with per-row `transform` or progress callbacks, use `importCsv()` from app code:
+For programmatic imports with per-row `transform` or progress callbacks, use `importCsv` from app code:
+
+```typescript
+  const result = await client.databases.importCsv(databaseId, {
+    csv: csvString, // provide csv or data (pre-parsed rows), not both
+    modelName: "products",
+    columnMap: { "Product Name": "name", "Unit Price": "price" },
+    types: { price: "number" },
+    idColumn: "sku",
+    transform: (row, _index) => {
+      if (!row.name) return null; // return null to skip a row
+      return { ...row, importedAt: new Date().toISOString() };
+    },
+    onProgress: ({ processed, total }) => {
+      console.log(`${processed}/${total} processed`);
+    },
+  });
+  // result: { imported, failed, errors, indexesCreated, durationMs }
+```
+
+Other options: `data` (pre-parsed rows, instead of `csv`), `delimiter`, `batchSize` (default 5000), `idGenerator` (per-row ID factory; the fallback chain is `idColumn` → `idGenerator` → generated ULID), `onBatchError` (return `false` to abort remaining batches), and `operationName` (the registered save op, default `"save"`, called as `{ modelName, id, data }`).
+
+A generated model class can stand in for `modelName` — the import then filters columns to the model's schema and syncs its indexes afterwards (`syncIndexes`, reported as `indexesCreated`):
 
 ```typescript
 import { Product } from "./models";
 
-// With model class
 const result = await client.databases.importCsv(databaseId, {
   csv: csvString,
   model: Product,
   columnMap: { "Product Name": "name", "Unit Price": "price" },
 });
-
-// Without model class (csv string or pre-parsed data array)
-const result = await client.databases.importCsv(databaseId, {
-  csv: csvString,       // provide csv or data, not both
-  // data: parsedRows,  // alternative: pre-parsed array of objects
-  modelName: "products",
-  types: { price: "number", stock: "number" },
-  idColumn: "sku",
-  transform: (row, index) => {
-    if (!row.name) return null; // skip
-    return { ...row, importedAt: new Date().toISOString() };
-  },
-  batchSize: 10000,
-  onProgress: ({ processed, total, imported, failed }) => {
-    console.log(`${processed}/${total} processed`);
-  },
-});
-// result: { imported: number, failed: number, errors: [...], indexesCreated: number, durationMs: number }
 ```
 
 ### Database design


### PR DESCRIPTION
## What the issue reported
`databases.importCsv` was documented JS-only (prose call shape in working-with-databases.md ~L317; ts-scoped fences in the DATABASES guide) even though Swift now has it.

## Verified against source
- Swift: `importCsv(databaseId:options:) async throws -> CsvImportResult` with `CsvImportOptions` carrying `csv`/`data`, `modelName`, `columnMap`, `transform` (return nil to skip), `types` (`CsvCoercionType`), `idColumn`/`idGenerator`, `delimiter`, `batchSize` (default 5000), `onProgress` (`CsvImportProgress`), `onBatchError`, `operationName` (`API/DatabasesAPI.swift:503`, `Types/DatabasesTypes.swift:323`).
- The JS `model:` class path (schema-driven field filtering + post-import `syncIndexes`) is JS-only — Swift requires `modelName` and reports `indexesCreated: 0` per source. Kept as a **ts-scoped** guide fence per STYLE.md platform treatment; no gap narration.

## What changed
- New corpus pair `examples/databases/db-import-csv.{ts,swift}` demonstrating the cross-platform surface (columnMap, types coercion, transform-with-skip, onProgress).
- `docs/getting-started/working-with-databases.md` — CLI path first, then a code-group with the corpus pair replacing the JS-shaped prose.
- `AGENT_GUIDE_TO_PRIMITIVE_DATABASES.template.md` — ts-scoped double fence → unscoped `{{ example }}` + a neutral options rundown (verified field-by-field against `CsvImportOptions`) + the model-class variant kept ts-scoped; guides re-rendered.

## Validation
`pnpm check:examples` (parity + both compiles + TOML + CLI + stamp) and `npx vitepress build docs` green.

Fixes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)