### PR TITLE
docs(swift): true up Swift client examples to the current client

### DIFF
--- a/docs/getting-started/working-with-documents.md
+++ b/docs/getting-started/working-with-documents.md
@@ -454,8 +454,10 @@ final class MyAppState: PrimitiveAppState {
     await super.connectClient()
     guard let client else { return }
     let result = try? await client.documents.getOrCreateWithAlias(
-      alias: DocumentAlias(scope: .user, aliasKey: "library"),
-      title: "Library"
+      options: GetOrCreateWithAliasOptions(
+        alias: AliasRef(scope: .user, aliasKey: "library"),
+        title: "Library"
+      )
     )
     guard let id = result?.documentId else { return }
     await selectDocumentAwaiting(id)

--- a/examples/databases/db-subscribe-params.swift
+++ b/examples/databases/db-subscribe-params.swift
@@ -6,9 +6,9 @@ func watchTeamTickets(
   client: JsBaoClient,
   databaseId: String,
   handleChange: @escaping (DatabaseChangeEvent) -> Void
-) -> () -> Void {
+) throws -> () -> Void {
   // #region example
-  let unsub = client.databases.subscribe(
+  let unsub = try client.databases.subscribe(
     databaseId: databaseId,
     subscriptionKey: "tickets-by-team",
     options: DatabaseSubscribeOptions(

--- a/examples/databases/db-subscribe.swift
+++ b/examples/databases/db-subscribe.swift
@@ -8,9 +8,9 @@ func watchOpenTickets(
   databaseId: String,
   removeTicket: @escaping (String) -> Void,
   upsertTicket: @escaping (Any?) -> Void
-) {
+) throws {
   // #region example
-  let unsub = client.databases.subscribe(
+  let unsub = try client.databases.subscribe(
     databaseId: databaseId,
     subscriptionKey: "my-open-tickets",
     options: DatabaseSubscribeOptions(onChange: { event in

--- a/examples/documents/close-document.swift
+++ b/examples/documents/close-document.swift
@@ -3,9 +3,10 @@ import JsBaoClient
 // Close a document to stop syncing it. Pass `evictLocal: true` via
 // CloseDocumentOptions to also drop the local cached copy.
 //
-// Note: Swift's `close` returns Void (it does not surface the `{ evicted }`
-// flag the JS client returns). Use `hasLocalCopy(documentId:)` afterward if you
-// need to confirm whether the local copy is still present.
+// `close` returns a `CloseDocumentResult` whose `evicted` flag reports whether
+// the local copy was actually dropped (it's skipped when local writes were
+// still outstanding). The result is `@discardableResult`, so you can ignore it
+// when you don't need to confirm eviction.
 func closeDocument(client: JsBaoClient, documentId: String) async {
   // #region example
   // Close and stop syncing

--- a/examples/sharing/share-remove.swift
+++ b/examples/sharing/share-remove.swift
@@ -7,7 +7,7 @@ func removeShare(
   userId: String
 ) async throws {
   // #region example
-  _ = try await client.documents.removePermission(documentId: documentId, userId: userId)
-  _ = try await client.documents.removePermission(documentId: documentId, email: "alice@example.com")
+  _ = try await client.documents.removePermission(documentId: documentId, .userId(userId))
+  _ = try await client.documents.removePermission(documentId: documentId, .email("alice@example.com"))
   // #endregion example
 }

--- a/examples/users-and-groups/me-profile.swift
+++ b/examples/users-and-groups/me-profile.swift
@@ -23,7 +23,7 @@ func manageMyProfile(client: JsBaoClient, avatar: Data) async throws {
   )
 
   // Upload an image directly; the server hosts it and returns a URL.
-  let uploaded = try await client.me.uploadAvatar(imageData: avatar, contentType: "image/png")
+  let uploaded = try await client.me.uploadAvatar(imageData: avatar, contentType: .png)
   let avatarUrl = uploaded.avatarUrl
 
   // update() and uploadAvatar() clear the cache automatically; reach for

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.swift.md
@@ -355,8 +355,10 @@ final class MyAppState: PrimitiveAppState {
             // createWithAlias — that has a TOCTOU window where two clients
             // onboarding at once both create and one doc is lost.
             let result = try await client.documents.getOrCreateWithAlias(
-                alias: DocumentAlias(scope: .user, aliasKey: "library"),
-                title: "Library"
+                options: GetOrCreateWithAliasOptions(
+                    alias: AliasRef(scope: .user, aliasKey: "library"),
+                    title: "Library"
+                )
             )
             // selectDocumentAwaiting opens the doc, routes the base class's
             // sync hooks at it, and fires onDocumentOpened below.

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.template.md
@@ -330,8 +330,10 @@ final class MyAppState: PrimitiveAppState {
             // createWithAlias — that has a TOCTOU window where two clients
             // onboarding at once both create and one doc is lost.
             let result = try await client.documents.getOrCreateWithAlias(
-                alias: DocumentAlias(scope: .user, aliasKey: "library"),
-                title: "Library"
+                options: GetOrCreateWithAliasOptions(
+                    alias: AliasRef(scope: .user, aliasKey: "library"),
+                    title: "Library"
+                )
             )
             // selectDocumentAwaiting opens the doc, routes the base class's
             // sync hooks at it, and fires onDocumentOpened below.

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_INVITATIONS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_INVITATIONS.swift.md
@@ -126,29 +126,30 @@ Admins/owners can invite at any role; members can invite only at `role: "member"
 
 ```swift
 // Admins/owners: any role
-_ = try await client.invitations.create(params: [
-  "email": "alice@example.com",
-  "role": "member",  // or "admin" / "owner" (admin/owner only)
-])
+_ = try await client.invitations.create(
+  params: CreateInvitationParams(email: "alice@example.com", role: "member")  // or "admin" / "owner" (admin/owner only)
+)
 
 // Full options
-_ = try await client.invitations.create(params: [
-  "email": "alice@example.com",
-  "role": "member",
-  "expiresAt": ISO8601DateFormatter().string(from: Date().addingTimeInterval(7 * 86400)),
-  "source": "team-onboarding-flow",
-  "note": "Backend hire — Q2 cohort",
-  "sendEmail": true,
-])
+_ = try await client.invitations.create(
+  params: CreateInvitationParams(
+    email: "alice@example.com",
+    role: "member",
+    expiresAt: ISO8601DateFormatter().string(from: Date().addingTimeInterval(7 * 86400)),
+    source: "team-onboarding-flow",
+    note: "Backend hire — Q2 cohort",
+    sendEmail: true
+  )
+)
 
 // Members: gate on quota first
 let quota = try await client.invitations.quota()
-let unlimited = quota["unlimited"] as? Bool ?? false
-let remaining = quota["remaining"] as? Int ?? 0
-if !unlimited && remaining <= 0 {
+if !quota.unlimited && quota.remaining <= 0 {
   return showQuotaExhausted()
 }
-_ = try await client.invitations.create(params: ["email": email, "role": "member"])
+_ = try await client.invitations.create(
+  params: CreateInvitationParams(email: email, role: "member")
+)
 ```
 
 ### Member invitations + quotas
@@ -197,10 +198,9 @@ For resend / lookup after the initial response is gone, fetch the invitation by 
 
 ```swift
 let inv = try await client.invitations.get(invitationId: invitationId)
-let inviteToken = inv["inviteToken"] as? String ?? ""
-let email = inv["email"] as? String ?? ""
+let inviteToken = inv.inviteToken ?? ""
 let acceptUrl = "\(myApp.baseURL)/invite/accept?inviteToken=\(inviteToken)"
-try await myEmailService.send(to: email, link: acceptUrl)
+try await myEmailService.send(to: inv.email, link: acceptUrl)
 ```
 
 Permissions for `invitations.get`: app admin/owner, OR the invitation's original inviter. Members who did not create the invitation receive 403 — `inviteToken` is a bearer credential, so read access is intentionally narrow.
@@ -250,9 +250,11 @@ Deferred grants are re-validated at resolution time. In a `domain`-restricted ap
 ### Inspecting pending state (debug only)
 
 ```swift
-let (grants, nextCursor) = try await client.invitations.listDeferredGrants(
+let result = try await client.invitations.listDeferredGrants(
   email: "alice@example.com"
 )
+let grants = result.grants        // [DeferredGrant]
+let nextCursor = result.nextCursor
 ```
 
 Reserve this for admin/debug UIs. For end-user "people with access + pending invitations" UI, use the per-resource `listPendingInvitations` endpoints on documents/groups/collections (see the [Documents guide](AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.md#building-a-members--pending-ui)).
@@ -268,21 +270,21 @@ Check quota, mint the app invitation, share the project document by email, and a
 ```swift
 func onboardTeammate(email: String, projectDocId: String) async throws {
   let quota = try await client.invitations.quota()
-  let unlimited = quota["unlimited"] as? Bool ?? false
-  let remaining = quota["remaining"] as? Int ?? 0
-  if !unlimited && remaining <= 0 {
+  if !quota.unlimited && quota.remaining <= 0 {
     throw OnboardingError.quotaExhausted
   }
 
-  _ = try await client.invitations.create(params: ["email": email, "role": "member"])
+  _ = try await client.invitations.create(
+    params: CreateInvitationParams(email: email, role: "member")
+  )
 
   _ = try await client.documents.updatePermissions(
     documentId: projectDocId,
-    params: ["permissions": [["email": email, "permission": "read-write"]]]
+    params: .email(email, permission: "read-write")
   )
 
   _ = try await client.groups.addMember(
-    groupType: "team", groupId: "engineering", params: ["email": email]
+    groupType: "team", groupId: "engineering", params: .email(email)
   )
 }
 ```
@@ -294,13 +296,15 @@ func onboardTeammate(email: String, projectDocId: String) async throws {
 The `invitation` event is the only typed app-membership event. The lifecycle action is on `event.action` (not `event.type`, which is always `"invitation"`). Branch on `action`: `created`/`updated`/`cancelled` go to the invitee only; `declined` to both; `accepted` to the inviter only (with `event.acceptedBy` carrying the userId). Treat unknown actions as a no-op.
 
 ```swift
-client.events.on(.invitation) { event in
-  switch event.action {
+client.events.onAny(.invitation) { payload in
+  guard let event = payload as? [String: Any],
+        let action = event["action"] as? String else { return }
+  switch action {
   case "created":   break  // invitee only
   case "updated":   break  // invitee only
   case "cancelled": break  // invitee only
   case "declined":  break  // both invitee and inviter
-  case "accepted":  break  // inviter only — event.acceptedBy carries the userId
+  case "accepted":  break  // inviter only — event["acceptedBy"] carries the userId
   default:          break  // future-proof: no-op, don't throw
   }
 }

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_INVITATIONS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_INVITATIONS.template.md
@@ -153,29 +153,30 @@ await client.invitations.create({ email, role: "member" });
 {{#lang swift}}
 ```swift
 // Admins/owners: any role
-_ = try await client.invitations.create(params: [
-  "email": "alice@example.com",
-  "role": "member",  // or "admin" / "owner" (admin/owner only)
-])
+_ = try await client.invitations.create(
+  params: CreateInvitationParams(email: "alice@example.com", role: "member")  // or "admin" / "owner" (admin/owner only)
+)
 
 // Full options
-_ = try await client.invitations.create(params: [
-  "email": "alice@example.com",
-  "role": "member",
-  "expiresAt": ISO8601DateFormatter().string(from: Date().addingTimeInterval(7 * 86400)),
-  "source": "team-onboarding-flow",
-  "note": "Backend hire — Q2 cohort",
-  "sendEmail": true,
-])
+_ = try await client.invitations.create(
+  params: CreateInvitationParams(
+    email: "alice@example.com",
+    role: "member",
+    expiresAt: ISO8601DateFormatter().string(from: Date().addingTimeInterval(7 * 86400)),
+    source: "team-onboarding-flow",
+    note: "Backend hire — Q2 cohort",
+    sendEmail: true
+  )
+)
 
 // Members: gate on quota first
 let quota = try await client.invitations.quota()
-let unlimited = quota["unlimited"] as? Bool ?? false
-let remaining = quota["remaining"] as? Int ?? 0
-if !unlimited && remaining <= 0 {
+if !quota.unlimited && quota.remaining <= 0 {
   return showQuotaExhausted()
 }
-_ = try await client.invitations.create(params: ["email": email, "role": "member"])
+_ = try await client.invitations.create(
+  params: CreateInvitationParams(email: email, role: "member")
+)
 ```
 {{/lang}}
 
@@ -240,10 +241,9 @@ await myEmailService.send({ to: inv.email, link: acceptUrl });
 {{#lang swift}}
 ```swift
 let inv = try await client.invitations.get(invitationId: invitationId)
-let inviteToken = inv["inviteToken"] as? String ?? ""
-let email = inv["email"] as? String ?? ""
+let inviteToken = inv.inviteToken ?? ""
 let acceptUrl = "\(myApp.baseURL)/invite/accept?inviteToken=\(inviteToken)"
-try await myEmailService.send(to: email, link: acceptUrl)
+try await myEmailService.send(to: inv.email, link: acceptUrl)
 ```
 {{/lang}}
 
@@ -307,9 +307,11 @@ const { grants, nextCursor } = await client.invitations.listDeferredGrants({
 {{/lang}}
 {{#lang swift}}
 ```swift
-let (grants, nextCursor) = try await client.invitations.listDeferredGrants(
+let result = try await client.invitations.listDeferredGrants(
   email: "alice@example.com"
 )
+let grants = result.grants        // [DeferredGrant]
+let nextCursor = result.nextCursor
 ```
 {{/lang}}
 
@@ -345,21 +347,21 @@ async function onboardTeammate(email: string, projectDocId: string) {
 ```swift
 func onboardTeammate(email: String, projectDocId: String) async throws {
   let quota = try await client.invitations.quota()
-  let unlimited = quota["unlimited"] as? Bool ?? false
-  let remaining = quota["remaining"] as? Int ?? 0
-  if !unlimited && remaining <= 0 {
+  if !quota.unlimited && quota.remaining <= 0 {
     throw OnboardingError.quotaExhausted
   }
 
-  _ = try await client.invitations.create(params: ["email": email, "role": "member"])
+  _ = try await client.invitations.create(
+    params: CreateInvitationParams(email: email, role: "member")
+  )
 
   _ = try await client.documents.updatePermissions(
     documentId: projectDocId,
-    params: ["permissions": [["email": email, "permission": "read-write"]]]
+    params: .email(email, permission: "read-write")
   )
 
   _ = try await client.groups.addMember(
-    groupType: "team", groupId: "engineering", params: ["email": email]
+    groupType: "team", groupId: "engineering", params: .email(email)
   )
 }
 ```
@@ -387,13 +389,15 @@ client.on("invitation", (event) => {
 {{/lang}}
 {{#lang swift}}
 ```swift
-client.events.on(.invitation) { event in
-  switch event.action {
+client.events.onAny(.invitation) { payload in
+  guard let event = payload as? [String: Any],
+        let action = event["action"] as? String else { return }
+  switch action {
   case "created":   break  // invitee only
   case "updated":   break  // invitee only
   case "cancelled": break  // invitee only
   case "declined":  break  // both invitee and inviter
-  case "accepted":  break  // inviter only — event.acceptedBy carries the userId
+  case "accepted":  break  // inviter only — event["acceptedBy"] carries the userId
   default:          break  // future-proof: no-op, don't throw
   }
 }

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_PERFORMANCE.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_PERFORMANCE.swift.md
@@ -43,11 +43,11 @@ A page needs several pieces of data from the same database, fetched one at a tim
 
 ```swift
 // 5 sequential round trips to the SAME database
-let groups = try await db.executeOperation(name: "listGroups")
-let accounts = try await db.executeOperation(name: "listAccounts")
-let holdings = try await db.executeOperation(name: "listHoldings")
-let targets = try await db.executeOperation(name: "listAllTargets")
-let latest = try await db.executeOperation(name: "listLatestSnapshot")
+let groups = try await client.databases.executeOperation(databaseId: databaseId, name: "listGroups")
+let accounts = try await client.databases.executeOperation(databaseId: databaseId, name: "listAccounts")
+let holdings = try await client.databases.executeOperation(databaseId: databaseId, name: "listHoldings")
+let targets = try await client.databases.executeOperation(databaseId: databaseId, name: "listAllTargets")
+let latest = try await client.databases.executeOperation(databaseId: databaseId, name: "listLatestSnapshot")
 ```
 
 Each call has its own request/response overhead. They serialize even though none depend on each other.
@@ -103,9 +103,10 @@ A per-item operation called once for every item in a collection:
 
 ```swift
 for group in groups {
-  let targets = try await db.executeOperation(
+  let targets = try await client.databases.executeOperation(
+    databaseId: databaseId,
     name: "listTargetsByGroup",
-    params: ["groupId": group.id]
+    options: ExecuteOperationOptions(params: ["groupId": .string(group.id)])
   )
   // ...use targets
 }
@@ -129,10 +130,11 @@ definition = '{"filter":{},"sort":{"groupId":1},"limit":1000}'
 Call it once, then group client-side:
 
 ```swift
-let all = try await db.executeOperation(name: "listAllTargets")
-var byGroup: [String: [Target]] = [:]
-for t in all.data {
-  byGroup[t.groupId, default: []].append(t)
+let all = try await client.databases.executeOperation(databaseId: databaseId, name: "listAllTargets")
+var byGroup: [String: [JSONValue]] = [:]
+for t in all["data"]?.arrayValue ?? [] {
+  guard let groupId = t["groupId"]?.stringValue else { continue }
+  byGroup[groupId, default: []].append(t)
 }
 for group in groups {
   let targets = byGroup[group.id] ?? []
@@ -153,9 +155,9 @@ Any time you find an `await ...executeOperation(...)` inside a `for` loop. This 
 Three independent reads awaited one after another:
 
 ```swift
-let a = try await db.executeOperation(name: "opA")
-let b = try await db.executeOperation(name: "opB")
-let c = try await db.executeOperation(name: "opC")
+let a = try await client.databases.executeOperation(databaseId: databaseId, name: "opA")
+let b = try await client.databases.executeOperation(databaseId: databaseId, name: "opB")
+let c = try await client.databases.executeOperation(databaseId: databaseId, name: "opC")
 ```
 
 Three sequential round trips even though none depends on the others.
@@ -412,10 +414,14 @@ final class SourceStore: ObservableObject {
   // a server-registered subscription key, and an options object carrying the
   // `onChange` callback (plus any `params` forwarded to the subscription's
   // filter CEL).
-  func observe(dbId: String) {
-    client.databases.subscribe(databaseId: dbId, key: "source-changes") { [weak self] _ in
-      self?.invalidate()
-    }
+  func observe(dbId: String) throws {
+    _ = try client.databases.subscribe(
+      databaseId: dbId,
+      subscriptionKey: "source-changes",
+      options: DatabaseSubscribeOptions(onChange: { [weak self] _ in
+        self?.invalidate()
+      })
+    )
   }
 }
 ```

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_PERFORMANCE.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_PERFORMANCE.template.md
@@ -54,11 +54,11 @@ const latest   = await db.executeOperation("listLatestSnapshot");
 {{#lang swift}}
 ```swift
 // 5 sequential round trips to the SAME database
-let groups = try await db.executeOperation(name: "listGroups")
-let accounts = try await db.executeOperation(name: "listAccounts")
-let holdings = try await db.executeOperation(name: "listHoldings")
-let targets = try await db.executeOperation(name: "listAllTargets")
-let latest = try await db.executeOperation(name: "listLatestSnapshot")
+let groups = try await client.databases.executeOperation(databaseId: databaseId, name: "listGroups")
+let accounts = try await client.databases.executeOperation(databaseId: databaseId, name: "listAccounts")
+let holdings = try await client.databases.executeOperation(databaseId: databaseId, name: "listHoldings")
+let targets = try await client.databases.executeOperation(databaseId: databaseId, name: "listAllTargets")
+let latest = try await client.databases.executeOperation(databaseId: databaseId, name: "listLatestSnapshot")
 ```
 {{/lang}}
 
@@ -120,9 +120,10 @@ for (const group of groups) {
 {{#lang swift}}
 ```swift
 for group in groups {
-  let targets = try await db.executeOperation(
+  let targets = try await client.databases.executeOperation(
+    databaseId: databaseId,
     name: "listTargetsByGroup",
-    params: ["groupId": group.id]
+    options: ExecuteOperationOptions(params: ["groupId": .string(group.id)])
   )
   // ...use targets
 }
@@ -163,10 +164,11 @@ for (const group of groups) {
 {{/lang}}
 {{#lang swift}}
 ```swift
-let all = try await db.executeOperation(name: "listAllTargets")
-var byGroup: [String: [Target]] = [:]
-for t in all.data {
-  byGroup[t.groupId, default: []].append(t)
+let all = try await client.databases.executeOperation(databaseId: databaseId, name: "listAllTargets")
+var byGroup: [String: [JSONValue]] = [:]
+for t in all["data"]?.arrayValue ?? [] {
+  guard let groupId = t["groupId"]?.stringValue else { continue }
+  byGroup[groupId, default: []].append(t)
 }
 for group in groups {
   let targets = byGroup[group.id] ?? []
@@ -196,9 +198,9 @@ const c = await db.executeOperation("opC");
 {{/lang}}
 {{#lang swift}}
 ```swift
-let a = try await db.executeOperation(name: "opA")
-let b = try await db.executeOperation(name: "opB")
-let c = try await db.executeOperation(name: "opC")
+let a = try await client.databases.executeOperation(databaseId: databaseId, name: "opA")
+let b = try await client.databases.executeOperation(databaseId: databaseId, name: "opB")
+let c = try await client.databases.executeOperation(databaseId: databaseId, name: "opC")
 ```
 {{/lang}}
 
@@ -598,10 +600,14 @@ final class SourceStore: ObservableObject {
   // a server-registered subscription key, and an options object carrying the
   // `onChange` callback (plus any `params` forwarded to the subscription's
   // filter CEL).
-  func observe(dbId: String) {
-    client.databases.subscribe(databaseId: dbId, key: "source-changes") { [weak self] _ in
-      self?.invalidate()
-    }
+  func observe(dbId: String) throws {
+    _ = try client.databases.subscribe(
+      databaseId: dbId,
+      subscriptionKey: "source-changes",
+      options: DatabaseSubscribeOptions(onChange: { [weak self] _ in
+        self?.invalidate()
+      })
+    )
   }
 }
 ```

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_PROMPTS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_PROMPTS.swift.md
@@ -658,11 +658,11 @@ The first arg is the `promptKey`, NOT the `promptId`. The endpoint is `POST /pro
 
 ```swift
 // WRONG — passing the prompt id instead of the prompt key
-try await client.prompts.execute("01HXY...PROMPT_ID", variables: [:])
+try await client.prompts.execute(promptKey: "01HXY...PROMPT_ID", options: ExecutePromptOptions())
 // → 404. Use the key from the TOML.
 
 // WRONG — expecting a top-level variable
-try await client.prompts.execute("p", variables: ["name": "Alice"])
+try await client.prompts.execute(promptKey: "p", options: ExecutePromptOptions(variables: ["name": "Alice"]))
 // template: "Hi {{ name }}"   ← won't resolve, renders as "Hi "
 // Fix: template: "Hi {{ input.name }}"
 ```

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_PROMPTS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_PROMPTS.template.md
@@ -647,11 +647,11 @@ await client.prompts.execute("p", { variables: { name: "Alice" } });
 {{#lang swift}}
 ```swift
 // WRONG — passing the prompt id instead of the prompt key
-try await client.prompts.execute("01HXY...PROMPT_ID", variables: [:])
+try await client.prompts.execute(promptKey: "01HXY...PROMPT_ID", options: ExecutePromptOptions())
 // → 404. Use the key from the TOML.
 
 // WRONG — expecting a top-level variable
-try await client.prompts.execute("p", variables: ["name": "Alice"])
+try await client.prompts.execute(promptKey: "p", options: ExecutePromptOptions(variables: ["name": "Alice"]))
 // template: "Hi {{ name }}"   ← won't resolve, renders as "Hi "
 // Fix: template: "Hi {{ input.name }}"
 ```

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.swift.md
@@ -181,7 +181,7 @@ The current authenticated user has its own namespace. Use it for "me"-scoped rea
   )
 
   // Upload an image directly; the server hosts it and returns a URL.
-  let uploaded = try await client.me.uploadAvatar(imageData: avatar, contentType: "image/png")
+  let uploaded = try await client.me.uploadAvatar(imageData: avatar, contentType: .png)
   let avatarUrl = uploaded.avatarUrl
 
   // update() and uploadAvatar() clear the cache automatically; reach for
@@ -756,18 +756,20 @@ autoAddCreator = true
 
 ```swift
 // User creates a team
-try await client.groups.create(
+try await client.groups.create(params: CreateGroupParams(
   groupType: "team",
   groupId: "alpha-team",
   name: "Alpha Team"
-)
+))
 
 // Share a document with the team
 try await client.documents.grantGroupPermission(
-  docId,
-  groupType: "team",
-  groupId: "alpha-team",
-  permission: "read-write"
+  documentId: docId,
+  params: GrantGroupPermissionParams(
+    groupType: "team",
+    groupId: "alpha-team",
+    permission: "read-write"
+  )
 )
 
 // Database operations gated by team membership
@@ -780,14 +782,16 @@ Use group types as roles within a context.
 
 ```swift
 // Create role groups for a project
-try await client.groups.create(groupType: "editor", groupId: "project-1", name: "Project 1 Editors")
-try await client.groups.create(groupType: "viewer", groupId: "project-1", name: "Project 1 Viewers")
+try await client.groups.create(params: CreateGroupParams(groupType: "editor", groupId: "project-1", name: "Project 1 Editors"))
+try await client.groups.create(params: CreateGroupParams(groupType: "viewer", groupId: "project-1", name: "Project 1 Viewers"))
 
 // Grant different document permissions
 try await client.documents.grantGroupPermission(
-  docId, groupType: "editor", groupId: "project-1", permission: "read-write")
+  documentId: docId,
+  params: GrantGroupPermissionParams(groupType: "editor", groupId: "project-1", permission: "read-write"))
 try await client.documents.grantGroupPermission(
-  docId, groupType: "viewer", groupId: "project-1", permission: "reader")
+  documentId: docId,
+  params: GrantGroupPermissionParams(groupType: "viewer", groupId: "project-1", permission: "reader"))
 
 // Database operations with role checks
 // Editors can modify:
@@ -820,12 +824,14 @@ The per-parameter `access` expression ensures parents can only view their own ch
 
 ```swift
 // A "parent-of" group per student
-try await client.groups.create(
+try await client.groups.create(params: CreateGroupParams(
   groupType: "parent-of",
   groupId: "student-123",
   name: "Parents of Student 123"
+))
+try await client.groups.addMember(
+  groupType: "parent-of", groupId: "student-123", params: .userId(parentUserId)
 )
-try await client.groups.addMember("parent-of", "student-123", userId: parentUserId)
 
 // Parent queries their child's grades — server enforces access
 let grades = try await client.databases.executeOperation(
@@ -838,19 +844,19 @@ Model nested organizational structure with multiple group types.
 
 ```swift
 // Organization-level groups
-try await client.groups.create(groupType: "org", groupId: "acme-corp", name: "Acme Corp")
+try await client.groups.create(params: CreateGroupParams(groupType: "org", groupId: "acme-corp", name: "Acme Corp"))
 
 // Department-level groups
-try await client.groups.create(groupType: "dept", groupId: "engineering", name: "Engineering")
-try await client.groups.create(groupType: "dept", groupId: "marketing", name: "Marketing")
+try await client.groups.create(params: CreateGroupParams(groupType: "dept", groupId: "engineering", name: "Engineering"))
+try await client.groups.create(params: CreateGroupParams(groupType: "dept", groupId: "marketing", name: "Marketing"))
 
 // Team-level groups
-try await client.groups.create(groupType: "team", groupId: "backend", name: "Backend Team")
+try await client.groups.create(params: CreateGroupParams(groupType: "team", groupId: "backend", name: "Backend Team"))
 
 // A user can be in multiple groups at different levels
-try await client.groups.addMember("org", "acme-corp", userId: userId)
-try await client.groups.addMember("dept", "engineering", userId: userId)
-try await client.groups.addMember("team", "backend", userId: userId)
+try await client.groups.addMember(groupType: "org", groupId: "acme-corp", params: .userId(userId))
+try await client.groups.addMember(groupType: "dept", groupId: "engineering", params: .userId(userId))
+try await client.groups.addMember(groupType: "team", groupId: "backend", params: .userId(userId))
 
 // CEL can check any level:
 // "isMemberOf('org', database.metadata.orgId)"

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.template.md
@@ -614,18 +614,20 @@ await client.documents.grantGroupPermission(docId, {
 {{#lang swift}}
 ```swift
 // User creates a team
-try await client.groups.create(
+try await client.groups.create(params: CreateGroupParams(
   groupType: "team",
   groupId: "alpha-team",
   name: "Alpha Team"
-)
+))
 
 // Share a document with the team
 try await client.documents.grantGroupPermission(
-  docId,
-  groupType: "team",
-  groupId: "alpha-team",
-  permission: "read-write"
+  documentId: docId,
+  params: GrantGroupPermissionParams(
+    groupType: "team",
+    groupId: "alpha-team",
+    permission: "read-write"
+  )
 )
 
 // Database operations gated by team membership
@@ -661,14 +663,16 @@ await client.documents.grantGroupPermission(docId, {
 {{#lang swift}}
 ```swift
 // Create role groups for a project
-try await client.groups.create(groupType: "editor", groupId: "project-1", name: "Project 1 Editors")
-try await client.groups.create(groupType: "viewer", groupId: "project-1", name: "Project 1 Viewers")
+try await client.groups.create(params: CreateGroupParams(groupType: "editor", groupId: "project-1", name: "Project 1 Editors"))
+try await client.groups.create(params: CreateGroupParams(groupType: "viewer", groupId: "project-1", name: "Project 1 Viewers"))
 
 // Grant different document permissions
 try await client.documents.grantGroupPermission(
-  docId, groupType: "editor", groupId: "project-1", permission: "read-write")
+  documentId: docId,
+  params: GrantGroupPermissionParams(groupType: "editor", groupId: "project-1", permission: "read-write"))
 try await client.documents.grantGroupPermission(
-  docId, groupType: "viewer", groupId: "project-1", permission: "reader")
+  documentId: docId,
+  params: GrantGroupPermissionParams(groupType: "viewer", groupId: "project-1", permission: "reader"))
 
 // Database operations with role checks
 // Editors can modify:
@@ -719,12 +723,14 @@ const grades = await client.databases.executeOperation(dbId, "viewGrades", {
 {{#lang swift}}
 ```swift
 // A "parent-of" group per student
-try await client.groups.create(
+try await client.groups.create(params: CreateGroupParams(
   groupType: "parent-of",
   groupId: "student-123",
   name: "Parents of Student 123"
+))
+try await client.groups.addMember(
+  groupType: "parent-of", groupId: "student-123", params: .userId(parentUserId)
 )
-try await client.groups.addMember("parent-of", "student-123", userId: parentUserId)
 
 // Parent queries their child's grades — server enforces access
 let grades = try await client.databases.executeOperation(
@@ -762,19 +768,19 @@ await client.groups.addMember("team", "backend", { userId });
 {{#lang swift}}
 ```swift
 // Organization-level groups
-try await client.groups.create(groupType: "org", groupId: "acme-corp", name: "Acme Corp")
+try await client.groups.create(params: CreateGroupParams(groupType: "org", groupId: "acme-corp", name: "Acme Corp"))
 
 // Department-level groups
-try await client.groups.create(groupType: "dept", groupId: "engineering", name: "Engineering")
-try await client.groups.create(groupType: "dept", groupId: "marketing", name: "Marketing")
+try await client.groups.create(params: CreateGroupParams(groupType: "dept", groupId: "engineering", name: "Engineering"))
+try await client.groups.create(params: CreateGroupParams(groupType: "dept", groupId: "marketing", name: "Marketing"))
 
 // Team-level groups
-try await client.groups.create(groupType: "team", groupId: "backend", name: "Backend Team")
+try await client.groups.create(params: CreateGroupParams(groupType: "team", groupId: "backend", name: "Backend Team"))
 
 // A user can be in multiple groups at different levels
-try await client.groups.addMember("org", "acme-corp", userId: userId)
-try await client.groups.addMember("dept", "engineering", userId: userId)
-try await client.groups.addMember("team", "backend", userId: userId)
+try await client.groups.addMember(groupType: "org", groupId: "acme-corp", params: .userId(userId))
+try await client.groups.addMember(groupType: "dept", groupId: "engineering", params: .userId(userId))
+try await client.groups.addMember(groupType: "team", groupId: "backend", params: .userId(userId))
 
 // CEL can check any level:
 // "isMemberOf('org', database.metadata.orgId)"

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.swift.md
@@ -1308,21 +1308,18 @@ The `workflowStatus` event uses `"completed"`; `getStatus` returns `"complete"`.
 For workflows with `requiresClientApply = true`, register an apply handler so a client deterministically runs follow-up logic exactly once.
 
 
-For "start a run and await its result", use `runAndApply`. It tracks each call by `runKey` (so N concurrent runs of the same `workflowKey` coexist), runs the full claim → getStatus → confirm flow internally, and returns a `WorkflowApplyContext` carrying the output:
+Register a per-`workflowKey` handler with `define(_:onApply:)`. When a `workflowStatus` event arrives with `needsApply == true` for that key, the client automatically claims the lease, fetches the output via `getStatus`, runs your handler, then confirms — releasing the claim if the handler throws:
 
 ```swift
-let ctx = try await client.workflows.runAndApply(
-    workflowKey: "ocr-content",
-    input: ["attachments": [["data": image.base64EncodedString(), "type": "image/jpeg"]]],
-    options: StartWorkflowOptions(contextDocId: documentId),
-    timeout: 120                          // default 120s; raise for slow LLM workflows
-)
-let output = ctx.output                   // Any? — cast to the final step's JSON shape
-// Terminal non-success throws WorkflowRunError.terminalFailure(status:message:);
-// missing output within the window throws .timedOut; task cancellation propagates.
+client.workflows.define("my-workflow-key") { ctx in
+    // Runs on exactly one connected client, after the lease is claimed.
+    // ctx.output, ctx.workflowKey, ctx.runKey, ctx.runId,
+    // ctx.contextDocId, ctx.startedByUserId, ctx.meta
+    // Write ctx.output into the contextDocId document here.
+}
 ```
 
-Use the lower-level `define` + `start` pair when you need a long-lived per-`workflowKey` handler rather than a per-call awaiter. When you do, the mandatory guards are: **register `define(...)` before `start(...)`** (else the apply may deliver before you subscribe); **guard the handler on a matching `runKey`** (a `.workflowStatus` event from a prior app session can otherwise resolve a fresh continuation); and a **`resolved` flag** (server retries can fire the handler more than once, and a `CheckedContinuation` traps on double-resume). If the device was offline when the server finished the run, call `client.workflows.deliverPendingApplies(contextDocId:)` after reconnect to drive the queued apply.
+Register the handler before starting runs, so an apply that lands quickly isn't missed. If the device was offline when the server finished the run, call `getPendingApplies(contextDocId:)` after reconnect to recover the parked applies.
 
 Manual flow if you need it: `claimApply` → run logic → `confirmApply` (success) or `releaseApply` (failure). 30s lease timeout for crashed clients.
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md
@@ -1246,21 +1246,18 @@ Manual flow if you need it: `claimApply` → run logic → `confirmApply` (succe
 {{/lang}}
 
 {{#lang swift}}
-For "start a run and await its result", use `runAndApply`. It tracks each call by `runKey` (so N concurrent runs of the same `workflowKey` coexist), runs the full claim → getStatus → confirm flow internally, and returns a `WorkflowApplyContext` carrying the output:
+Register a per-`workflowKey` handler with `define(_:onApply:)`. When a `workflowStatus` event arrives with `needsApply == true` for that key, the client automatically claims the lease, fetches the output via `getStatus`, runs your handler, then confirms — releasing the claim if the handler throws:
 
 ```swift
-let ctx = try await client.workflows.runAndApply(
-    workflowKey: "ocr-content",
-    input: ["attachments": [["data": image.base64EncodedString(), "type": "image/jpeg"]]],
-    options: StartWorkflowOptions(contextDocId: documentId),
-    timeout: 120                          // default 120s; raise for slow LLM workflows
-)
-let output = ctx.output                   // Any? — cast to the final step's JSON shape
-// Terminal non-success throws WorkflowRunError.terminalFailure(status:message:);
-// missing output within the window throws .timedOut; task cancellation propagates.
+client.workflows.define("my-workflow-key") { ctx in
+    // Runs on exactly one connected client, after the lease is claimed.
+    // ctx.output, ctx.workflowKey, ctx.runKey, ctx.runId,
+    // ctx.contextDocId, ctx.startedByUserId, ctx.meta
+    // Write ctx.output into the contextDocId document here.
+}
 ```
 
-Use the lower-level `define` + `start` pair when you need a long-lived per-`workflowKey` handler rather than a per-call awaiter. When you do, the mandatory guards are: **register `define(...)` before `start(...)`** (else the apply may deliver before you subscribe); **guard the handler on a matching `runKey`** (a `.workflowStatus` event from a prior app session can otherwise resolve a fresh continuation); and a **`resolved` flag** (server retries can fire the handler more than once, and a `CheckedContinuation` traps on double-resume). If the device was offline when the server finished the run, call `client.workflows.deliverPendingApplies(contextDocId:)` after reconnect to drive the queued apply.
+Register the handler before starting runs, so an apply that lands quickly isn't missed. If the device was offline when the server finished the run, call `getPendingApplies(contextDocId:)` after reconnect to recover the parked applies.
 
 Manual flow if you need it: `claimApply` → run logic → `confirmApply` (success) or `releaseApply` (failure). 30s lease timeout for crashed clients.
 {{/lang}}


### PR DESCRIPTION
**Draft — depends on [Primitive-Labs/js-bao-wss#1071](https://github.com/Primitive-Labs/js-bao-wss/pull/1071).**

Trues up the Swift client examples across `docs/`, `guides/`, and the `examples/` corpus to match the current Swift client shipped in js-bao-wss **PR #1071** (chunk-2 parity pass). Held as a draft until #1071 merges.

## Why draft / dependency
These examples use APIs introduced in #1071 that `main`'s published client doesn't carry yet (e.g. the `removePermission` `DocumentPermissionTarget` union). The `examples/` corpus compiles against the current client locally; on `main` the validation gates only pass once #1071 ships and the vendored `library_repos/js-bao-wss` submodule re-pins to the released commit. Merge order: **#1071 first, then this.**

## Approach
Per-subject verification passes (one agent per subject), each checking every Swift example — corpus, guide-template inline `{{#lang swift}}` fences, and human-page client fences — against the current client source, using the compile-verified corpus as the reference. Only genuinely-outdated examples were changed; JavaScript/TypeScript untouched. Riskiest uncompiled guide-fence claims were spot-checked back against the source.

## Changes
**Corpus (compile-verified):**
- `sharing/share-remove` — `removePermission` union target (`.userId` / `.email`)
- `documents/close-document` — note corrected (`close` → `CloseDocumentResult { evicted }`)
- `users-and-groups/me-profile` — `uploadAvatar(contentType: .png)` (`AvatarContentType` enum)
- `databases/db-subscribe` (+`-params`) — `databases.subscribe` now `throws` (added `try`)

**Guide templates (Swift blocks only; `.swift.md` re-rendered):**
- DOCUMENTS — `getOrCreateWithAlias(options: GetOrCreateWithAliasOptions(alias: AliasRef…))`
- INVITATIONS — typed `CreateInvitationParams` / quota struct / `DeferredGrantListResult`; invitation events via `events.onAny`
- USERS_AND_GROUPS — `GroupsAPI.create(params:)` / `addMember(params:)`, `grantGroupPermission(documentId:params:)`
- WORKFLOWS — apply story via `define(_:onApply:)` / `getPendingApplies` (`runAndApply` / `deliverPendingApplies` removed)
- PROMPTS — `execute(promptKey:options: ExecutePromptOptions)`
- PERFORMANCE — `client.databases.executeOperation(databaseId:) -> JSONValue`; `subscribe(subscriptionKey:options: DatabaseSubscribeOptions)`

**Verified already-current (no changes):** auth, blobs / blob-buckets, integrations, analytics, devtools, data-modeling, scheduling.

## Validation (local, against the current client)
`compile-examples` (283 ✓) · example parity ✓ · `render-guides --check` ✓ · `vitepress build` (no dead links) ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)