### PR TITLE
auth guide: promote 15 inline fences to corpus pairs (#87, AUTHENTICATION chunk)

### DIFF
--- a/examples/auth/auth-error-handling.swift
+++ b/examples/auth/auth-error-handling.swift
@@ -1,0 +1,32 @@
+import JsBaoClient
+
+// AuthError is thrown for non-2xx auth responses. It carries an optional
+// `code: AuthCode?` enum — switch on `error.code`.
+func verifyWithErrorHandling(
+  client: JsBaoClient,
+  email: String,
+  code: String,
+  showUserMessage: (String) -> Void
+) async throws {
+  // #region example
+  do {
+    _ = try await client.auth.otpVerify(email: email, code: code)
+  } catch let error as AuthError {
+    switch error.code {
+    case .invalidToken,          // bad/expired code
+         .tokenExpired,          // token expired
+         .invitationRequired,    // invite-only app, no invitation
+         .domainNotAllowed,      // domain-mode app, email not in allowed domains
+         .addedToWaitlist,       // waitlist enabled, user added
+         .waitlistEntryUpdated,  // existing waitlist entry updated
+         .magicLinkNotEnabled,   // magic link off in admin console
+         .inviteTokenInvalid,    // bad invite token
+         .inviteTokenExpired,    // invite token expired
+         .inviteAlreadyAccepted: // invite already used
+      showUserMessage(error.message)
+    default:
+      throw error
+    }
+  }
+  // #endregion example
+}

--- a/examples/auth/auth-error-handling.ts
+++ b/examples/auth/auth-error-handling.ts
@@ -1,0 +1,46 @@
+import { AuthError, AUTH_CODES, type JsBaoClient } from "js-bao-wss-client";
+
+// AuthError is thrown for non-2xx auth responses with a machine-readable
+// code. Switch on the exported AUTH_CODES constants; compare server-only
+// codes as string literals.
+export async function verifyWithErrorHandling(
+  client: JsBaoClient,
+  email: string,
+  code: string,
+  showUserMessage: (message: string) => void
+) {
+  // #region example
+  try {
+    await client.otpVerify(email, code);
+  } catch (err) {
+    if (err instanceof AuthError) {
+      switch (err.code) {
+        case AUTH_CODES.INVALID_TOKEN:          // bad/expired code
+        case AUTH_CODES.TOKEN_EXPIRED:          // token expired
+        case AUTH_CODES.INVITATION_REQUIRED:    // invite-only app, no invitation
+        case AUTH_CODES.DOMAIN_NOT_ALLOWED:     // domain-mode app, email not in allowed domains
+        case AUTH_CODES.ADDED_TO_WAITLIST:      // waitlist enabled, user added
+        case AUTH_CODES.WAITLIST_ENTRY_UPDATED: // existing waitlist entry updated
+        case AUTH_CODES.PASSKEY_NOT_ENABLED:    // passkey off in admin console
+        case AUTH_CODES.MAGIC_LINK_NOT_ENABLED: // magic link off in admin console
+        case AUTH_CODES.INVITE_TOKEN_INVALID:   // bad invite token
+        case AUTH_CODES.INVITE_TOKEN_EXPIRED:   // invite token expired
+        case AUTH_CODES.INVITE_ALREADY_ACCEPTED: // invite already used
+          showUserMessage(err.message);
+          return;
+      }
+      // Server-only codes — not in the client's AUTH_CODES constant, so check
+      // the string directly:
+      switch (err.code) {
+        case "RATE_LIMITED":             // too many requests; err may include retryAfter
+        case "OTP_MAX_ATTEMPTS":         // too many bad guesses; request new code
+        case "OTP_NOT_ENABLED":          // OTP off in admin console
+        case "RESERVED_EMAIL_FOR_ADMIN": // +primitivetest emails can't hold admin/owner roles
+          showUserMessage(err.message);
+          return;
+      }
+    }
+    throw err;
+  }
+  // #endregion example
+}

--- a/examples/auth/auth-events-minimal.swift
+++ b/examples/auth/auth-events-minimal.swift
@@ -1,0 +1,16 @@
+import JsBaoClient
+
+// The minimum auth wiring: one handler, two triggers.
+func wireMinimalAuthHandler(
+  client: JsBaoClient,
+  navigateToLogin: @escaping () -> Void
+) -> [EventSubscription] {
+  // #region example
+  func promptLogin() { navigateToLogin() }
+  let failed = client.events.on(.authFailed) { (_: AuthFailedEvent) in promptLogin() }
+  let state = client.events.on(.authState) { (event: AuthStateEvent) in
+    if !event.authenticated { promptLogin() }
+  }
+  // #endregion example
+  return [failed, state]
+}

--- a/examples/auth/auth-events-minimal.ts
+++ b/examples/auth/auth-events-minimal.ts
@@ -1,0 +1,16 @@
+import type { JsBaoClient } from "js-bao-wss-client";
+
+// The minimum auth wiring: one handler, three triggers.
+export function wireMinimalAuthHandler(
+  client: JsBaoClient,
+  navigateToLogin: () => void
+) {
+  // #region example
+  const promptLogin = () => navigateToLogin();
+  client.on("auth-failed", promptLogin);
+  client.on("auth:onlineAuthRequired", promptLogin);
+  client.on("auth:state", ({ authenticated }) => {
+    if (!authenticated) promptLogin();
+  });
+  // #endregion example
+}

--- a/examples/auth/auth-events.swift
+++ b/examples/auth/auth-events.swift
@@ -1,0 +1,27 @@
+import JsBaoClient
+
+// The canonical auth events, delivered as typed event structs. `authFailed`
+// and `authState` are the ones most apps must handle.
+func wireAuthEvents(
+  client: JsBaoClient,
+  redirectToLogin: @escaping () -> Void
+) -> [EventSubscription] {
+  // #region example
+  // Token refresh failed or server invalidated session — prompt re-login.
+  let failed = client.events.on(.authFailed) { (event: AuthFailedEvent) in
+    redirectToLogin()
+  }
+
+  // Token applied successfully (login, refresh, or OAuth callback).
+  let success = client.events.on(.authSuccess) { (event: AuthSuccessEvent) in
+    // event.cause names the operation that produced the token.
+    // Treat unknown values as a generic success — the set may grow.
+  }
+
+  // Generic state-machine event — fires on transitions.
+  let state = client.events.on(.authState) { (event: AuthStateEvent) in
+    // event.authenticated, event.userId, event.mode (NetworkMode)
+  }
+  // #endregion example
+  return [failed, success, state]
+}

--- a/examples/auth/auth-events.ts
+++ b/examples/auth/auth-events.ts
@@ -1,0 +1,42 @@
+import type { JsBaoClient } from "js-bao-wss-client";
+
+// The canonical auth events. `auth-failed` and `auth:onlineAuthRequired`
+// are the ones most apps must handle.
+export function wireAuthEvents(
+  client: JsBaoClient,
+  redirectToLogin: () => void,
+  promptSignIn: () => void,
+  clearSensitiveUI: () => void,
+  navigateHome: () => void
+) {
+  // #region example
+  // Token refresh failed or server invalidated session — prompt re-login.
+  client.on("auth-failed", ({ message, reason }) => {
+    redirectToLogin();
+  });
+
+  // Token applied successfully (login, refresh, or OAuth callback).
+  client.on("auth-success", ({ token, previousToken, cause }) => {
+    // cause names the operation that produced the token. Stable values:
+    //   Sign-in:    "oauthCallback" | "magicLinkVerify" | "otpVerify" | "passkeyAuth"
+    //   Refresh:    "httpRefresh" | "ws-challenge" | "bootstrap:refresh" | "backoff-retry"
+    //   Lifecycle:  "persisted-hydrate" | "ws-handshake" | "auto-network:online"
+    //               | "networkMode:online" | "http-request"
+    //   Manual:     "manual"
+    // Treat unknown values as a generic success — the set may grow.
+  });
+
+  // Came back online without a valid token. Show sign-in.
+  client.on("auth:onlineAuthRequired", () => {
+    promptSignIn();
+  });
+
+  // Generic state machine event — fires on transitions.
+  client.on("auth:state", ({ authenticated, mode, userId }) => {
+    // mode: "online" | "offline" | "none" | "auto"
+  });
+
+  client.on("auth:logout", () => clearSensitiveUI());
+  client.on("auth:logout:complete", () => navigateHome());
+  // #endregion example
+}

--- a/examples/auth/logout.swift
+++ b/examples/auth/logout.swift
@@ -6,6 +6,5 @@ func signOut(client: JsBaoClient) async throws {
   try await client.auth.logout(options: LogoutOptions(
     wipeLocal: true // delete locally cached document data + KV cache
   ))
-  // Fires `auth:logout` immediately and `auth:logout:complete` when finished.
   // #endregion example
 }

--- a/examples/auth/magic-link-callback.swift
+++ b/examples/auth/magic-link-callback.swift
@@ -1,0 +1,24 @@
+import Foundation
+import JsBaoClient
+
+// Magic-link callback: the token arrives as `magic_token` (not `token`,
+// `magicToken`, or `code`). Read it off the redirect URI, verify it, then
+// route by the result flags.
+func handleMagicLinkCallback(
+  client: JsBaoClient,
+  callbackURL: URL,
+  showOnboarding: () -> Void,
+  offerPasskeyRegistration: () -> Void
+) async throws {
+  // #region example
+  let magicToken = URLComponents(url: callbackURL, resolvingAgainstBaseURL: false)?
+    .queryItems?.first(where: { $0.name == "magic_token" })?.value
+
+  if let magicToken {
+    let result = try await client.auth.magicLinkVerify(token: magicToken)
+    // Token is now stored on the client and WS auto-connects.
+    if result.isNewUser == true { showOnboarding() }
+    if result.promptAddPasskey == true { offerPasskeyRegistration() }
+  }
+  // #endregion example
+}

--- a/examples/auth/magic-link-callback.ts
+++ b/examples/auth/magic-link-callback.ts
@@ -1,0 +1,21 @@
+import type { JsBaoClient } from "js-bao-wss-client";
+
+// Magic-link callback page: the token arrives as `magic_token` (not `token`,
+// `magicToken`, or `code`). Verify it, then route by the result flags.
+export async function handleMagicLinkCallback(
+  client: JsBaoClient,
+  showOnboarding: () => void,
+  offerPasskeyRegistration: () => void
+) {
+  // #region example
+  const magicToken = new URLSearchParams(window.location.search).get("magic_token");
+
+  if (magicToken) {
+    const { user, isNewUser, promptAddPasskey } = await client.magicLinkVerify(magicToken);
+    // Token is now stored on the client and WS auto-connects.
+    if (isNewUser) showOnboarding();
+    if (promptAddPasskey) offerPasskeyRegistration();
+    return user;
+  }
+  // #endregion example
+}

--- a/examples/auth/manual-token.swift
+++ b/examples/auth/manual-token.swift
@@ -1,0 +1,15 @@
+import JsBaoClient
+
+// Read the current token's claims, or set a token obtained out-of-band.
+func manualToken(client: JsBaoClient, jwt: String) {
+  // #region example
+  // Manually set a token (e.g. obtained out-of-band). Triggers authSuccess
+  // and pushes through the normal apply-token pipeline.
+  client.updateToken(jwt, cause: "external")
+
+  // Read the current token via the decoded JWT payload, or track it from the
+  // authSuccess event.
+  let payload = client.getJwtPayload()
+  // #endregion example
+  _ = payload
+}

--- a/examples/auth/manual-token.ts
+++ b/examples/auth/manual-token.ts
@@ -1,0 +1,12 @@
+import type { JsBaoClient } from "js-bao-wss-client";
+
+// Read the current token, or set one obtained out-of-band.
+export function manualToken(client: JsBaoClient, jwt: string) {
+  // #region example
+  client.getToken(); // string | null
+
+  // Manually set a token (e.g. you obtained one out-of-band). Triggers
+  // auth-success and pushes through the normal apply-token pipeline.
+  client.setToken(jwt, { cause: "external" });
+  // #endregion example
+}

--- a/examples/auth/oauth-callback.swift
+++ b/examples/auth/oauth-callback.swift
@@ -1,0 +1,13 @@
+import JsBaoClient
+
+// OAuth callback: complete the flow on an existing client instance.
+// `code` and `state` come from the redirect URI delivered to your
+// ASWebAuthenticationSession completion handler.
+func completeOAuth(client: JsBaoClient, code: String, state: String) async throws {
+  // #region example
+  if !code.isEmpty && !state.isEmpty {
+    try await client.handleOAuthCallback(code: code, state: state)
+    // Token now stored, WebSocket reconnected. Navigate.
+  }
+  // #endregion example
+}

--- a/examples/auth/oauth-callback.ts
+++ b/examples/auth/oauth-callback.ts
@@ -1,0 +1,17 @@
+import type { JsBaoClient } from "js-bao-wss-client";
+
+// OAuth callback page: extract code/state and complete the flow on an
+// existing client instance.
+export async function completeOAuth(client: JsBaoClient) {
+  // #region example
+  const params = new URLSearchParams(window.location.search);
+  const code = params.get("code");
+  const state = params.get("state");
+
+  if (code && state) {
+    await client.handleOAuthCallback(code, state);
+    // Token now stored, WebSocket reconnected. Navigate.
+    window.location.href = "/";
+  }
+  // #endregion example
+}

--- a/examples/auth/oauth-exchange-code.swift
+++ b/examples/auth/oauth-exchange-code.swift
@@ -1,0 +1,21 @@
+import JsBaoClient
+
+// OAuth callback without a client instance: exchange the code statically,
+// then persist the token however your app does.
+func exchangeCode(
+  apiUrl: String,
+  appId: String,
+  code: String,
+  state: String
+) async throws -> String {
+  // #region example
+  let token = try await JsBaoClient.exchangeOAuthCode(
+    apiUrl: apiUrl,
+    appId: appId,
+    code: code,
+    state: state
+  )
+  // Persist however your app does (e.g. Keychain), or pass to the client.
+  // #endregion example
+  return token
+}

--- a/examples/auth/oauth-exchange-code.ts
+++ b/examples/auth/oauth-exchange-code.ts
@@ -1,0 +1,21 @@
+import { JsBaoClient } from "js-bao-wss-client";
+
+// OAuth callback without a client instance: exchange the code statically,
+// then persist the token however your app does.
+export async function exchangeCode(
+  apiUrl: string,
+  appId: string,
+  code: string,
+  state: string
+) {
+  // #region example
+  const token = await JsBaoClient.exchangeOAuthCode({
+    apiUrl,
+    appId,
+    code,
+    state,
+  });
+  // Persist however your app does (storage / cookie / pass to initializeClient)
+  // #endregion example
+  return token;
+}

--- a/examples/auth/test-user-otp.swift
+++ b/examples/auth/test-user-otp.swift
@@ -4,8 +4,14 @@ import JsBaoClient
 // OTP code. The derived account must already exist as a user in the app.
 func signInTestUser(client: JsBaoClient) async throws {
   // #region example
-  _ = try await client.auth.otpRequest(email: "alice+primitivetest-teacher@example.com")
-  _ = try await client.auth.otpVerify(email: "alice+primitivetest-teacher@example.com", code: "000000")
+  // Requires the app owner to have added "alice@example.com" to the app's
+  // testAccountBaseEmails whitelist. Then any `alice+primitivetest<suffix>@example.com`
+  // derivative becomes a test account that accepts code "000000".
+  _ = try await client.auth.otpRequest(email: "alice+primitivetest@example.com")
+  _ = try await client.auth.otpVerify(email: "alice+primitivetest@example.com", code: "000000")
   // client is now authenticated; the access token expires in 30 minutes
+
+  // Role-distinguished derivatives (Gmail/Workspace deliver them to the same inbox):
+  _ = try await client.auth.otpRequest(email: "alice+primitivetest-teacher@example.com")
   // #endregion example
 }

--- a/examples/auth/test-user-otp.ts
+++ b/examples/auth/test-user-otp.ts
@@ -4,8 +4,14 @@ import type { JsBaoClient } from "js-bao-wss-client";
 // OTP code. The derived account must already exist as a user in the app.
 export async function signInTestUser(client: JsBaoClient) {
   // #region example
-  await client.otpRequest("alice+primitivetest-teacher@example.com");
-  await client.otpVerify("alice+primitivetest-teacher@example.com", "000000");
+  // Requires the app owner to have added "alice@example.com" to the app's
+  // testAccountBaseEmails whitelist. Then any `alice+primitivetest<suffix>@example.com`
+  // derivative becomes a test account that accepts code "000000".
+  await client.otpRequest("alice+primitivetest@example.com");
+  await client.otpVerify("alice+primitivetest@example.com", "000000");
   // client is now authenticated; the access token expires in 30 minutes
+
+  // Role-distinguished derivatives (Gmail/Workspace deliver them to the same inbox):
+  await client.otpRequest("alice+primitivetest-teacher@example.com");
   // #endregion example
 }

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_AUTHENTICATION.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_AUTHENTICATION.swift.md
@@ -94,25 +94,24 @@ Dev → prod checklist: add the production origin to `corsAllowedOrigins`, add t
 When the callback page can construct a client (you already have the JWT or are happy to re-init), extract `code`/`state` from the callback and pass them to `handleOAuthCallback`:
 
 ```swift
-// `code` and `state` come from the redirect URI delivered to your
-// ASWebAuthenticationSession completion handler.
-if !code.isEmpty && !state.isEmpty {
-  try await client.handleOAuthCallback(code: code, state: state)
-  // Token now stored, WebSocket reconnected. Navigate.
-}
+  if !code.isEmpty && !state.isEmpty {
+    try await client.handleOAuthCallback(code: code, state: state)
+    // Token now stored, WebSocket reconnected. Navigate.
+  }
 ```
 
 ### Handle the callback (static method — when no client yet)
 
 ```swift
-let token = try await JsBaoClient.exchangeOAuthCode(
-  apiUrl: apiUrl,
-  appId: appId,
-  code: code,
-  state: state
-)
-// Persist however your app does (e.g. Keychain), or pass to the client.
+  let token = try await JsBaoClient.exchangeOAuthCode(
+    apiUrl: apiUrl,
+    appId: appId,
+    code: code,
+    state: state
+  )
+  // Persist however your app does (e.g. Keychain), or pass to the client.
 ```
+
 
 **Don't:**
 
@@ -143,9 +142,22 @@ let token = try await client.handleOAuthCallback(code: code, state: state)
 
 `auth.magicLinkRequest(email:redirectUri:)` takes the `redirectUri` as a required argument. `auth.magicLinkVerify(token:)` returns a `MagicLinkVerifyResult` (`.user`, `.promptAddPasskey?`, `.isNewUser?`).
 
-### Reading the token
+### Reading the token (callback page)
 
-The magic-link callback delivers the token as a `magic_token` value (not `token`, `magicToken`, or `code`). Read it from the redirect URI and pass it to `magicLinkVerify(token:)`.
+The callback delivers the token as a `magic_token` value — **not** `token`, `magicToken`, or `code`:
+
+```swift
+  let magicToken = URLComponents(url: callbackURL, resolvingAgainstBaseURL: false)?
+    .queryItems?.first(where: { $0.name == "magic_token" })?.value
+
+  if let magicToken {
+    let result = try await client.auth.magicLinkVerify(token: magicToken)
+    // Token is now stored on the client and WS auto-connects.
+    if result.isNewUser == true { showOnboarding() }
+    if result.promptAddPasskey == true { offerPasskeyRegistration() }
+  }
+```
+
 
 ---
 
@@ -165,32 +177,33 @@ The magic-link callback delivers the token as a `magic_token` value (not `token`
 
 ### Error handling
 
-`AuthError` is thrown for non-2xx responses with a machine-readable code.
-
-`AuthError` carries an optional `code: AuthCode?` enum — switch on `error.code`:
+`AuthError` is thrown for non-2xx responses with a machine-readable code:
 
 ```swift
-do {
-  let result = try await client.auth.otpVerify(email: email, code: code)
-} catch let error as AuthError {
-  switch error.code {
-  case .invalidToken,          // bad/expired code
-       .invitationRequired,    // invite-only app, no invitation
-       .domainNotAllowed,      // domain-mode app, email not in allowed domains
-       .magicLinkNotEnabled,   // magic link off in admin console
-       .inviteTokenInvalid,    // bad invite token
-       .inviteTokenExpired,    // invite token expired
-       .inviteAlreadyAccepted, // invite already used
-       .addedToWaitlist,       // waitlist enabled, user added
-       .waitlistEntryUpdated:  // existing waitlist entry updated
-    showUserMessage(error.message)
-  default:
-    throw error
+  do {
+    _ = try await client.auth.otpVerify(email: email, code: code)
+  } catch let error as AuthError {
+    switch error.code {
+    case .invalidToken,          // bad/expired code
+         .tokenExpired,          // token expired
+         .invitationRequired,    // invite-only app, no invitation
+         .domainNotAllowed,      // domain-mode app, email not in allowed domains
+         .addedToWaitlist,       // waitlist enabled, user added
+         .waitlistEntryUpdated,  // existing waitlist entry updated
+         .magicLinkNotEnabled,   // magic link off in admin console
+         .inviteTokenInvalid,    // bad invite token
+         .inviteTokenExpired,    // invite token expired
+         .inviteAlreadyAccepted: // invite already used
+      showUserMessage(error.message)
+    default:
+      throw error
+    }
   }
-}
 ```
 
-> **Caveat on OTP disabled.** When OTP is disabled the request endpoint returns a plain 400 with the message `"OTP authentication is not enabled for this app"` and no machine-readable code. Don't rely on a code to detect that case — gate the OTP UI on `getAuthConfig()`'s `otpEnabled` up front instead.
+> **Caveat on OTP disabled.** When OTP is disabled the request endpoint returns a plain 400 with the message `"OTP authentication is not enabled for this app"` and **no `code` field**. Don't rely on a code to detect that case — gate the OTP UI on `getAuthConfig()`'s `otpEnabled` up front instead.
+
+`AuthCode` also carries the SDK-generated cases `.tokenInvalid`, `.refreshFailed`, `.networkError`, and `.unauthorized`, plus `.passkeyNotEnabled` and `.memberInvitationsDisabled` from the server. Server codes outside the enum (e.g. rate limiting) arrive with `code == nil` — fall back to `error.message`.
 
 The same `AuthError` codes apply to `magicLinkRequest`/`magicLinkVerify`.
 
@@ -201,46 +214,38 @@ The same `AuthError` codes apply to `magicLinkRequest`/`magicLinkVerify`.
 
 ## Auth Events
 
-These are the canonical events. `auth-failed` and `auth:onlineAuthRequired` are the ones most apps must handle.
+These are the canonical events.
 
-Register handlers with `client.events.on(...)`, which delivers typed event structs:
+`authFailed` and `authState` are the ones most apps must handle. Register handlers with `client.events.on(...)`, which delivers typed event structs and returns an `EventSubscription` — hold it for as long as you want the handler live:
 
 ```swift
-// Token refresh failed or server invalidated session — prompt re-login.
-client.events.on(.authFailed) { event in
-  redirectToLogin()
-}
+  // Token refresh failed or server invalidated session — prompt re-login.
+  let failed = client.events.on(.authFailed) { (event: AuthFailedEvent) in
+    redirectToLogin()
+  }
 
-// Token applied successfully (login, refresh, or OAuth callback).
-client.events.on(.authSuccess) { event in
-  // event.cause names the operation that produced the token.
-  // Treat unknown values as a generic success — the set may grow.
-}
+  // Token applied successfully (login, refresh, or OAuth callback).
+  let success = client.events.on(.authSuccess) { (event: AuthSuccessEvent) in
+    // event.cause names the operation that produced the token.
+    // Treat unknown values as a generic success — the set may grow.
+  }
 
-// Came back online without a valid token. Show sign-in.
-client.events.on(.onlineAuthRequired) { _ in
-  promptSignIn()
-}
-
-// Generic state-machine event — fires on transitions.
-client.events.on(.authState) { event in
-  // event.mode: "online" | "offline" | "none" | "auto"
-}
-
-client.events.on(.logout) { _ in clearSensitiveUI() }
-client.events.on(.logoutComplete) { _ in navigateHome() }
+  // Generic state-machine event — fires on transitions.
+  let state = client.events.on(.authState) { (event: AuthStateEvent) in
+    // event.authenticated, event.userId, event.mode (NetworkMode)
+  }
 ```
+
 
 ### Minimal handler
 
 ```swift
-func promptLogin() { navigateToLogin() }
-client.events.on(.authFailed) { _ in promptLogin() }
-client.events.on(.onlineAuthRequired) { _ in promptLogin() }
-client.events.on(.authState) { event in if !event.authenticated { promptLogin() } }
+  func promptLogin() { navigateToLogin() }
+  let failed = client.events.on(.authFailed) { (_: AuthFailedEvent) in promptLogin() }
+  let state = client.events.on(.authState) { (event: AuthStateEvent) in
+    if !event.authenticated { promptLogin() }
+  }
 ```
-
-Subscriptions are retained for the lifetime of the client; keep a reference to any token the API returns if you need to unsubscribe earlier.
 
 ---
 
@@ -288,13 +293,13 @@ The admin console exposes the same toggles. App code does not need to special-ca
 To read or manually set the token:
 
 ```swift
-// Manually set a token (e.g. obtained out-of-band). Triggers authSuccess
-// and pushes through the normal apply-token pipeline.
-client.updateToken(jwt, cause: "external")
+  // Manually set a token (e.g. obtained out-of-band). Triggers authSuccess
+  // and pushes through the normal apply-token pipeline.
+  client.updateToken(jwt, cause: "external")
 
-// Read the current token via the decoded JWT payload, or track it from the
-// authSuccess event.
-let payload = client.getJwtPayload()
+  // Read the current token via the decoded JWT payload, or track it from the
+  // authSuccess event.
+  let payload = client.getJwtPayload()
 ```
 
 **Don't:**
@@ -320,10 +325,9 @@ The client persists the token to the Keychain across app launches. `waitForAuthB
   try await client.auth.logout(options: LogoutOptions(
     wipeLocal: true // delete locally cached document data + KV cache
   ))
-  // Fires `auth:logout` immediately and `auth:logout:complete` when finished.
 ```
 
-`auth.logout(options:)` takes a `LogoutOptions` — `wipeLocal` (delete locally cached document data + KV cache), `revokeOffline` (also revoke any stored offline grant), `clearOfflineIdentity` (defaults `true`). Logout fires `logout` immediately and `logoutComplete` when finished.
+`auth.logout(options:)` takes a `LogoutOptions` — `wipeLocal` (delete locally cached document data + KV cache), `revokeOffline` (also revoke any stored offline grant), `clearOfflineIdentity` (defaults `true`).
 
 ---
 
@@ -388,14 +392,15 @@ See the [Invitations guide](AGENT_GUIDE_TO_PRIMITIVE_INVITATIONS.md#deferred-gra
 There is **no `primitive test-users` CLI command**. The bypass is server-side: an OTP request for an email shaped like `<base-local>+primitivetest<suffix>@<base-domain>` accepts the magic code `"000000"` instead of the emailed code, but **only when the base address is on the app's `testAccountBaseEmails` whitelist**.
 
 ```swift
-// Requires the app owner to have added "alice@example.com" to the app's
-// testAccountBaseEmails whitelist. Then any `alice+primitivetest<suffix>@example.com`
-// derivative becomes a test account that accepts code "000000".
-_ = try await client.auth.otpRequest(email: "alice+primitivetest@example.com")
-let result = try await client.auth.otpVerify(email: "alice+primitivetest@example.com", code: "000000")
+  // Requires the app owner to have added "alice@example.com" to the app's
+  // testAccountBaseEmails whitelist. Then any `alice+primitivetest<suffix>@example.com`
+  // derivative becomes a test account that accepts code "000000".
+  _ = try await client.auth.otpRequest(email: "alice+primitivetest@example.com")
+  _ = try await client.auth.otpVerify(email: "alice+primitivetest@example.com", code: "000000")
+  // client is now authenticated; the access token expires in 30 minutes
 
-// Role-distinguished derivatives (Gmail/Workspace deliver them to the same inbox):
-_ = try await client.auth.otpRequest(email: "alice+primitivetest-teacher@example.com")
+  // Role-distinguished derivatives (Gmail/Workspace deliver them to the same inbox):
+  _ = try await client.auth.otpRequest(email: "alice+primitivetest-teacher@example.com")
 ```
 
 Guardrails:

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_AUTHENTICATION.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_AUTHENTICATION.template.md
@@ -102,58 +102,14 @@ await client.startOAuthFlow(continueUrl, {
 
 When the callback page can construct a client (you already have the JWT or are happy to re-init), extract `code`/`state` from the callback and pass them to `handleOAuthCallback`:
 
-{{#lang ts}}
-```typescript
-const params = new URLSearchParams(window.location.search);
-const code = params.get("code");
-const state = params.get("state");
-
-if (code && state) {
-  await client.handleOAuthCallback(code, state);
-  // Token now stored, WebSocket reconnected. Navigate.
-  window.location.href = "/";
-}
-```
-{{/lang}}
-{{#lang swift}}
-```swift
-// `code` and `state` come from the redirect URI delivered to your
-// ASWebAuthenticationSession completion handler.
-if !code.isEmpty && !state.isEmpty {
-  try await client.handleOAuthCallback(code: code, state: state)
-  // Token now stored, WebSocket reconnected. Navigate.
-}
-```
-{{/lang}}
+{{ example: auth/oauth-callback }}
 
 ### Handle the callback (static method — when no client yet)
 
-{{#lang ts}}
-```typescript
-import { JsBaoClient } from "js-bao-wss-client";
+{{ example: auth/oauth-exchange-code }}
 
-const token = await JsBaoClient.exchangeOAuthCode({
-  apiUrl: API_URL,
-  appId: APP_ID,
-  code,
-  state,
-  // Pass these if your app uses a refresh proxy:
-  refreshProxyBaseUrl: `${window.location.origin}/proxy`,
-  refreshProxyCookieMaxAgeSeconds: 7 * 24 * 60 * 60,
-});
-// Persist however your app does (storage / cookie / pass to initializeClient)
-```
-{{/lang}}
-{{#lang swift}}
-```swift
-let token = try await JsBaoClient.exchangeOAuthCode(
-  apiUrl: apiUrl,
-  appId: appId,
-  code: code,
-  state: state
-)
-// Persist however your app does (e.g. Keychain), or pass to the client.
-```
+{{#lang ts}}
+If your app uses a refresh proxy, also pass `refreshProxyBaseUrl` (e.g. `` `${window.location.origin}/proxy` ``) and `refreshProxyCookieMaxAgeSeconds` to `exchangeOAuthCode`.
 {{/lang}}
 
 **Don't:**
@@ -184,24 +140,18 @@ let token = try await client.handleOAuthCallback(code: code, state: state)
 
 {{#lang ts}}
 `magicLinkRequest` accepts an optional `redirectUri` (defaulting to the client's `oauthRedirectUri`) and throws `Error("Redirect URI not configured")` if neither is set.
+{{/lang}}
+{{#lang swift}}
+`auth.magicLinkRequest(email:redirectUri:)` takes the `redirectUri` as a required argument. `auth.magicLinkVerify(token:)` returns a `MagicLinkVerifyResult` (`.user`, `.promptAddPasskey?`, `.isNewUser?`).
+{{/lang}}
 
 ### Reading the token (callback page)
 
-The callback page reads `?magic_token=...` off the URL and feeds it to `magicLinkVerify`:
+The callback delivers the token as a `magic_token` value — **not** `token`, `magicToken`, or `code`:
 
-```typescript
-const magicToken = new URLSearchParams(window.location.search).get("magic_token");
+{{ example: auth/magic-link-callback }}
 
-if (magicToken) {
-  const { user, isNewUser, promptAddPasskey } = await client.magicLinkVerify(magicToken);
-  // Token is now stored on the client and WS auto-connects.
-  if (isNewUser) showOnboarding();
-  if (promptAddPasskey) offerPasskeyRegistration();
-}
-```
-
-The query param name is **`magic_token`** (not `token`, `magicToken`, or `code`).
-
+{{#lang ts}}
 The callback URL may also carry `?purpose=login-add-passkey`. The server appends this when the link was sent for an existing user the platform thinks should add a passkey (e.g. they signed in via OTP/magic-link but have no passkey on file). The `magicLinkVerify` call itself is unchanged — apps that read `purpose` from the URL can use it as a hint to route the user to passkey registration after sign-in instead of straight to the home screen.
 
 To accept an invitation server-side at verify time (so the deferred grant resolves to the signing-in user even when emails differ), pass `inviteToken`:
@@ -209,13 +159,6 @@ To accept an invitation server-side at verify time (so the deferred grant resolv
 ```typescript
 await client.magicLinkVerify(magicToken, { inviteToken: inviteTokenFromUrl });
 ```
-{{/lang}}
-{{#lang swift}}
-`auth.magicLinkRequest(email:redirectUri:)` takes the `redirectUri` as a required argument. `auth.magicLinkVerify(token:)` returns a `MagicLinkVerifyResult` (`.user`, `.promptAddPasskey?`, `.isNewUser?`).
-
-### Reading the token
-
-The magic-link callback delivers the token as a `magic_token` value (not `token`, `magicToken`, or `code`). Read it from the redirect URI and pass it to `magicLinkVerify(token:)`.
 {{/lang}}
 
 ---
@@ -233,79 +176,19 @@ The magic-link callback delivers the token as a `magic_token` value (not `token`
 
 ### Error handling
 
-`AuthError` is thrown for non-2xx responses with a machine-readable code.
+`AuthError` is thrown for non-2xx responses with a machine-readable code:
+
+{{ example: auth/auth-error-handling }}
+
+> **Caveat on OTP disabled.** When OTP is disabled the request endpoint returns a plain 400 with the message `"OTP authentication is not enabled for this app"` and **no `code` field**. Don't rely on a code to detect that case — gate the OTP UI on `getAuthConfig()`'s `otpEnabled` up front instead.
 
 {{#lang ts}}
-Import from the package and switch on `err.code`:
-
-```typescript
-import { AuthError, AUTH_CODES } from "js-bao-wss-client";
-
-try {
-  await client.otpVerify(email, code);
-} catch (err) {
-  if (err instanceof AuthError) {
-    switch (err.code) {
-      case AUTH_CODES.INVALID_TOKEN:          // bad/expired code
-      case AUTH_CODES.TOKEN_EXPIRED:          // token expired
-      case AUTH_CODES.INVITATION_REQUIRED:    // invite-only app, no invitation
-      case AUTH_CODES.DOMAIN_NOT_ALLOWED:     // domain-mode app, email not in allowed domains
-      case AUTH_CODES.ADDED_TO_WAITLIST:      // waitlist enabled, user added
-      case AUTH_CODES.WAITLIST_ENTRY_UPDATED: // existing waitlist entry updated
-      case AUTH_CODES.PASSKEY_NOT_ENABLED:    // passkey off in admin console
-      case AUTH_CODES.MAGIC_LINK_NOT_ENABLED: // magic link off in admin console
-      case AUTH_CODES.INVITE_TOKEN_INVALID:   // bad invite token (#466)
-      case AUTH_CODES.INVITE_TOKEN_EXPIRED:   // invite token expired
-      case AUTH_CODES.INVITE_ALREADY_ACCEPTED: // invite already used
-        showUserMessage(err.message);
-        return;
-    }
-    // Server-only codes — not in the client's AUTH_CODES constant, so check
-    // the string directly:
-    switch (err.code) {
-      case "RATE_LIMITED":            // too many requests; err may include retryAfter
-      case "OTP_MAX_ATTEMPTS":        // too many bad guesses; request new code
-      case "OTP_NOT_ENABLED":         // OTP off in admin console
-      case "RESERVED_EMAIL_FOR_ADMIN": // +primitivetest emails can't hold admin/owner roles
-        showUserMessage(err.message);
-        return;
-    }
-  }
-  throw err;
-}
-```
-
 The exported `AUTH_CODES` constant covers: `ADDED_TO_WAITLIST`, `INVITATION_REQUIRED`, `DOMAIN_NOT_ALLOWED`, `INVALID_TOKEN`, `TOKEN_EXPIRED`, `PASSKEY_NOT_ENABLED`, `MAGIC_LINK_NOT_ENABLED`, `WAITLIST_ENTRY_UPDATED`, `INVITE_TOKEN_INVALID`, `INVITE_TOKEN_EXPIRED`, `INVITE_ALREADY_ACCEPTED`. The server may also return `RATE_LIMITED`, `OTP_MAX_ATTEMPTS`, and `RESERVED_EMAIL_FOR_ADMIN` — compare those as string literals.
-
-> **Caveat on `OTP_NOT_ENABLED`.** The constant is defined and exported, but the OTP request endpoint returns a plain 400 with the message `"OTP authentication is not enabled for this app"` and **no `code` field** when OTP is disabled. Don't rely on switching on `OTP_NOT_ENABLED` to detect that case — gate the OTP UI on `getAuthConfig().otpEnabled` up front instead.
 
 The same `AuthError` codes apply to `magicLinkRequest`/`magicLinkVerify` and `passkey*` methods.
 {{/lang}}
 {{#lang swift}}
-`AuthError` carries an optional `code: AuthCode?` enum — switch on `error.code`:
-
-```swift
-do {
-  let result = try await client.auth.otpVerify(email: email, code: code)
-} catch let error as AuthError {
-  switch error.code {
-  case .invalidToken,          // bad/expired code
-       .invitationRequired,    // invite-only app, no invitation
-       .domainNotAllowed,      // domain-mode app, email not in allowed domains
-       .magicLinkNotEnabled,   // magic link off in admin console
-       .inviteTokenInvalid,    // bad invite token
-       .inviteTokenExpired,    // invite token expired
-       .inviteAlreadyAccepted, // invite already used
-       .addedToWaitlist,       // waitlist enabled, user added
-       .waitlistEntryUpdated:  // existing waitlist entry updated
-    showUserMessage(error.message)
-  default:
-    throw error
-  }
-}
-```
-
-> **Caveat on OTP disabled.** When OTP is disabled the request endpoint returns a plain 400 with the message `"OTP authentication is not enabled for this app"` and no machine-readable code. Don't rely on a code to detect that case — gate the OTP UI on `getAuthConfig()`'s `otpEnabled` up front instead.
+`AuthCode` also carries the SDK-generated cases `.tokenInvalid`, `.refreshFailed`, `.networkError`, and `.unauthorized`, plus `.passkeyNotEnabled` and `.memberInvitationsDisabled` from the server. Server codes outside the enum (e.g. rate limiting) arrive with `code == nil` — fall back to `error.message`.
 
 The same `AuthError` codes apply to `magicLinkRequest`/`magicLinkVerify`.
 {{/lang}}
@@ -381,42 +264,18 @@ await client.passkeyDelete(passkeyId);
 
 ## Auth Events
 
-These are the canonical events. `auth-failed` and `auth:onlineAuthRequired` are the ones most apps must handle.
+These are the canonical events.
 
 {{#lang ts}}
-Register handlers with `client.on(...)`:
+`auth-failed` and `auth:onlineAuthRequired` are the ones most apps must handle. Register handlers with `client.on(...)`:
+{{/lang}}
+{{#lang swift}}
+`authFailed` and `authState` are the ones most apps must handle. Register handlers with `client.events.on(...)`, which delivers typed event structs and returns an `EventSubscription` — hold it for as long as you want the handler live:
+{{/lang}}
 
-```typescript
-// Token refresh failed or server invalidated session — prompt re-login.
-client.on("auth-failed", ({ message, reason }) => {
-  redirectToLogin();
-});
+{{ example: auth/auth-events }}
 
-// Token applied successfully (login, refresh, or OAuth callback).
-client.on("auth-success", ({ token, previousToken, cause }) => {
-  // cause names the operation that produced the token. Stable values:
-  //   Sign-in:    "oauthCallback" | "magicLinkVerify" | "otpVerify" | "passkeyAuth"
-  //   Refresh:    "httpRefresh" | "ws-challenge" | "bootstrap:refresh" | "backoff-retry"
-  //   Lifecycle:  "persisted-hydrate" | "ws-handshake" | "auto-network:online"
-  //               | "networkMode:online" | "http-request"
-  //   Manual:     "manual"
-  // Treat unknown values as a generic success — the set may grow.
-});
-
-// Came back online without a valid token. Show sign-in.
-client.on("auth:onlineAuthRequired", () => {
-  promptSignIn();
-});
-
-// Generic state machine event — fires on transitions.
-client.on("auth:state", ({ authenticated, mode, userId }) => {
-  // mode: "online" | "offline" | "none" | "auto"
-});
-
-client.on("auth:logout", () => clearSensitiveUI());
-client.on("auth:logout:complete", () => navigateHome());
-```
-
+{{#lang ts}}
 **Don't:**
 
 ```typescript
@@ -425,56 +284,11 @@ client.on("auth:logout:complete", () => navigateHome());
 client.onAuthStateChange((u) => {});
 await client.signInWithGoogle();
 ```
+{{/lang}}
 
 ### Minimal handler
 
-```typescript
-const promptLogin = () => navigateToLogin();
-client.on("auth-failed", promptLogin);
-client.on("auth:onlineAuthRequired", promptLogin);
-client.on("auth:state", ({ authenticated }) => { if (!authenticated) promptLogin(); });
-```
-{{/lang}}
-{{#lang swift}}
-Register handlers with `client.events.on(...)`, which delivers typed event structs:
-
-```swift
-// Token refresh failed or server invalidated session — prompt re-login.
-client.events.on(.authFailed) { event in
-  redirectToLogin()
-}
-
-// Token applied successfully (login, refresh, or OAuth callback).
-client.events.on(.authSuccess) { event in
-  // event.cause names the operation that produced the token.
-  // Treat unknown values as a generic success — the set may grow.
-}
-
-// Came back online without a valid token. Show sign-in.
-client.events.on(.onlineAuthRequired) { _ in
-  promptSignIn()
-}
-
-// Generic state-machine event — fires on transitions.
-client.events.on(.authState) { event in
-  // event.mode: "online" | "offline" | "none" | "auto"
-}
-
-client.events.on(.logout) { _ in clearSensitiveUI() }
-client.events.on(.logoutComplete) { _ in navigateHome() }
-```
-
-### Minimal handler
-
-```swift
-func promptLogin() { navigateToLogin() }
-client.events.on(.authFailed) { _ in promptLogin() }
-client.events.on(.onlineAuthRequired) { _ in promptLogin() }
-client.events.on(.authState) { event in if !event.authenticated { promptLogin() } }
-```
-
-Subscriptions are retained for the lifetime of the client; keep a reference to any token the API returns if you need to unsubscribe earlier.
-{{/lang}}
+{{ example: auth/auth-events-minimal }}
 
 ---
 
@@ -513,17 +327,11 @@ The admin console exposes the same toggles. App code does not need to special-ca
 
 To read or manually set the token:
 
-{{#lang ts}}
-```typescript
-client.getToken(); // string | null
-
-// Manually set a token (e.g. you obtained one out-of-band). Triggers
-// auth-success and pushes through the normal apply-token pipeline.
-client.setToken(jwt, { cause: "external" });
-```
+{{ example: auth/manual-token }}
 
 **Don't:**
 
+{{#lang ts}}
 ```typescript
 // WRONG — there is no client.auth.setToken. It's client.setToken(...).
 client.auth.setToken(jwt);
@@ -533,18 +341,6 @@ const doc = await client.openDocument(id);     // before await client.waitForAut
 ```
 {{/lang}}
 {{#lang swift}}
-```swift
-// Manually set a token (e.g. obtained out-of-band). Triggers authSuccess
-// and pushes through the normal apply-token pipeline.
-client.updateToken(jwt, cause: "external")
-
-// Read the current token via the decoded JWT payload, or track it from the
-// authSuccess event.
-let payload = client.getJwtPayload()
-```
-
-**Don't:**
-
 ```swift
 // WRONG — opening documents before auth is ready throws or fails silently.
 let doc = try await client.openDocument(id)  // before try await client.waitForAuthReady()
@@ -622,7 +418,7 @@ await client.logout({
 Logout fires `auth:logout` immediately and `auth:logout:complete` when finished.
 {{/lang}}
 {{#lang swift}}
-`auth.logout(options:)` takes a `LogoutOptions` — `wipeLocal` (delete locally cached document data + KV cache), `revokeOffline` (also revoke any stored offline grant), `clearOfflineIdentity` (defaults `true`). Logout fires `logout` immediately and `logoutComplete` when finished.
+`auth.logout(options:)` takes a `LogoutOptions` — `wipeLocal` (delete locally cached document data + KV cache), `revokeOffline` (also revoke any stored offline grant), `clearOfflineIdentity` (defaults `true`).
 {{/lang}}
 
 ---
@@ -761,30 +557,7 @@ If you're using the template, this route is already wired in `src/router/routes.
 
 There is **no `primitive test-users` CLI command**. The bypass is server-side: an OTP request for an email shaped like `<base-local>+primitivetest<suffix>@<base-domain>` accepts the magic code `"000000"` instead of the emailed code, but **only when the base address is on the app's `testAccountBaseEmails` whitelist**.
 
-{{#lang ts}}
-```typescript
-// Requires the app owner to have added "alice@example.com" to the app's
-// testAccountBaseEmails whitelist. Then any `alice+primitivetest<suffix>@example.com`
-// derivative becomes a test account that accepts code "000000".
-await client.otpRequest("alice+primitivetest@example.com");
-const { user } = await client.otpVerify("alice+primitivetest@example.com", "000000");
-
-// Role-distinguished derivatives (Gmail/Workspace deliver them to the same inbox):
-await client.otpRequest("alice+primitivetest-teacher@example.com");
-```
-{{/lang}}
-{{#lang swift}}
-```swift
-// Requires the app owner to have added "alice@example.com" to the app's
-// testAccountBaseEmails whitelist. Then any `alice+primitivetest<suffix>@example.com`
-// derivative becomes a test account that accepts code "000000".
-_ = try await client.auth.otpRequest(email: "alice+primitivetest@example.com")
-let result = try await client.auth.otpVerify(email: "alice+primitivetest@example.com", code: "000000")
-
-// Role-distinguished derivatives (Gmail/Workspace deliver them to the same inbox):
-_ = try await client.auth.otpRequest(email: "alice+primitivetest-teacher@example.com")
-```
-{{/lang}}
+{{ example: auth/test-user-otp }}
 
 Guardrails:
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_AUTHENTICATION.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_AUTHENTICATION.ts.md
@@ -118,33 +118,30 @@ await client.startOAuthFlow(continueUrl, {
 When the callback page can construct a client (you already have the JWT or are happy to re-init), extract `code`/`state` from the callback and pass them to `handleOAuthCallback`:
 
 ```typescript
-const params = new URLSearchParams(window.location.search);
-const code = params.get("code");
-const state = params.get("state");
+  const params = new URLSearchParams(window.location.search);
+  const code = params.get("code");
+  const state = params.get("state");
 
-if (code && state) {
-  await client.handleOAuthCallback(code, state);
-  // Token now stored, WebSocket reconnected. Navigate.
-  window.location.href = "/";
-}
+  if (code && state) {
+    await client.handleOAuthCallback(code, state);
+    // Token now stored, WebSocket reconnected. Navigate.
+    window.location.href = "/";
+  }
 ```
 
 ### Handle the callback (static method — when no client yet)
 
 ```typescript
-import { JsBaoClient } from "js-bao-wss-client";
-
-const token = await JsBaoClient.exchangeOAuthCode({
-  apiUrl: API_URL,
-  appId: APP_ID,
-  code,
-  state,
-  // Pass these if your app uses a refresh proxy:
-  refreshProxyBaseUrl: `${window.location.origin}/proxy`,
-  refreshProxyCookieMaxAgeSeconds: 7 * 24 * 60 * 60,
-});
-// Persist however your app does (storage / cookie / pass to initializeClient)
+  const token = await JsBaoClient.exchangeOAuthCode({
+    apiUrl,
+    appId,
+    code,
+    state,
+  });
+  // Persist however your app does (storage / cookie / pass to initializeClient)
 ```
+
+If your app uses a refresh proxy, also pass `refreshProxyBaseUrl` (e.g. `` `${window.location.origin}/proxy` ``) and `refreshProxyCookieMaxAgeSeconds` to `exchangeOAuthCode`.
 
 **Don't:**
 
@@ -179,20 +176,19 @@ const { token } = await client.handleOAuthCallback(code, state);
 
 ### Reading the token (callback page)
 
-The callback page reads `?magic_token=...` off the URL and feeds it to `magicLinkVerify`:
+The callback delivers the token as a `magic_token` value — **not** `token`, `magicToken`, or `code`:
 
 ```typescript
-const magicToken = new URLSearchParams(window.location.search).get("magic_token");
+  const magicToken = new URLSearchParams(window.location.search).get("magic_token");
 
-if (magicToken) {
-  const { user, isNewUser, promptAddPasskey } = await client.magicLinkVerify(magicToken);
-  // Token is now stored on the client and WS auto-connects.
-  if (isNewUser) showOnboarding();
-  if (promptAddPasskey) offerPasskeyRegistration();
-}
+  if (magicToken) {
+    const { user, isNewUser, promptAddPasskey } = await client.magicLinkVerify(magicToken);
+    // Token is now stored on the client and WS auto-connects.
+    if (isNewUser) showOnboarding();
+    if (promptAddPasskey) offerPasskeyRegistration();
+    return user;
+  }
 ```
-
-The query param name is **`magic_token`** (not `token`, `magicToken`, or `code`).
 
 The callback URL may also carry `?purpose=login-add-passkey`. The server appends this when the link was sent for an existing user the platform thinks should add a passkey (e.g. they signed in via OTP/magic-link but have no passkey on file). The `magicLinkVerify` call itself is unchanged — apps that read `purpose` from the URL can use it as a hint to route the user to passkey registration after sign-in instead of straight to the home screen.
 
@@ -218,50 +214,46 @@ await client.magicLinkVerify(magicToken, { inviteToken: inviteTokenFromUrl });
 
 ### Error handling
 
-`AuthError` is thrown for non-2xx responses with a machine-readable code.
-
-Import from the package and switch on `err.code`:
+`AuthError` is thrown for non-2xx responses with a machine-readable code:
 
 ```typescript
-import { AuthError, AUTH_CODES } from "js-bao-wss-client";
-
-try {
-  await client.otpVerify(email, code);
-} catch (err) {
-  if (err instanceof AuthError) {
-    switch (err.code) {
-      case AUTH_CODES.INVALID_TOKEN:          // bad/expired code
-      case AUTH_CODES.TOKEN_EXPIRED:          // token expired
-      case AUTH_CODES.INVITATION_REQUIRED:    // invite-only app, no invitation
-      case AUTH_CODES.DOMAIN_NOT_ALLOWED:     // domain-mode app, email not in allowed domains
-      case AUTH_CODES.ADDED_TO_WAITLIST:      // waitlist enabled, user added
-      case AUTH_CODES.WAITLIST_ENTRY_UPDATED: // existing waitlist entry updated
-      case AUTH_CODES.PASSKEY_NOT_ENABLED:    // passkey off in admin console
-      case AUTH_CODES.MAGIC_LINK_NOT_ENABLED: // magic link off in admin console
-      case AUTH_CODES.INVITE_TOKEN_INVALID:   // bad invite token (#466)
-      case AUTH_CODES.INVITE_TOKEN_EXPIRED:   // invite token expired
-      case AUTH_CODES.INVITE_ALREADY_ACCEPTED: // invite already used
-        showUserMessage(err.message);
-        return;
+  try {
+    await client.otpVerify(email, code);
+  } catch (err) {
+    if (err instanceof AuthError) {
+      switch (err.code) {
+        case AUTH_CODES.INVALID_TOKEN:          // bad/expired code
+        case AUTH_CODES.TOKEN_EXPIRED:          // token expired
+        case AUTH_CODES.INVITATION_REQUIRED:    // invite-only app, no invitation
+        case AUTH_CODES.DOMAIN_NOT_ALLOWED:     // domain-mode app, email not in allowed domains
+        case AUTH_CODES.ADDED_TO_WAITLIST:      // waitlist enabled, user added
+        case AUTH_CODES.WAITLIST_ENTRY_UPDATED: // existing waitlist entry updated
+        case AUTH_CODES.PASSKEY_NOT_ENABLED:    // passkey off in admin console
+        case AUTH_CODES.MAGIC_LINK_NOT_ENABLED: // magic link off in admin console
+        case AUTH_CODES.INVITE_TOKEN_INVALID:   // bad invite token
+        case AUTH_CODES.INVITE_TOKEN_EXPIRED:   // invite token expired
+        case AUTH_CODES.INVITE_ALREADY_ACCEPTED: // invite already used
+          showUserMessage(err.message);
+          return;
+      }
+      // Server-only codes — not in the client's AUTH_CODES constant, so check
+      // the string directly:
+      switch (err.code) {
+        case "RATE_LIMITED":             // too many requests; err may include retryAfter
+        case "OTP_MAX_ATTEMPTS":         // too many bad guesses; request new code
+        case "OTP_NOT_ENABLED":          // OTP off in admin console
+        case "RESERVED_EMAIL_FOR_ADMIN": // +primitivetest emails can't hold admin/owner roles
+          showUserMessage(err.message);
+          return;
+      }
     }
-    // Server-only codes — not in the client's AUTH_CODES constant, so check
-    // the string directly:
-    switch (err.code) {
-      case "RATE_LIMITED":            // too many requests; err may include retryAfter
-      case "OTP_MAX_ATTEMPTS":        // too many bad guesses; request new code
-      case "OTP_NOT_ENABLED":         // OTP off in admin console
-      case "RESERVED_EMAIL_FOR_ADMIN": // +primitivetest emails can't hold admin/owner roles
-        showUserMessage(err.message);
-        return;
-    }
+    throw err;
   }
-  throw err;
-}
 ```
 
-The exported `AUTH_CODES` constant covers: `ADDED_TO_WAITLIST`, `INVITATION_REQUIRED`, `DOMAIN_NOT_ALLOWED`, `INVALID_TOKEN`, `TOKEN_EXPIRED`, `PASSKEY_NOT_ENABLED`, `MAGIC_LINK_NOT_ENABLED`, `WAITLIST_ENTRY_UPDATED`, `INVITE_TOKEN_INVALID`, `INVITE_TOKEN_EXPIRED`, `INVITE_ALREADY_ACCEPTED`. The server may also return `RATE_LIMITED`, `OTP_MAX_ATTEMPTS`, and `RESERVED_EMAIL_FOR_ADMIN` — compare those as string literals.
+> **Caveat on OTP disabled.** When OTP is disabled the request endpoint returns a plain 400 with the message `"OTP authentication is not enabled for this app"` and **no `code` field**. Don't rely on a code to detect that case — gate the OTP UI on `getAuthConfig()`'s `otpEnabled` up front instead.
 
-> **Caveat on `OTP_NOT_ENABLED`.** The constant is defined and exported, but the OTP request endpoint returns a plain 400 with the message `"OTP authentication is not enabled for this app"` and **no `code` field** when OTP is disabled. Don't rely on switching on `OTP_NOT_ENABLED` to detect that case — gate the OTP UI on `getAuthConfig().otpEnabled` up front instead.
+The exported `AUTH_CODES` constant covers: `ADDED_TO_WAITLIST`, `INVITATION_REQUIRED`, `DOMAIN_NOT_ALLOWED`, `INVALID_TOKEN`, `TOKEN_EXPIRED`, `PASSKEY_NOT_ENABLED`, `MAGIC_LINK_NOT_ENABLED`, `WAITLIST_ENTRY_UPDATED`, `INVITE_TOKEN_INVALID`, `INVITE_TOKEN_EXPIRED`, `INVITE_ALREADY_ACCEPTED`. The server may also return `RATE_LIMITED`, `OTP_MAX_ATTEMPTS`, and `RESERVED_EMAIL_FOR_ADMIN` — compare those as string literals.
 
 The same `AuthError` codes apply to `magicLinkRequest`/`magicLinkVerify` and `passkey*` methods.
 
@@ -334,39 +326,39 @@ await client.passkeyDelete(passkeyId);
 
 ## Auth Events
 
-These are the canonical events. `auth-failed` and `auth:onlineAuthRequired` are the ones most apps must handle.
+These are the canonical events.
 
-Register handlers with `client.on(...)`:
+`auth-failed` and `auth:onlineAuthRequired` are the ones most apps must handle. Register handlers with `client.on(...)`:
 
 ```typescript
-// Token refresh failed or server invalidated session — prompt re-login.
-client.on("auth-failed", ({ message, reason }) => {
-  redirectToLogin();
-});
+  // Token refresh failed or server invalidated session — prompt re-login.
+  client.on("auth-failed", ({ message, reason }) => {
+    redirectToLogin();
+  });
 
-// Token applied successfully (login, refresh, or OAuth callback).
-client.on("auth-success", ({ token, previousToken, cause }) => {
-  // cause names the operation that produced the token. Stable values:
-  //   Sign-in:    "oauthCallback" | "magicLinkVerify" | "otpVerify" | "passkeyAuth"
-  //   Refresh:    "httpRefresh" | "ws-challenge" | "bootstrap:refresh" | "backoff-retry"
-  //   Lifecycle:  "persisted-hydrate" | "ws-handshake" | "auto-network:online"
-  //               | "networkMode:online" | "http-request"
-  //   Manual:     "manual"
-  // Treat unknown values as a generic success — the set may grow.
-});
+  // Token applied successfully (login, refresh, or OAuth callback).
+  client.on("auth-success", ({ token, previousToken, cause }) => {
+    // cause names the operation that produced the token. Stable values:
+    //   Sign-in:    "oauthCallback" | "magicLinkVerify" | "otpVerify" | "passkeyAuth"
+    //   Refresh:    "httpRefresh" | "ws-challenge" | "bootstrap:refresh" | "backoff-retry"
+    //   Lifecycle:  "persisted-hydrate" | "ws-handshake" | "auto-network:online"
+    //               | "networkMode:online" | "http-request"
+    //   Manual:     "manual"
+    // Treat unknown values as a generic success — the set may grow.
+  });
 
-// Came back online without a valid token. Show sign-in.
-client.on("auth:onlineAuthRequired", () => {
-  promptSignIn();
-});
+  // Came back online without a valid token. Show sign-in.
+  client.on("auth:onlineAuthRequired", () => {
+    promptSignIn();
+  });
 
-// Generic state machine event — fires on transitions.
-client.on("auth:state", ({ authenticated, mode, userId }) => {
-  // mode: "online" | "offline" | "none" | "auto"
-});
+  // Generic state machine event — fires on transitions.
+  client.on("auth:state", ({ authenticated, mode, userId }) => {
+    // mode: "online" | "offline" | "none" | "auto"
+  });
 
-client.on("auth:logout", () => clearSensitiveUI());
-client.on("auth:logout:complete", () => navigateHome());
+  client.on("auth:logout", () => clearSensitiveUI());
+  client.on("auth:logout:complete", () => navigateHome());
 ```
 
 **Don't:**
@@ -381,10 +373,12 @@ await client.signInWithGoogle();
 ### Minimal handler
 
 ```typescript
-const promptLogin = () => navigateToLogin();
-client.on("auth-failed", promptLogin);
-client.on("auth:onlineAuthRequired", promptLogin);
-client.on("auth:state", ({ authenticated }) => { if (!authenticated) promptLogin(); });
+  const promptLogin = () => navigateToLogin();
+  client.on("auth-failed", promptLogin);
+  client.on("auth:onlineAuthRequired", promptLogin);
+  client.on("auth:state", ({ authenticated }) => {
+    if (!authenticated) promptLogin();
+  });
 ```
 
 ---
@@ -433,11 +427,11 @@ The admin console exposes the same toggles. App code does not need to special-ca
 To read or manually set the token:
 
 ```typescript
-client.getToken(); // string | null
+  client.getToken(); // string | null
 
-// Manually set a token (e.g. you obtained one out-of-band). Triggers
-// auth-success and pushes through the normal apply-token pipeline.
-client.setToken(jwt, { cause: "external" });
+  // Manually set a token (e.g. you obtained one out-of-band). Triggers
+  // auth-success and pushes through the normal apply-token pipeline.
+  client.setToken(jwt, { cause: "external" });
 ```
 
 **Don't:**
@@ -627,14 +621,15 @@ If you're using the template, this route is already wired in `src/router/routes.
 There is **no `primitive test-users` CLI command**. The bypass is server-side: an OTP request for an email shaped like `<base-local>+primitivetest<suffix>@<base-domain>` accepts the magic code `"000000"` instead of the emailed code, but **only when the base address is on the app's `testAccountBaseEmails` whitelist**.
 
 ```typescript
-// Requires the app owner to have added "alice@example.com" to the app's
-// testAccountBaseEmails whitelist. Then any `alice+primitivetest<suffix>@example.com`
-// derivative becomes a test account that accepts code "000000".
-await client.otpRequest("alice+primitivetest@example.com");
-const { user } = await client.otpVerify("alice+primitivetest@example.com", "000000");
+  // Requires the app owner to have added "alice@example.com" to the app's
+  // testAccountBaseEmails whitelist. Then any `alice+primitivetest<suffix>@example.com`
+  // derivative becomes a test account that accepts code "000000".
+  await client.otpRequest("alice+primitivetest@example.com");
+  await client.otpVerify("alice+primitivetest@example.com", "000000");
+  // client is now authenticated; the access token expires in 30 minutes
 
-// Role-distinguished derivatives (Gmail/Workspace deliver them to the same inbox):
-await client.otpRequest("alice+primitivetest-teacher@example.com");
+  // Role-distinguished derivatives (Gmail/Workspace deliver them to the same inbox):
+  await client.otpRequest("alice+primitivetest-teacher@example.com");
 ```
 
 Guardrails:


### PR DESCRIPTION
## Scope
First chunk of #87 (migrate inline template fences to the compile-gated corpus), covering AGENT_GUIDE_TO_PRIMITIVE_AUTHENTICATION.template.md: **34 → 19 inline fences**.

## New corpus pairs (compiled on both languages)
- `auth/oauth-callback` — instance `handleOAuthCallback`
- `auth/oauth-exchange-code` — static `exchangeOAuthCode`
- `auth/magic-link-callback` — `magic_token` extraction + verify + result-flag routing (forced writing the previously missing Swift example)
- `auth/auth-error-handling` — `AuthError` switching (`AUTH_CODES` / `AuthCode` enum)
- `auth/auth-events` + `auth/auth-events-minimal` — canonical and minimal handler wiring
- `auth/manual-token` — `getToken`/`setToken` ↔ `updateToken`/`getJwtPayload`
- `auth/test-user-otp` — enriched existing pair (whitelist context + role derivatives), fences replaced with the include

## Latent errors surfaced by the compile gate (fixed against source)
- Swift event case is **`.authOnlineRequired`**, not `.onlineAuthRequired` as the old fence claimed.
- **`.authOnlineRequired` and `.authLogout` are declared but never emitted** by the Swift client, and no logout-complete case exists — the old fences showed handlers that could never fire, and the logout sections claimed events that don't happen. Swift examples/prose now cover the three events that fire (`.authFailed`/`.authSuccess`/`.authState`); `examples/auth/logout.swift`'s event comment removed. Parity gap filed: js-bao-wss#1059.
- Swift `AuthCode` note rewritten from source (`Types/Errors.swift`): unknown server codes arrive as `code == nil`.

## Kept inline (per the issue's rule 2)
Anti-pattern "Don't" fences (deliberately non-compilable), JS-only capabilities (passkeys ×4, `persistJwtInStorage`, refresh proxy, logout extra options, `startOAuthFlow` options, `magicLinkVerify` inviteToken), template-app/SPAD integration patterns (Vue store, AuthGateView/Combine), and shape fragments (jsonc/http/bash).

## Validation
`pnpm check:examples` (parity + both compiles + TOML + CLI + stamp) and `npx vitepress build docs` green.

Part of #87 — the issue stays open for the remaining templates (DOCUMENTS is blocked on swift-primitive-app-dev#33 for its SPAD-scoped fences).

🤖 Generated with [Claude Code](https://claude.com/claude-code)