### PR TITLE
DOCUMENTS guide: promote 12 inline fences to compile-gated corpus pairs (#87)

### DIFF
--- a/examples/documents/aggregate-facet.swift
+++ b/examples/documents/aggregate-facet.swift
@@ -1,0 +1,12 @@
+import JsBaoClient
+
+// Grouping by a stringset field counts per value.
+func aggregateFacet() {
+  // #region example
+  let tagCounts = Task.aggregate(AggregateOptions(
+    groupBy: ["tags"], // "tags" is a stringset field
+    operations: [AggregateOperation(type: .count)]
+  ))
+  // #endregion example
+  _ = tagCounts
+}

--- a/examples/documents/aggregate-facet.ts
+++ b/examples/documents/aggregate-facet.ts
@@ -1,0 +1,14 @@
+import { Task } from "../_harness/generated/ts/Task.generated";
+
+// Grouping by a stringset field counts per value. When the only operation
+// is `count`, the value collapses to a number.
+export async function aggregateFacet() {
+  // #region example
+  const tagCounts = await Task.aggregate({
+    groupBy: ["tags"], // "tags" is a stringset field
+    operations: [{ type: "count" }],
+  });
+  // Returns: { "work": 15, "urgent": 8, "personal": 5, ... }
+  // #endregion example
+  return tagCounts;
+}

--- a/examples/documents/date-handling.swift
+++ b/examples/documents/date-handling.swift
@@ -1,0 +1,25 @@
+import Foundation
+import JsBaoClient
+
+// Dates are stored as ISO-8601 strings — lexicographic order matches
+// chronological order, so string comparison works in queries.
+func dateHandling(documentId: String, taskId: String) throws {
+  // #region example
+  let now = ISO8601DateFormatter().string(from: Date())
+
+  // Store
+  if var task = Task.find(taskId) {
+    task.dueDate = now
+    try task.save(in: documentId)
+
+    // Compare
+    if let dueDate = task.dueDate, dueDate < now {
+      // overdue
+    }
+  }
+
+  // Query with date comparison
+  let overdue = Task.query(["dueDate": ["$lt": now]])
+  // #endregion example
+  _ = overdue
+}

--- a/examples/documents/date-handling.ts
+++ b/examples/documents/date-handling.ts
@@ -1,0 +1,22 @@
+import { Task } from "../_harness/generated/ts/Task.generated";
+
+// Dates are stored as ISO-8601 strings — lexicographic order matches
+// chronological order, so string comparison works in queries.
+export async function dateHandling(task: Task) {
+  // #region example
+  // Store
+  task.dueDate = new Date().toISOString();
+
+  // Compare
+  const due = new Date(task.dueDate);
+  if (due < new Date()) {
+    // overdue
+  }
+
+  // Query with date comparison
+  const overdue = await Task.query({
+    dueDate: { $lt: new Date().toISOString() },
+  });
+  // #endregion example
+  return overdue.data;
+}

--- a/examples/documents/list-accessible.swift
+++ b/examples/documents/list-accessible.swift
@@ -1,0 +1,14 @@
+import JsBaoClient
+
+// An "everything I can access" surface: combine owned + directly shared
+// documents with collection (and group) memberships.
+func listAccessible(client: JsBaoClient) async throws {
+  // #region example
+  let owned = try await client.me.ownedDocuments()
+  let shared = try await client.me.sharedDocuments().items
+  let collections = try await client.collections.list()
+  // then iterate collections / group memberships and call
+  // collections.listDocuments / groups.listDocuments.
+  // #endregion example
+  _ = (owned, shared, collections)
+}

--- a/examples/documents/list-accessible.ts
+++ b/examples/documents/list-accessible.ts
@@ -1,0 +1,14 @@
+import type { JsBaoClient } from "js-bao-wss-client";
+
+// An "everything I can access" surface: combine owned + directly shared
+// documents with collection (and group) memberships.
+export async function listAccessible(client: JsBaoClient) {
+  // #region example
+  const owned = await client.me.ownedDocuments();
+  const shared = (await client.me.sharedDocuments()).items;
+  const collections = await client.collections.list();
+  // then iterate collections / groups.listUserMemberships and call
+  // collections.listDocuments / groups.listDocuments.
+  // #endregion example
+  return { owned, shared, collections };
+}

--- a/examples/documents/open-tagged.swift
+++ b/examples/documents/open-tagged.swift
@@ -1,0 +1,16 @@
+import JsBaoClient
+
+// Open every document with a given tag, then query across all of them.
+func openTagged(client: JsBaoClient) async throws {
+  // #region example
+  // Open every document with a given tag
+  let channels = try await client.me.ownedDocuments(tag: "channel")
+  for channel in channels {
+    _ = try await client.documents.open(channel.documentId)
+  }
+
+  // Queries run across all open documents by default
+  let messages = Message.query()
+  // #endregion example
+  _ = messages
+}

--- a/examples/documents/open-tagged.ts
+++ b/examples/documents/open-tagged.ts
@@ -1,0 +1,17 @@
+import type { JsBaoClient } from "js-bao-wss-client";
+import { Message } from "../_harness/generated/ts/Message.generated";
+
+// Open every document with a given tag, then query across all of them.
+export async function openTagged(client: JsBaoClient) {
+  // #region example
+  // Open every document with a given tag
+  const channels = await client.me.ownedDocuments({ tag: "channel" });
+  await Promise.all(
+    channels.map((ch) => client.documents.open(ch.documentId))
+  );
+
+  // Queries run across all open documents by default
+  const messages = await Message.query({});
+  // #endregion example
+  return messages.data;
+}

--- a/examples/documents/query-and.swift
+++ b/examples/documents/query-and.swift
@@ -1,0 +1,13 @@
+import JsBaoClient
+
+// Plain field maps AND together — every condition must match.
+func queryAnd() {
+  // #region example
+  let result = Task.query([
+    "completed": false,
+    "priority": ["$gte": 3],
+    "category": ["$in": ["work", "urgent"]],
+  ])
+  // #endregion example
+  _ = result
+}

--- a/examples/documents/query-and.ts
+++ b/examples/documents/query-and.ts
@@ -1,0 +1,13 @@
+import { Task } from "../_harness/generated/ts/Task.generated";
+
+// Plain field maps AND together — every condition must match.
+export async function queryAnd() {
+  // #region example
+  const result = await Task.query({
+    completed: false,
+    priority: { $gte: 3 },
+    category: { $in: ["work", "urgent"] },
+  });
+  // #endregion example
+  return result.data;
+}

--- a/examples/documents/stringset-ops.swift
+++ b/examples/documents/stringset-ops.swift
@@ -1,0 +1,20 @@
+import JsBaoClient
+
+// Stringset fields are a native Set<String>: mutate the set, test
+// membership, then save the record to persist the change.
+func stringsetOps(documentId: String, taskId: String) throws {
+  // #region example
+  if var task = Task.find(taskId) {
+    // Add/remove tags
+    task.tags?.insert("urgent")
+    task.tags?.remove("low-priority")
+
+    // Check membership
+    if task.tags?.contains("urgent") == true {
+      // ...
+    }
+
+    try task.save(in: documentId)
+  }
+  // #endregion example
+}

--- a/examples/documents/stringset-ops.ts
+++ b/examples/documents/stringset-ops.ts
@@ -1,0 +1,20 @@
+import type { Task } from "../_harness/generated/ts/Task.generated";
+
+// Stringset fields hold a set of strings (tags, labels): mutate with
+// add/remove, test membership, convert to an array for display.
+export function stringsetOps(task: Task) {
+  // #region example
+  // Add/remove tags
+  task.tags?.add("urgent");
+  task.tags?.remove("low-priority");
+
+  // Check membership
+  if (task.tags?.has("urgent")) {
+    // ...
+  }
+
+  // Convert to array for display
+  const tagList = task.tags?.toArray() ?? [];
+  // #endregion example
+  return tagList;
+}

--- a/examples/documents/tag-filter-local.swift
+++ b/examples/documents/tag-filter-local.swift
@@ -1,0 +1,15 @@
+import JsBaoClient
+
+// Create a tagged document, then filter the owned list locally by tag.
+func tagFilterLocal(client: JsBaoClient) async throws {
+  // #region example
+  let result = try await client.documents.create(
+    options: CreateDocumentOptions(title: "My List", tags: ["todolist"])
+  )
+
+  // Filter locally
+  let owned = try await client.me.ownedDocuments()
+  let todoLists = owned.filter { $0.tags?.contains("todolist") == true }
+  // #endregion example
+  _ = (result, todoLists)
+}

--- a/examples/documents/tag-filter-local.ts
+++ b/examples/documents/tag-filter-local.ts
@@ -1,0 +1,16 @@
+import type { JsBaoClient } from "js-bao-wss-client";
+
+// Create a tagged document, then filter the owned list locally by tag.
+export async function tagFilterLocal(client: JsBaoClient) {
+  // #region example
+  const { metadata } = await client.documents.create({
+    title: "My List",
+    tags: ["todolist"],
+  });
+
+  // Filter locally
+  const owned = await client.me.ownedDocuments();
+  const todoLists = owned.filter((doc) => doc.tags?.includes("todolist"));
+  // #endregion example
+  return { metadata, todoLists };
+}

--- a/examples/sharing/collection-member-email.swift
+++ b/examples/sharing/collection-member-email.swift
@@ -1,0 +1,31 @@
+import JsBaoClient
+
+// Collections accept email-based members exactly like documents and groups —
+// a deferred grant that resolves on signup.
+func addCollectionMembers(
+  client: JsBaoClient,
+  collectionId: String
+) async throws {
+  // #region example
+  // Add an individual member by userId
+  _ = try await client.collections.addMember(
+    collectionId: collectionId,
+    params: .user("user-abc", permission: .readWrite)
+  )
+
+  // Or by email — deferred grant resolves on signup
+  let result = try await client.collections.addMember(
+    collectionId: collectionId,
+    params: .email(
+      "newhire@example.com",
+      permission: .reader,
+      sendEmail: true, // optional: platform sends an invite email
+      collectionUrl: "https://app.example.com/onboarding", // required when sendEmail is true
+      note: "Sharing the onboarding docs"
+    )
+  )
+  // result is .direct (added / already_member) or .deferred —
+  // the deferred case carries invitationId / inviteToken / expiresAt.
+  // #endregion example
+  _ = result
+}

--- a/examples/sharing/collection-member-email.ts
+++ b/examples/sharing/collection-member-email.ts
@@ -1,0 +1,28 @@
+import type { JsBaoClient } from "js-bao-wss-client";
+
+// Collections accept email-based members exactly like documents and groups —
+// a deferred grant that resolves on signup.
+export async function addCollectionMembers(
+  client: JsBaoClient,
+  collectionId: string
+) {
+  // #region example
+  // Add an individual member by userId
+  await client.collections.addMember(collectionId, {
+    userId: "user-abc",
+    permission: "read-write", // "reader" or "read-write"
+  });
+
+  // Or by email — deferred grant resolves on signup
+  const result = await client.collections.addMember(collectionId, {
+    email: "newhire@example.com",
+    permission: "reader",
+    sendEmail: true, // optional: platform sends an invite email
+    collectionUrl: "https://app.example.com/onboarding", // required when sendEmail is true
+    note: "Sharing the onboarding docs",
+  });
+  // result.status: "added" | "already_member" | "pending_signup"
+  // Pending case carries { invitationId, inviteToken, expiresAt }.
+  // #endregion example
+  return result;
+}

--- a/examples/sharing/remove-permission.swift
+++ b/examples/sharing/remove-permission.swift
@@ -1,0 +1,27 @@
+import JsBaoClient
+
+// Removal is its own call — there is no `permission: null` form on
+// updatePermissions. Ownership transfer hands the document to a new owner.
+func removePermissions(
+  client: JsBaoClient,
+  documentId: String,
+  newOwnerId: String
+) async throws {
+  // #region example
+  // Remove a current member by userId:
+  try await client.documents.removePermission(
+    documentId: documentId, userId: "user-abc"
+  )
+
+  // Cancel a pending email-based invite, OR remove a current member
+  // matched by email:
+  try await client.documents.removePermission(
+    documentId: documentId, email: "alice@example.com"
+  )
+
+  // Hand the document to a new owner:
+  try await client.documents.transferOwnership(
+    documentId: documentId, newOwnerId: newOwnerId
+  )
+  // #endregion example
+}

--- a/examples/sharing/remove-permission.ts
+++ b/examples/sharing/remove-permission.ts
@@ -1,0 +1,23 @@
+import type { JsBaoClient } from "js-bao-wss-client";
+
+// Removal is its own call — there is no `permission: null` form on
+// updatePermissions. Ownership transfer hands the document to a new owner.
+export async function removePermissions(
+  client: JsBaoClient,
+  documentId: string,
+  newOwnerId: string
+) {
+  // #region example
+  // Remove a current member by userId:
+  await client.documents.removePermission(documentId, "user-abc");
+
+  // Cancel a pending email-based invite, OR remove a current member
+  // matched by email:
+  await client.documents.removePermission(documentId, {
+    email: "alice@example.com",
+  });
+
+  // Hand the document to a new owner:
+  await client.documents.transferOwnership(documentId, newOwnerId);
+  // #endregion example
+}

--- a/examples/sharing/share-email-deferred.swift
+++ b/examples/sharing/share-email-deferred.swift
@@ -1,0 +1,28 @@
+import JsBaoClient
+
+// Share by email with notification — resolves immediately if the user
+// exists, otherwise creates a deferred grant that auto-applies when the
+// recipient signs up. With `sendEmail: true`, `documentUrl` is required
+// AND the app must have `baseUrl` configured (used to compose the accept
+// URL for the deferred-share email). Both preconditions return HTTP 400
+// if missing.
+func shareByEmailDeferred(
+  client: JsBaoClient,
+  documentId: String
+) async throws {
+  // #region example
+  let result = try await client.documents.updatePermissions(
+    documentId: documentId,
+    params: .email(
+      "alice@example.com",
+      permission: "read-write",
+      sendEmail: true,
+      documentUrl: "https://app.example.com/lists"
+    )
+  )
+  // Returns a direct grant (existing user) or a deferred grant
+  // (invitationId / inviteToken) that the recipient redeems via
+  // client.invitations.accept(inviteToken:) after signup.
+  // #endregion example
+  _ = result
+}

--- a/examples/sharing/share-email-deferred.ts
+++ b/examples/sharing/share-email-deferred.ts
@@ -1,0 +1,25 @@
+import type { JsBaoClient } from "js-bao-wss-client";
+
+// Share by email with notification — resolves immediately if the user
+// exists, otherwise creates a deferred grant that auto-applies when the
+// recipient signs up. With `sendEmail: true`, `documentUrl` is required
+// AND the app must have `baseUrl` configured (used to compose the accept
+// URL for the deferred-share email). Both preconditions return HTTP 400
+// if missing.
+export async function shareByEmailDeferred(
+  client: JsBaoClient,
+  documentId: string
+) {
+  // #region example
+  const result = await client.documents.updatePermissions(documentId, {
+    email: "alice@example.com",
+    permission: "read-write",
+    sendEmail: true,
+    documentUrl: "https://app.example.com/lists",
+  });
+  // Returns a direct grant (existing user) or a deferred grant
+  // ({ invitationId, inviteToken, ... }) that the recipient redeems via
+  // client.invitations.accept(inviteToken) after signup.
+  // #endregion example
+  return result;
+}

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.swift.md
@@ -118,6 +118,17 @@ There is **no single "my documents" list**. A user reaches documents through **f
 Each shared document in the result extends the base `DocumentInfo` (`title`, `createdBy`, `createdAt`, `lastModified`, plus `tags`/`metadata`/`thumbnailBlobId` when set) with the share-only extras `permission` (never `"owner"`), `source` (`"permission"` | `"invitation"`), `grantedBy`, `invitationId` (invitation rows only).
 
 
+For an "everything I can access" surface, combine the owned + shared calls with group and collection memberships:
+
+```swift
+  let owned = try await client.me.ownedDocuments()
+  let shared = try await client.me.sharedDocuments().items
+  let collections = try await client.collections.list()
+  // then iterate collections / group memberships and call
+  // collections.listDocuments / groups.listDocuments.
+```
+
+
 ## Core data operations
 
 Every example below is compiled against the real client as part of the docs build. The [Querying Data](#querying-data) and [Saving Data](#saving-data) sections below go deeper on projections, includes, and save options.
@@ -328,6 +339,17 @@ List with `me.ownedDocuments()` and `open()` the selected document; create a new
 
 All documents that need live updates or cross-document queries must be open. Tag documents so you can fetch a set with `me.ownedDocuments({ tag })` (and `me.sharedDocuments({ tag })` if the user can also be a non-owner), open each, and track per-document readiness yourself. For collective sharing of multiple documents as a unit, prefer the server-side Collections API (`client.collections.*` — see [Collections](#collections) below) over local tracking.
 
+```swift
+  // Open every document with a given tag
+  let channels = try await client.me.ownedDocuments(tag: "channel")
+  for channel in channels {
+    _ = try await client.documents.open(channel.documentId)
+  }
+
+  // Queries run across all open documents by default
+  let messages = Message.query()
+```
+
 
 The most common multi-doc shape is one ambient library/index document plus N per-item documents (each shareable independently); see [Index doc + per-item docs](#index-doc--per-item-docs-keying-tombstones-reconcile) below for keying, tombstones, and the reconcile pass. Open auxiliary docs with `appState.openAuxiliaryDoc(_:modelType:)` and close them with `appState.closeAuxiliaryDoc(_:)`.
 
@@ -443,6 +465,15 @@ Use tags to categorize documents by type. Pass `tags` to `create()`, filter the 
 
 You can also create a tagged document and filter locally:
 
+```swift
+  let result = try await client.documents.create(
+    options: CreateDocumentOptions(title: "My List", tags: ["todolist"])
+  )
+
+  // Filter locally
+  let owned = try await client.me.ownedDocuments()
+  let todoLists = owned.filter { $0.tags?.contains("todolist") == true }
+```
 
 ## Defining Models
 
@@ -596,8 +627,69 @@ fields = ["name", "parentId"]
 unique_constraints = [["name", "parentId"]]
 ```
 
+### Working with StringSets
+
+```swift
+  if var task = Task.find(taskId) {
+    // Add/remove tags
+    task.tags?.insert("urgent")
+    task.tags?.remove("low-priority")
+
+    // Check membership
+    if task.tags?.contains("urgent") == true {
+      // ...
+    }
+
+    try task.save(in: documentId)
+  }
+```
+
+### Working with Dates
+
+Dates are stored as ISO-8601 strings — lexicographic order matches chronological order, so string comparison works in queries:
+
+```swift
+  let now = ISO8601DateFormatter().string(from: Date())
+
+  // Store
+  if var task = Task.find(taskId) {
+    task.dueDate = now
+    try task.save(in: documentId)
+
+    // Compare
+    if let dueDate = task.dueDate, dueDate < now {
+      // overdue
+    }
+  }
+
+  // Query with date comparison
+  let overdue = Task.query(["dueDate": ["$lt": now]])
+```
 
 ## Querying Data
+
+
+**Logical operators** — see [Logical query operators](#logical-query-operators) above for the compiled `$or` example. Plain field maps AND together:
+
+```swift
+  let result = Task.query([
+    "completed": false,
+    "priority": ["$gte": 3],
+    "category": ["$in": ["work", "urgent"]],
+  ])
+```
+
+
+**StringSet facet aggregation** — grouping by a `stringset` field counts per value:
+
+```swift
+  let tagCounts = Task.aggregate(AggregateOptions(
+    groupBy: ["tags"], // "tags" is a stringset field
+    operations: [AggregateOperation(type: .count)]
+  ))
+```
+
+Only one stringset facet field is allowed per aggregation.
 
 
 ### View-data binding with `BaoDataLoader`
@@ -744,7 +836,33 @@ Documents can be shared with individual users (by userId or email), with groups,
 
 ### Quick Reference
 
-The core share calls — by userId, by email, and with a group — are in [Share a document (user / email / group)](#share-a-document-user--email--group) above. The full surface adds batch grants, deferred email shares, and access requests:
+The core share calls — by userId, by email, and with a group — are in [Share a document (user / email / group)](#share-a-document-user--email--group) above. The full surface adds batch grants and deferred email shares (for responding to a 403 with the `canRequestAccess` hint, see [Document Access Requests](#document-access-requests) below):
+
+```swift
+  _ = try await client.documents.updatePermissions(
+    documentId: documentId,
+    params: .batch([
+      PermissionAssignment(userId: "user-abc", permission: "read-write"),
+      PermissionAssignment(email: "alice@example.com", permission: "reader"),
+      PermissionAssignment(email: "bob@example.com", permission: "read-write"),
+    ])
+  )
+```
+
+```swift
+  let result = try await client.documents.updatePermissions(
+    documentId: documentId,
+    params: .email(
+      "alice@example.com",
+      permission: "read-write",
+      sendEmail: true,
+      documentUrl: "https://app.example.com/lists"
+    )
+  )
+  // Returns a direct grant (existing user) or a deferred grant
+  // (invitationId / inviteToken) that the recipient redeems via
+  // client.invitations.accept(inviteToken:) after signup.
+```
 
 
 
@@ -833,10 +951,7 @@ Beyond the Quick Reference and the `PrimitiveShareDocumentDialog` UI, the full p
 
 #### Direct shares: `updatePermissions`
 
-The method is **`updatePermissions`** (no `setPermissions`). Two forms — single user (by id or email) and batch (any mix of userId and email):
-
-
-Optional fields on either form: `sendEmail`, `documentUrl`, `note`.
+The method is **`updatePermissions`** (no `setPermissions`). Two forms — single user (by id or email; see [Share a document (user / email / group)](#share-a-document-user--email--group)) and batch (any mix of userId and email; see the [Quick Reference](#quick-reference)). Optional fields on either form: `sendEmail`, `documentUrl`, `note`.
 
 When `sendEmail: true`, the server delivers per-recipient emails:
 
@@ -848,6 +963,24 @@ Both branches share two preconditions when `sendEmail: true`: `documentUrl` must
 Repeated email-based calls are idempotent: a second `updatePermissions(documentId, { email })` with the same email updates the existing pending `DeferredDocumentPermission` in place rather than creating a duplicate row, so the latest `permission` value wins at signup-time resolution and `client.documents.listPendingInvitations(documentId)` shows one entry per pending recipient.
 
 **There is no `permission: null` to remove.** Removal is a separate call (`removePermission` by userId or by email; `transferOwnership` to hand a document to a new owner):
+
+```swift
+  // Remove a current member by userId:
+  try await client.documents.removePermission(
+    documentId: documentId, userId: "user-abc"
+  )
+
+  // Cancel a pending email-based invite, OR remove a current member
+  // matched by email:
+  try await client.documents.removePermission(
+    documentId: documentId, email: "alice@example.com"
+  )
+
+  // Hand the document to a new owner:
+  try await client.documents.transferOwnership(
+    documentId: documentId, newOwnerId: newOwnerId
+  )
+```
 
 
 Lowering a user's direct permission while they still have a higher one via a group is a no-op — the group wins (effective = MAX). To actually lower it, also lower or revoke the group permission.
@@ -866,6 +999,19 @@ The method is **`grantGroupPermission`** (no `setGroupPermission`). Member chang
 
 `client.users.lookup(email)` reports whether an email maps to an existing app user — use it to decide whether to share by `userId` (definitive) or `email` (will defer if no app user yet). The argument is a plain string, not `{ email }`.
 
+```swift
+  // One user's basic profile
+  let user = try await client.users.getBasic(userId: userId)
+
+  // Batch-fetch several profiles in one round-trip
+  let profiles = try await client.users.getProfiles(userIds: [userId, "user-456"])
+
+  // Find a user by email
+  let found = try await client.users.lookup(email: "alice@example.com")
+
+  // The current signed-in user
+  let me = try await client.me.get()
+```
 
 #### Redeeming a deferred grant
 
@@ -972,8 +1118,29 @@ A collection's members + pending invites in one call:
 Additional collection calls:
 
 
-Collections accept email-based members exactly like documents and groups — a deferred grant that resolves on signup:
+Collections accept email-based members exactly like documents and groups — a deferred grant that resolves on signup. Inspect the result's `status` (`"added"` / `"already_member"` / `"pending_signup"`); group shares, members + pending reads, and removals are in [Collections](#collections) above:
 
+```swift
+  // Add an individual member by userId
+  _ = try await client.collections.addMember(
+    collectionId: collectionId,
+    params: .user("user-abc", permission: .readWrite)
+  )
+
+  // Or by email — deferred grant resolves on signup
+  let result = try await client.collections.addMember(
+    collectionId: collectionId,
+    params: .email(
+      "newhire@example.com",
+      permission: .reader,
+      sendEmail: true, // optional: platform sends an invite email
+      collectionUrl: "https://app.example.com/onboarding", // required when sendEmail is true
+      note: "Sharing the onboarding docs"
+    )
+  )
+  // result is .direct (added / already_member) or .deferred —
+  // the deferred case carries invitationId / inviteToken / expiresAt.
+```
 
 The deferred-grant flow on `collections.addMember({ email })` mirrors the document share path: `app.baseUrl` must be configured, `sendEmail: true` requires `collectionUrl`, and `client.invitations.delete(invitationId)` cancels every pending collection add (plus any pending document shares and group adds) attached to the invitation. See the [Invitations guide](AGENT_GUIDE_TO_PRIMITIVE_INVITATIONS.md#deferred-grants) for the resolution lifecycle.
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.template.md
@@ -120,17 +120,13 @@ Each shared document in the result extends the base `DocumentInfo` (`title`, `cr
 
 {{#lang ts}}
 `ownedDocuments` and `sharedDocuments` return the unified `{ items, cursor }` envelope (raw-JSON `cursor`, NOT base64url). `ownedDocuments()` returns a flat `DocumentInfo[]` by default, or the envelope with `returnPage: true`.
+{{/lang}}
 
-For an "everything I can access" surface, combine these two calls with group and collection memberships:
+For an "everything I can access" surface, combine the owned + shared calls with group and collection memberships:
 
-```typescript
-const owned  = await jsBaoClient.me.ownedDocuments();
-const shared = (await jsBaoClient.me.sharedDocuments()).items;
-const collections = await jsBaoClient.collections.list();
-// then iterate collections / groups.listUserMemberships and call
-// collections.listDocuments / groups.listDocuments.
-```
+{{ example: documents/list-accessible }}
 
+{{#lang ts}}
 `jsBaoClient.documents.hasLocalCopy(documentId)` is the synchronous local-cache check, useful when deciding whether to render skeletons before `open()` resolves.
 
 #### Do not use
@@ -234,18 +230,9 @@ List with `me.ownedDocuments()` and `open()` the selected document; create a new
 
 All documents that need live updates or cross-document queries must be open. Tag documents so you can fetch a set with `me.ownedDocuments({ tag })` (and `me.sharedDocuments({ tag })` if the user can also be a non-owner), open each, and track per-document readiness yourself. For collective sharing of multiple documents as a unit, prefer the server-side Collections API (`client.collections.*` — see [Collections](#collections) below) over local tracking.
 
+{{ example: documents/open-tagged }}
+
 {{#lang ts}}
-```typescript
-// Open every document with a given tag
-const channels = await jsBaoClient.me.ownedDocuments({ tag: "channel" });
-await Promise.all(
-  channels.map((ch) => jsBaoClient.documents.open(ch.documentId))
-);
-
-// Query runs across all open documents by default
-const messages = await Message.query({});
-```
-
 The template does not ship a built-in "multi-document" Pinia store. A minimal store for "all documents tagged `channel`":
 
 ```typescript
@@ -410,18 +397,7 @@ Use tags to categorize documents by type. Pass `tags` to `create()`, filter the 
 
 You can also create a tagged document and filter locally:
 
-{{#lang ts}}
-```typescript
-const { metadata } = await jsBaoClient.documents.create({
-  title: "My List",
-  tags: ["todolist"],
-});
-
-// Filter locally
-const owned = await jsBaoClient.me.ownedDocuments();
-const todoListsLocal = owned.filter((doc) => doc.tags?.includes("todolist"));
-```
-{{/lang}}
+{{ example: documents/tag-filter-local }}
 
 ## Defining Models
 
@@ -657,41 +633,15 @@ fields = ["name", "parentId"]
 unique_constraints = [["name", "parentId"]]
 ```
 
-{{#lang ts}}
 ### Working with StringSets
 
-```typescript
-// Add/remove tags
-task.tags.add("urgent");
-task.tags.remove("low-priority");
-
-// Check membership
-if (task.tags.has("urgent")) { ... }
-
-// Convert to array for display
-const tagList = task.tags.toArray();
-```
+{{ example: documents/stringset-ops }}
 
 ### Working with Dates
 
-Dates are stored as ISO-8601 strings. Convert for comparisons:
+Dates are stored as ISO-8601 strings — lexicographic order matches chronological order, so string comparison works in queries:
 
-```typescript
-// Store
-task.dueDate = new Date().toISOString();
-
-// Compare
-const due = new Date(task.dueDate);
-if (due < new Date()) {
-  console.log("Overdue!");
-}
-
-// Query with date comparison
-const result = await Task.query({
-  dueDate: { $lt: new Date().toISOString() },
-});
-```
-{{/lang}}
+{{ example: documents/date-handling }}
 
 ## Querying Data
 
@@ -740,15 +690,13 @@ items.map(...);  // TypeError: items.map is not a function
 | `$all`          | StringSet contains all values  | `{ tags: { $all: ["work", "urgent"] } }`             |
 | `$size`         | StringSet size comparison      | `{ tags: { $size: { $gte: 2 } } }`                   |
 
+{{/lang}}
+
 **Logical operators** — see [Logical query operators](#logical-query-operators) above for the compiled `$or` example. Plain field maps AND together:
 
-```typescript
-const result = await Task.query({
-  completed: false,
-  priority: { $gte: 3 },
-  tags: { $in: ["work", "urgent"] },
-});
-```
+{{ example: documents/query-and }}
+
+{{#lang ts}}
 
 ### Pagination
 
@@ -848,17 +796,16 @@ Group and calculate statistics — see [Aggregation](#aggregation) above for the
 
 Multi-field `groupBy` produces deeper nesting (`result[group1][group2] = { ...ops }`). Operation result keys are `count`, `sum_<field>`, `avg_<field>`, `min_<field>`, `max_<field>`.
 
-**StringSet facet aggregation** — grouping by a `stringset` field counts per value. When the only operation is `count`, the value collapses to a number:
+{{/lang}}
 
-```typescript
-const tagCounts = await Task.aggregate({
-  groupBy: ["tags"],  // "tags" is a stringset field
-  operations: [{ type: "count" }],
-});
-// Returns: { "work": 15, "urgent": 8, "personal": 5, ... }
-```
+**StringSet facet aggregation** — grouping by a `stringset` field counts per value:
 
-Only one stringset facet field is allowed per aggregation. To check membership of a specific value across records, use a `StringSetMembership` groupBy entry: `{ field: "tags", contains: "urgent" }`.
+{{ example: documents/aggregate-facet }}
+
+Only one stringset facet field is allowed per aggregation.
+
+{{#lang ts}}
+When the only operation is `count`, the value collapses to a number. To check membership of a specific value across records, use a `StringSetMembership` groupBy entry: `{ field: "tags", contains: "urgent" }`.
 
 ### useJsBaoDataLoader Pattern
 
@@ -1285,46 +1232,13 @@ Documents can be shared with individual users (by userId or email), with groups,
 
 ### Quick Reference
 
-The core share calls — by userId, by email, and with a group — are in [Share a document (user / email / group)](#share-a-document-user--email--group) above. The full surface adds batch grants, deferred email shares, and access requests:
+The core share calls — by userId, by email, and with a group — are in [Share a document (user / email / group)](#share-a-document-user--email--group) above. The full surface adds batch grants and deferred email shares (for responding to a 403 with the `canRequestAccess` hint, see [Document Access Requests](#document-access-requests) below):
+
+{{ example: sharing/share-batch }}
+
+{{ example: sharing/share-email-deferred }}
 
 {{#lang ts}}
-```typescript
-// Batch — multiple users at once
-await client.documents.updatePermissions(documentId, {
-  permissions: [
-    { userId: "user-abc", permission: "read-write" },
-    { userId: "user-xyz", permission: "reader" },
-  ],
-});
-
-// By email with notification — resolves if the user exists, otherwise creates a
-// deferred grant that auto-applies when the recipient signs up. With
-// `sendEmail: true`, `documentUrl` is required AND the app must have `baseUrl`
-// configured (used to compose the accept URL for the deferred-share email).
-// Both preconditions return HTTP 400 if missing.
-await client.documents.updatePermissions(documentId, {
-  email: "alice@example.com",
-  permission: "read-write",
-  sendEmail: true,
-  documentUrl: `${window.location.origin}/lists`,
-});
-// Returns either a DirectPermissionGrant (existing user) or a
-// DeferredPermissionGrant ({ invitationId, inviteToken, ... }) that the
-// recipient redeems via client.invitations.accept(inviteToken) after signup.
-
-// Respond to a 403 with canRequestAccess hint. `permission` is REQUIRED.
-try {
-  await client.documents.open(documentId);
-} catch (err) {
-  if (err.details?.canRequestAccess) {
-    await client.documents.requestAccess(documentId, {
-      permission: "read-write",
-      message: "Please grant me access",
-    });
-  }
-}
-```
-
 **Wrong** — these names look reasonable but do not exist on the API:
 
 ```typescript
@@ -1428,28 +1342,7 @@ Beyond the Quick Reference and the `PrimitiveShareDocumentDialog` UI, the full p
 
 #### Direct shares: `updatePermissions`
 
-The method is **`updatePermissions`** (no `setPermissions`). Two forms — single user (by id or email) and batch (any mix of userId and email):
-
-{{#lang ts}}
-```typescript
-// Single user (by id or email)
-await client.documents.updatePermissions(documentId, {
-  email: "alice@example.com",
-  permission: "read-write",
-});
-
-// Batch (any mix of userId and email)
-await client.documents.updatePermissions(documentId, {
-  permissions: [
-    { userId: "user-abc", permission: "read-write" },
-    { email: "alice@example.com", permission: "reader" },
-    { email: "bob@example.com",   permission: "read-write" },
-  ],
-});
-```
-{{/lang}}
-
-Optional fields on either form: `sendEmail`, `documentUrl`, `note`.
+The method is **`updatePermissions`** (no `setPermissions`). Two forms — single user (by id or email; see [Share a document (user / email / group)](#share-a-document-user--email--group)) and batch (any mix of userId and email; see the [Quick Reference](#quick-reference)). Optional fields on either form: `sendEmail`, `documentUrl`, `note`.
 
 When `sendEmail: true`, the server delivers per-recipient emails:
 
@@ -1462,18 +1355,9 @@ Repeated email-based calls are idempotent: a second `updatePermissions(documentI
 
 **There is no `permission: null` to remove.** Removal is a separate call (`removePermission` by userId or by email; `transferOwnership` to hand a document to a new owner):
 
+{{ example: sharing/remove-permission }}
+
 {{#lang ts}}
-```typescript
-// Remove a current member by userId:
-await client.documents.removePermission(documentId, "user-abc");
-await client.documents.removePermission(documentId, { userId: "user-abc" });
-
-// Cancel a pending email-based invite, OR remove a current member matched by email:
-await client.documents.removePermission(documentId, { email: "alice@example.com" });
-
-await client.documents.transferOwnership(documentId, newOwnerId);
-```
-
 **Don't do this** (silent no-op for someone with a higher group permission, and there is no `null` form):
 
 ```typescript
@@ -1540,13 +1424,7 @@ await client.documents.revokeGroupPermission(documentId, "team", "engineering");
 
 `client.users.lookup(email)` reports whether an email maps to an existing app user — use it to decide whether to share by `userId` (definitive) or `email` (will defer if no app user yet). The argument is a plain string, not `{ email }`.
 
-{{#lang ts}}
-```typescript
-const result = await client.users.lookup("alice@example.com");
-// { exists: true, user: { userId, name, email } }
-// or { exists: false }
-```
-{{/lang}}
+{{ example: users-and-groups/users-lookup }}
 
 #### Redeeming a deferred grant
 
@@ -1689,44 +1567,9 @@ await client.collections.removeMember(collection.collectionId, targetUserId);
 ```
 {{/lang}}
 
-Collections accept email-based members exactly like documents and groups — a deferred grant that resolves on signup:
+Collections accept email-based members exactly like documents and groups — a deferred grant that resolves on signup. Inspect the result's `status` (`"added"` / `"already_member"` / `"pending_signup"`); group shares, members + pending reads, and removals are in [Collections](#collections) above:
 
-{{#lang ts}}
-```typescript
-// Add an individual member by userId
-await client.collections.addMember(collectionId, {
-  userId: "user-abc",
-  permission: "read-write",              // "reader" or "read-write"
-});
-
-// Or by email — deferred grant resolves on signup, mirroring documents/groups
-const result = await client.collections.addMember(collectionId, {
-  email: "newhire@example.com",
-  permission: "reader",
-  sendEmail: true,                       // optional: platform sends an invite email
-  collectionUrl: "https://...",          // required when sendEmail is true
-  note: "Sharing the onboarding docs",
-});
-// result.status: "added" | "already_member" | "pending_signup"
-// Pending case carries { invitationId, inviteToken, expiresAt }.
-
-// Share with a group (fans out to every document in the collection)
-await client.collections.grantGroupPermission(collectionId, {
-  groupType: "team",
-  groupId: "engineering",
-  permission: "reader",
-});
-
-// Inspect / undo
-const access = await client.collections.getAccess(collectionId);
-// → { members: [...], groups: [...] }
-const pending = await client.collections.listPendingInvitations(collectionId);
-// → [{ email, permission, invitationId, expiresAt, ... }]
-await client.collections.removeMember(collectionId, "user-abc");
-await client.collections.revokeGroupPermission(collectionId, "team", "engineering");
-// Change a user's permission: call addMember again with the new level.
-```
-{{/lang}}
+{{ example: sharing/collection-member-email }}
 
 The deferred-grant flow on `collections.addMember({ email })` mirrors the document share path: `app.baseUrl` must be configured, `sendEmail: true` requires `collectionUrl`, and `client.invitations.delete(invitationId)` cancels every pending collection add (plus any pending document shares and group adds) attached to the invitation. See the [Invitations guide](AGENT_GUIDE_TO_PRIMITIVE_INVITATIONS.md#deferred-grants) for the resolution lifecycle.
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.ts.md
@@ -145,14 +145,14 @@ Each shared document in the result extends the base `DocumentInfo` (`title`, `cr
 
 `ownedDocuments` and `sharedDocuments` return the unified `{ items, cursor }` envelope (raw-JSON `cursor`, NOT base64url). `ownedDocuments()` returns a flat `DocumentInfo[]` by default, or the envelope with `returnPage: true`.
 
-For an "everything I can access" surface, combine these two calls with group and collection memberships:
+For an "everything I can access" surface, combine the owned + shared calls with group and collection memberships:
 
 ```typescript
-const owned  = await jsBaoClient.me.ownedDocuments();
-const shared = (await jsBaoClient.me.sharedDocuments()).items;
-const collections = await jsBaoClient.collections.list();
-// then iterate collections / groups.listUserMemberships and call
-// collections.listDocuments / groups.listDocuments.
+  const owned = await client.me.ownedDocuments();
+  const shared = (await client.me.sharedDocuments()).items;
+  const collections = await client.collections.list();
+  // then iterate collections / groups.listUserMemberships and call
+  // collections.listDocuments / groups.listDocuments.
 ```
 
 `jsBaoClient.documents.hasLocalCopy(documentId)` is the synchronous local-cache check, useful when deciding whether to render skeletons before `open()` resolves.
@@ -362,14 +362,14 @@ List with `me.ownedDocuments()` and `open()` the selected document; create a new
 All documents that need live updates or cross-document queries must be open. Tag documents so you can fetch a set with `me.ownedDocuments({ tag })` (and `me.sharedDocuments({ tag })` if the user can also be a non-owner), open each, and track per-document readiness yourself. For collective sharing of multiple documents as a unit, prefer the server-side Collections API (`client.collections.*` — see [Collections](#collections) below) over local tracking.
 
 ```typescript
-// Open every document with a given tag
-const channels = await jsBaoClient.me.ownedDocuments({ tag: "channel" });
-await Promise.all(
-  channels.map((ch) => jsBaoClient.documents.open(ch.documentId))
-);
+  // Open every document with a given tag
+  const channels = await client.me.ownedDocuments({ tag: "channel" });
+  await Promise.all(
+    channels.map((ch) => client.documents.open(ch.documentId))
+  );
 
-// Query runs across all open documents by default
-const messages = await Message.query({});
+  // Queries run across all open documents by default
+  const messages = await Message.query({});
 ```
 
 The template does not ship a built-in "multi-document" Pinia store. A minimal store for "all documents tagged `channel`":
@@ -461,14 +461,14 @@ Use tags to categorize documents by type. Pass `tags` to `create()`, filter the 
 You can also create a tagged document and filter locally:
 
 ```typescript
-const { metadata } = await jsBaoClient.documents.create({
-  title: "My List",
-  tags: ["todolist"],
-});
+  const { metadata } = await client.documents.create({
+    title: "My List",
+    tags: ["todolist"],
+  });
 
-// Filter locally
-const owned = await jsBaoClient.me.ownedDocuments();
-const todoListsLocal = owned.filter((doc) => doc.tags?.includes("todolist"));
+  // Filter locally
+  const owned = await client.me.ownedDocuments();
+  const todoLists = owned.filter((doc) => doc.tags?.includes("todolist"));
 ```
 
 ## Defining Models
@@ -631,35 +631,37 @@ unique_constraints = [["name", "parentId"]]
 ### Working with StringSets
 
 ```typescript
-// Add/remove tags
-task.tags.add("urgent");
-task.tags.remove("low-priority");
+  // Add/remove tags
+  task.tags?.add("urgent");
+  task.tags?.remove("low-priority");
 
-// Check membership
-if (task.tags.has("urgent")) { ... }
+  // Check membership
+  if (task.tags?.has("urgent")) {
+    // ...
+  }
 
-// Convert to array for display
-const tagList = task.tags.toArray();
+  // Convert to array for display
+  const tagList = task.tags?.toArray() ?? [];
 ```
 
 ### Working with Dates
 
-Dates are stored as ISO-8601 strings. Convert for comparisons:
+Dates are stored as ISO-8601 strings — lexicographic order matches chronological order, so string comparison works in queries:
 
 ```typescript
-// Store
-task.dueDate = new Date().toISOString();
+  // Store
+  task.dueDate = new Date().toISOString();
 
-// Compare
-const due = new Date(task.dueDate);
-if (due < new Date()) {
-  console.log("Overdue!");
-}
+  // Compare
+  const due = new Date(task.dueDate);
+  if (due < new Date()) {
+    // overdue
+  }
 
-// Query with date comparison
-const result = await Task.query({
-  dueDate: { $lt: new Date().toISOString() },
-});
+  // Query with date comparison
+  const overdue = await Task.query({
+    dueDate: { $lt: new Date().toISOString() },
+  });
 ```
 
 ## Querying Data
@@ -708,15 +710,17 @@ items.map(...);  // TypeError: items.map is not a function
 | `$all`          | StringSet contains all values  | `{ tags: { $all: ["work", "urgent"] } }`             |
 | `$size`         | StringSet size comparison      | `{ tags: { $size: { $gte: 2 } } }`                   |
 
+
 **Logical operators** — see [Logical query operators](#logical-query-operators) above for the compiled `$or` example. Plain field maps AND together:
 
 ```typescript
-const result = await Task.query({
-  completed: false,
-  priority: { $gte: 3 },
-  tags: { $in: ["work", "urgent"] },
-});
+  const result = await Task.query({
+    completed: false,
+    priority: { $gte: 3 },
+    category: { $in: ["work", "urgent"] },
+  });
 ```
+
 
 ### Pagination
 
@@ -816,17 +820,20 @@ Group and calculate statistics — see [Aggregation](#aggregation) above for the
 
 Multi-field `groupBy` produces deeper nesting (`result[group1][group2] = { ...ops }`). Operation result keys are `count`, `sum_<field>`, `avg_<field>`, `min_<field>`, `max_<field>`.
 
-**StringSet facet aggregation** — grouping by a `stringset` field counts per value. When the only operation is `count`, the value collapses to a number:
+
+**StringSet facet aggregation** — grouping by a `stringset` field counts per value:
 
 ```typescript
-const tagCounts = await Task.aggregate({
-  groupBy: ["tags"],  // "tags" is a stringset field
-  operations: [{ type: "count" }],
-});
-// Returns: { "work": 15, "urgent": 8, "personal": 5, ... }
+  const tagCounts = await Task.aggregate({
+    groupBy: ["tags"], // "tags" is a stringset field
+    operations: [{ type: "count" }],
+  });
+  // Returns: { "work": 15, "urgent": 8, "personal": 5, ... }
 ```
 
-Only one stringset facet field is allowed per aggregation. To check membership of a specific value across records, use a `StringSetMembership` groupBy entry: `{ field: "tags", contains: "urgent" }`.
+Only one stringset facet field is allowed per aggregation.
+
+When the only operation is `count`, the value collapses to a number. To check membership of a specific value across records, use a `StringSetMembership` groupBy entry: `{ field: "tags", contains: "urgent" }`.
 
 ### useJsBaoDataLoader Pattern
 
@@ -1162,43 +1169,28 @@ Documents can be shared with individual users (by userId or email), with groups,
 
 ### Quick Reference
 
-The core share calls — by userId, by email, and with a group — are in [Share a document (user / email / group)](#share-a-document-user--email--group) above. The full surface adds batch grants, deferred email shares, and access requests:
+The core share calls — by userId, by email, and with a group — are in [Share a document (user / email / group)](#share-a-document-user--email--group) above. The full surface adds batch grants and deferred email shares (for responding to a 403 with the `canRequestAccess` hint, see [Document Access Requests](#document-access-requests) below):
 
 ```typescript
-// Batch — multiple users at once
-await client.documents.updatePermissions(documentId, {
-  permissions: [
-    { userId: "user-abc", permission: "read-write" },
-    { userId: "user-xyz", permission: "reader" },
-  ],
-});
+  await client.documents.updatePermissions(documentId, {
+    permissions: [
+      { userId: "user-abc", permission: "read-write" },
+      { email: "alice@example.com", permission: "reader" },
+      { email: "bob@example.com", permission: "read-write" },
+    ],
+  });
+```
 
-// By email with notification — resolves if the user exists, otherwise creates a
-// deferred grant that auto-applies when the recipient signs up. With
-// `sendEmail: true`, `documentUrl` is required AND the app must have `baseUrl`
-// configured (used to compose the accept URL for the deferred-share email).
-// Both preconditions return HTTP 400 if missing.
-await client.documents.updatePermissions(documentId, {
-  email: "alice@example.com",
-  permission: "read-write",
-  sendEmail: true,
-  documentUrl: `${window.location.origin}/lists`,
-});
-// Returns either a DirectPermissionGrant (existing user) or a
-// DeferredPermissionGrant ({ invitationId, inviteToken, ... }) that the
-// recipient redeems via client.invitations.accept(inviteToken) after signup.
-
-// Respond to a 403 with canRequestAccess hint. `permission` is REQUIRED.
-try {
-  await client.documents.open(documentId);
-} catch (err) {
-  if (err.details?.canRequestAccess) {
-    await client.documents.requestAccess(documentId, {
-      permission: "read-write",
-      message: "Please grant me access",
-    });
-  }
-}
+```typescript
+  const result = await client.documents.updatePermissions(documentId, {
+    email: "alice@example.com",
+    permission: "read-write",
+    sendEmail: true,
+    documentUrl: "https://app.example.com/lists",
+  });
+  // Returns a direct grant (existing user) or a deferred grant
+  // ({ invitationId, inviteToken, ... }) that the recipient redeems via
+  // client.invitations.accept(inviteToken) after signup.
 ```
 
 **Wrong** — these names look reasonable but do not exist on the API:
@@ -1325,26 +1317,7 @@ Beyond the Quick Reference and the `PrimitiveShareDocumentDialog` UI, the full p
 
 #### Direct shares: `updatePermissions`
 
-The method is **`updatePermissions`** (no `setPermissions`). Two forms — single user (by id or email) and batch (any mix of userId and email):
-
-```typescript
-// Single user (by id or email)
-await client.documents.updatePermissions(documentId, {
-  email: "alice@example.com",
-  permission: "read-write",
-});
-
-// Batch (any mix of userId and email)
-await client.documents.updatePermissions(documentId, {
-  permissions: [
-    { userId: "user-abc", permission: "read-write" },
-    { email: "alice@example.com", permission: "reader" },
-    { email: "bob@example.com",   permission: "read-write" },
-  ],
-});
-```
-
-Optional fields on either form: `sendEmail`, `documentUrl`, `note`.
+The method is **`updatePermissions`** (no `setPermissions`). Two forms — single user (by id or email; see [Share a document (user / email / group)](#share-a-document-user--email--group)) and batch (any mix of userId and email; see the [Quick Reference](#quick-reference)). Optional fields on either form: `sendEmail`, `documentUrl`, `note`.
 
 When `sendEmail: true`, the server delivers per-recipient emails:
 
@@ -1358,14 +1331,17 @@ Repeated email-based calls are idempotent: a second `updatePermissions(documentI
 **There is no `permission: null` to remove.** Removal is a separate call (`removePermission` by userId or by email; `transferOwnership` to hand a document to a new owner):
 
 ```typescript
-// Remove a current member by userId:
-await client.documents.removePermission(documentId, "user-abc");
-await client.documents.removePermission(documentId, { userId: "user-abc" });
+  // Remove a current member by userId:
+  await client.documents.removePermission(documentId, "user-abc");
 
-// Cancel a pending email-based invite, OR remove a current member matched by email:
-await client.documents.removePermission(documentId, { email: "alice@example.com" });
+  // Cancel a pending email-based invite, OR remove a current member
+  // matched by email:
+  await client.documents.removePermission(documentId, {
+    email: "alice@example.com",
+  });
 
-await client.documents.transferOwnership(documentId, newOwnerId);
+  // Hand the document to a new owner:
+  await client.documents.transferOwnership(documentId, newOwnerId);
 ```
 
 **Don't do this** (silent no-op for someone with a higher group permission, and there is no `null` form):
@@ -1430,9 +1406,17 @@ await client.documents.revokeGroupPermission(documentId, "team", "engineering");
 `client.users.lookup(email)` reports whether an email maps to an existing app user — use it to decide whether to share by `userId` (definitive) or `email` (will defer if no app user yet). The argument is a plain string, not `{ email }`.
 
 ```typescript
-const result = await client.users.lookup("alice@example.com");
-// { exists: true, user: { userId, name, email } }
-// or { exists: false }
+  // One user's basic profile
+  const user = await client.users.getBasic(userId);
+
+  // Batch-fetch several profiles in one round-trip
+  const profiles = await client.users.getProfiles([userId, "user-456"]);
+
+  // Find a user by email
+  const found = await client.users.lookup("alice@example.com");
+
+  // The current signed-in user
+  const me = await client.me.get();
 ```
 
 #### Redeeming a deferred grant
@@ -1603,41 +1587,25 @@ await client.collections.removeMember(collection.collectionId, targetUserId);
 // Change a user's permission: call addMember again with the new level.
 ```
 
-Collections accept email-based members exactly like documents and groups — a deferred grant that resolves on signup:
+Collections accept email-based members exactly like documents and groups — a deferred grant that resolves on signup. Inspect the result's `status` (`"added"` / `"already_member"` / `"pending_signup"`); group shares, members + pending reads, and removals are in [Collections](#collections) above:
 
 ```typescript
-// Add an individual member by userId
-await client.collections.addMember(collectionId, {
-  userId: "user-abc",
-  permission: "read-write",              // "reader" or "read-write"
-});
+  // Add an individual member by userId
+  await client.collections.addMember(collectionId, {
+    userId: "user-abc",
+    permission: "read-write", // "reader" or "read-write"
+  });
 
-// Or by email — deferred grant resolves on signup, mirroring documents/groups
-const result = await client.collections.addMember(collectionId, {
-  email: "newhire@example.com",
-  permission: "reader",
-  sendEmail: true,                       // optional: platform sends an invite email
-  collectionUrl: "https://...",          // required when sendEmail is true
-  note: "Sharing the onboarding docs",
-});
-// result.status: "added" | "already_member" | "pending_signup"
-// Pending case carries { invitationId, inviteToken, expiresAt }.
-
-// Share with a group (fans out to every document in the collection)
-await client.collections.grantGroupPermission(collectionId, {
-  groupType: "team",
-  groupId: "engineering",
-  permission: "reader",
-});
-
-// Inspect / undo
-const access = await client.collections.getAccess(collectionId);
-// → { members: [...], groups: [...] }
-const pending = await client.collections.listPendingInvitations(collectionId);
-// → [{ email, permission, invitationId, expiresAt, ... }]
-await client.collections.removeMember(collectionId, "user-abc");
-await client.collections.revokeGroupPermission(collectionId, "team", "engineering");
-// Change a user's permission: call addMember again with the new level.
+  // Or by email — deferred grant resolves on signup
+  const result = await client.collections.addMember(collectionId, {
+    email: "newhire@example.com",
+    permission: "reader",
+    sendEmail: true, // optional: platform sends an invite email
+    collectionUrl: "https://app.example.com/onboarding", // required when sendEmail is true
+    note: "Sharing the onboarding docs",
+  });
+  // result.status: "added" | "already_member" | "pending_signup"
+  // Pending case carries { invitationId, inviteToken, expiresAt }.
 ```
 
 The deferred-grant flow on `collections.addMember({ email })` mirrors the document share path: `app.baseUrl` must be configured, `sendEmail: true` requires `collectionUrl`, and `client.invitations.delete(invitationId)` cancels every pending collection add (plus any pending document shares and group adds) attached to the invitation. See the [Invitations guide](AGENT_GUIDE_TO_PRIMITIVE_INVITATIONS.md#deferred-grants) for the resolution lifecycle.


### PR DESCRIPTION
First DOCUMENTS chunk of #87 (does not close it — 42 fences remain across this and other templates).

**Promoted to new compile-gated corpus pairs** (each verified against the JS and Swift client source before writing; all compile against both clients):
- `documents/list-accessible` — owned + shared + collections combined view
- `documents/open-tagged` — open every doc with a tag, cross-document query
- `documents/tag-filter-local` — create tagged document, filter locally
- `documents/stringset-ops` — stringset add/remove/membership (JS `StringSet` methods ↔ Swift native `Set<String>` + save)
- `documents/date-handling` — ISO-8601 storage, comparison, `$lt` query
- `documents/query-and` — implicit AND field maps
- `documents/aggregate-facet` — stringset facet counting
- `sharing/remove-permission` — removePermission by userId/email + transferOwnership
- `sharing/collection-member-email` — collection addMember incl. deferred email grants
- `sharing/share-email-deferred` — email share with sendEmail/documentUrl preconditions

**Deduplicated** two fences into existing corpus examples: `sharing/share-batch`, `users-and-groups/users-lookup`.

**Template restructuring:** `{{#lang ts}}` blocks split so placeholders sit in neutral prose — the Swift build gains every promoted section (each API confirmed present in the Swift client: `me.ownedDocuments/sharedDocuments`, `users.lookup`, `removePermission`/`transferOwnership`, `AddCollectionMemberParams.email`, `UpdatePermissionsData.email`, stringset-aware `aggregate`).

**Fact fix found by the migration:** the old AND-query fence used `$in` on a stringset field; stringsets take `$contains`/`$all`, so the corpus example uses a scalar field.

**Deliberately not promoted** (per the issue's judgment clause): DON'T/wrong-code teaching fragments, output-shape comments, ts-only capabilities (relationship includes, `upsertByUnique` — absent from the Swift generated statics, adjacent to js-bao-wss#1053), and the framework-glue sections (Pinia/`PrimitiveAppState`/dataloader) which need a dedicated restructuring chunk.

**Parity bug filed:** Primitive-Labs/js-bao-wss#1070 — JS client lacks the derived `documentDeleted` event; that section stays Swift-scoped.

**Validation:** `pnpm check:examples` ✓ (TS + Swift example compilation, parity, render, CLI, stamp), `npx vitepress build docs` ✓, docs-page-review PASS (lang-block balance, both rendered builds coherent, anchors resolve, no content lost).

Part of #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)