### PR TITLE
Docs for the 2026-06-03 release backfill + next truing pass (Swift parity-to-zero, model facade)

### DIFF
--- a/docs-sources.json
+++ b/docs-sources.json
@@ -3,11 +3,11 @@
   "stampedAt": "2026-06-05",
   "libraries": {
     "js-bao-wss": {
-      "commit": "8249eb353cff04a9ff9bd7a871dc1791358296b1",
+      "commit": "32eed517f30f8be4405f112a3fe2cd491d383144",
       "npm": {
-        "js-bao-wss-client": "2.0.0",
+        "js-bao-wss-client": "2.0.1",
         "js-bao": "0.5.1",
-        "primitive-admin": "1.0.49"
+        "primitive-admin": "1.0.50"
       }
     },
     "primitive-app-dev": {
@@ -17,7 +17,7 @@
       }
     },
     "swift-primitive-app-dev": {
-      "commit": "a290e9aa4a0d180d7ac0dfddee5b20e179baa7f3"
+      "commit": "0253320fe8ef97137d4391e3c3dac5c3e5f4cc48"
     }
   }
 }

--- a/docs/getting-started/access-control.md
+++ b/docs/getting-started/access-control.md
@@ -41,6 +41,7 @@ Each place a rule appears adds its own context on top — operation `params.*`, 
 | Database subscriptions (`accessRule` + `filter`) | Who can subscribe, and which changes they receive | [Real-Time Subscriptions](./working-with-databases.md#real-time-subscriptions) |
 | Workflows (`accessRule`) | Who can start a run directly from a client | [Controlling Access to Workflows](./workflows.md#controlling-access-to-workflows) |
 | Server-stamped fields (trigger `when` conditions) | Whether a computed field applies to this write | [Server-Stamped Fields](./working-with-databases.md#server-stamped-fields) |
+| Blob buckets (`ruleSetId`) | Member-level reads and writes of a bucket's blobs | [Blobs and Files](./blobs-and-files.md#access-policies) |
 | Rule sets | Who can perform **management operations** on groups and collections | below |
 
 ## Rule Sets: Governing Management Operations
@@ -56,7 +57,7 @@ primitive rule-sets create "team-management" \
   }'
 ```
 
-Bind a rule set to a **group type** or **collection type** via its type config — in TOML (`config/group-type-configs/<type>.toml`, `config/collection-type-configs/<type>.toml`) or from the client (`client.groupTypeConfigs.create({ groupType, ruleSetId })`).
+Bind a rule set to a **group type** or **collection type** via its type config — in TOML (`config/group-type-configs/<type>.toml`, `config/collection-type-configs/<type>.toml`) or from the client (`client.groupTypeConfigs.create({ groupType, ruleSetId })`). A **blob bucket** attaches one directly via its `ruleSetId`, where it governs member reads and writes — see [Blobs and Files](./blobs-and-files.md#access-policies).
 
 Two behaviors to know:
 

--- a/docs/getting-started/blobs-and-files.md
+++ b/docs/getting-started/blobs-and-files.md
@@ -76,6 +76,8 @@ A bucket's **access policy** decides who can read and write its blobs. App admin
 
 Pick the simplest policy that fits.
 
+For member access that the three policies can't express, attach a [rule set](./access-control.md#rule-sets-governing-management-operations) to the bucket — set `ruleSetId` in the bucket's TOML, or pass `--rule-set-id` to `primitive blob-buckets create`. An attached rule set becomes the authority for member-level access: admins and owners are always allowed, unauthenticated callers are rejected, and every other read or write is decided by the rule set's CEL rules.
+
 ## TTL Tiers
 
 Each bucket has a **TTL tier** that governs how long blobs live before the storage layer deletes them. Pick the shortest tier that fits — short-lived blobs are cheaper and safer.

--- a/docs/getting-started/configuring-your-backend.md
+++ b/docs/getting-started/configuring-your-backend.md
@@ -23,6 +23,16 @@ primitive sync push --dir ./config    # apply your changes to the server
 
 The files live in your repo, so configuration changes ride the same workflow as code: branches, diffs, reviews, rollbacks. `sync push` validates every file before applying anything — a validation error aborts the push with no changes applied — and reports the file and entity behind any failure.
 
+Every `sync pull` snapshots the sync directory before writing, so a pull that overwrites local edits is recoverable:
+
+```bash
+primitive sync revert --list            # list available snapshots
+primitive sync revert                   # restore the most recent
+primitive sync revert --snapshot <id>   # restore a specific one
+```
+
+Snapshots are local CLI state, kept out of version control and pruned after 28 days. `revert` replaces the sync directory with the snapshot — run `primitive sync diff` afterwards to see where the restored files stand relative to the server.
+
 ## What Lives in the Config Directory
 
 One subdirectory per kind of configuration:

--- a/docs/getting-started/devtools.md
+++ b/docs/getting-started/devtools.md
@@ -143,7 +143,7 @@ The inspector covers the same ground as the web overlay, plus iOS-specific stora
 | **SQLite / Memory SQL** | The client's on-disk store and the in-memory SQL projection that backs queries, browsable directly |
 | **Events / Logs** | The live client event stream and the inspector's own log tail |
 
-Your typed models appear in the Documents tab automatically when you create them with `makeTypedModel(doc:documentId:)` in your `PrimitiveAppState` subclass. To register in-app tests, conform your app state to `InspectorTestHost`:
+Your models appear in the Documents tab automatically — the inspector reads the client's shared cross-document store, so every model registered with the client (`client.registerModels([...])`) or read/written once through its codegen'd facade is listed, per open document. To register in-app tests, conform your app state to `InspectorTestHost`:
 
 ```swift
 extension MyAppState: InspectorTestHost {

--- a/docs/getting-started/primitive-cli.md
+++ b/docs/getting-started/primitive-cli.md
@@ -255,7 +255,12 @@ primitive sync diff
 
 # Push local changes to server
 primitive sync push
+
+# Restore the sync directory from a pre-pull snapshot
+primitive sync revert
 ```
+
+Every `pull` snapshots the sync directory before writing; `sync revert` restores the most recent snapshot, `--list` enumerates the available ones, and `--snapshot <id>` picks a specific one.
 
 Pass `--dir <path>` to override and use a fixed directory:
 

--- a/docs/getting-started/workflows.md
+++ b/docs/getting-started/workflows.md
@@ -161,7 +161,7 @@ A workflow runs on the server, but its result often belongs in a **document** �
 
 1. The client registers an apply handler for the workflow with `workflows.define(workflowKey, { onApply })`.
 2. When a run reaches `apply_pending`, a client calls `claimApply()` (an exclusive, time-limited claim), runs the handler, then `confirmApply()` — or `releaseApply()` on failure so another client can retry.
-3. The template helpers and Swift's `runAndApply(...)` wrap this loop for you — most apps never call claim/confirm directly.
+3. `define(...)` wraps this loop for you — when the status event arrives, the client claims the lease, runs your handler, and confirms (or releases on a thrown error). Most apps never call claim/confirm directly.
 
 If a workflow's output doesn't need to land in a document — it writes to databases, sends email, returns a value — leave `requiresClientApply` off. Server-only workflows (cron-fired jobs especially) should set it to `false` explicitly, otherwise runs sit in `apply_pending` waiting for a client that never comes:
 

--- a/docs/getting-started/workflows.md
+++ b/docs/getting-started/workflows.md
@@ -526,6 +526,8 @@ type = "text"
 text = "Summarize: {{ input.content }}"
 ```
 
+The `model` must be on the server's allow-list of Gemini models — a disallowed model is rejected when you save the workflow, not when it runs.
+
 ### `prompt.execute`
 
 Runs a [managed prompt](./prompts.md) — versioned, testable, and configured outside the workflow:

--- a/docs/getting-started/working-with-documents.md
+++ b/docs/getting-started/working-with-documents.md
@@ -351,7 +351,7 @@ Pass a sort and a page size, then carry the cursor forward.
 
 :::
 
-In Swift, cursor pagination lives on the `.dynamic` layer (`queryPaged`); use `sortOrder` (an ordered list) so the cursor is stable across pages.
+In Swift, use `sortOrder` (an ordered list) so the cursor is stable across pages.
 
 ### Aggregations
 
@@ -365,7 +365,7 @@ Group-by with `count` / `avg` / `sum` / `min` / `max`, an optional pre-filter, s
 
 :::
 
-When you group by a `stringset` field (like `tags`), each member value becomes its own group — a tag-facet count.
+When you group by a `stringset` field (like `tags`), each member value becomes its own group — a tag-facet count. To split records by whether the set contains one specific value instead, use a membership `groupBy` entry (the `urgentSplit` call above). One stringset facet field is allowed per aggregation.
 
 ## Reacting to Changes
 
@@ -443,16 +443,17 @@ Splitting this into a resolve followed by a create looks fine but has a race: tw
 
 ### Opening Documents on iOS
 
-On iOS, the canonical place to open documents and bind models is your `PrimitiveAppState` subclass — open in `connectClient()`, bind in the `onDocumentOpened` hook:
+On iOS, the canonical place to open documents is your `PrimitiveAppState` subclass — open in `connectClient()`:
 
 ```swift
 @MainActor
 final class MyAppState: PrimitiveAppState {
-  @Published private(set) var tasks: TypedModel<TaskRecord>?
-
   override func connectClient() async {
     await super.connectClient()
     guard let client else { return }
+    // Pre-register models so every open document is mirrored into the
+    // client's shared store (and listed in the Debug Inspector).
+    client.registerModels([TaskRecord.self])
     let result = try? await client.documents.getOrCreateWithAlias(
       alias: DocumentAlias(scope: .user, aliasKey: "library"),
       title: "Library"
@@ -460,14 +461,10 @@ final class MyAppState: PrimitiveAppState {
     guard let id = result?.documentId else { return }
     await selectDocumentAwaiting(id)
   }
-
-  override func onDocumentOpened(doc: YDocument, documentId: String) async {
-    tasks = makeTypedModel(doc: doc, documentId: documentId)
-  }
 }
 ```
 
-One `TypedModel` per record type per document. Prefer `makeTypedModel(doc:documentId:)` over direct construction — it also registers the model with the in-app Debug Inspector.
+There is no per-document model binding: reads go through the model's statics (`TaskRecord.query(...)`, cross-document by default — scope to one document with `QueryOptions(documents: [documentId])`), and writes go through record instances (`try TaskRecord(...).save(in: documentId)`). `registerModels([...])` at connect time is optional but recommended — the facade also lazily registers a model on its first read. For per-document setup beyond models, override the `onDocumentOpened(doc:documentId:)` hook.
 
 ## Common Document Usage Patterns
 

--- a/examples/auth/logout.swift
+++ b/examples/auth/logout.swift
@@ -4,7 +4,8 @@ import JsBaoClient
 func signOut(client: JsBaoClient) async throws {
   // #region example
   try await client.auth.logout(options: LogoutOptions(
-    wipeLocal: true // delete locally cached document data + KV cache
+    wipeLocal: true, // delete locally cached document data + KV cache
+    waitForDisconnect: true // wait for the WS to close before resolving
   ))
   // #endregion example
 }

--- a/examples/databases/db-subscribe-params.swift
+++ b/examples/databases/db-subscribe-params.swift
@@ -6,9 +6,9 @@ func watchTeamTickets(
   client: JsBaoClient,
   databaseId: String,
   handleChange: @escaping (DatabaseChangeEvent) -> Void
-) -> () -> Void {
+) throws -> () -> Void {
   // #region example
-  let unsub = client.databases.subscribe(
+  let unsub = try client.databases.subscribe(
     databaseId: databaseId,
     subscriptionKey: "tickets-by-team",
     options: DatabaseSubscribeOptions(

--- a/examples/databases/db-subscribe.swift
+++ b/examples/databases/db-subscribe.swift
@@ -8,9 +8,9 @@ func watchOpenTickets(
   databaseId: String,
   removeTicket: @escaping (String) -> Void,
   upsertTicket: @escaping (Any?) -> Void
-) {
+) throws {
   // #region example
-  let unsub = client.databases.subscribe(
+  let unsub = try client.databases.subscribe(
     databaseId: databaseId,
     subscriptionKey: "my-open-tickets",
     options: DatabaseSubscribeOptions(onChange: { event in

--- a/examples/documents/aggregate.swift
+++ b/examples/documents/aggregate.swift
@@ -14,6 +14,19 @@ func taskStats() {
     sort: AggregateSort(field: "count", direction: -1),
     limit: 10
   ))
+
+  // Grouping by a stringset field counts per member value (facet):
+  let tagCounts = Task.aggregate(AggregateOptions(
+    groupBy: ["tags"],
+    operations: [AggregateOperation(type: .count)]
+  ))
+
+  // Group by whether the set contains a value (membership) — rows carry
+  // a "has_tags_urgent" key of "true" / "false":
+  let urgentSplit = Task.aggregate(AggregateOptions(
+    groupBy: [.stringSetMembership(field: "tags", contains: "urgent")],
+    operations: [AggregateOperation(type: .count)]
+  ))
   // #endregion example
-  _ = stats
+  _ = (stats, tagCounts, urgentSplit)
 }

--- a/examples/documents/aggregate.ts
+++ b/examples/documents/aggregate.ts
@@ -14,6 +14,18 @@ export async function taskStats() {
     sort: { field: "count", direction: -1 },
     limit: 10,
   });
+
+  // Grouping by a stringset field counts per member value (facet):
+  const tagCounts = await Task.aggregate({
+    groupBy: ["tags"],
+    operations: [{ type: "count" }],
+  });
+
+  // Group by whether the set contains a value (membership):
+  const urgentSplit = await Task.aggregate({
+    groupBy: [{ field: "tags", contains: "urgent" }],
+    operations: [{ type: "count" }],
+  });
   // #endregion example
-  return stats;
+  return { stats, tagCounts, urgentSplit };
 }

--- a/examples/documents/dataloader-glue.swift
+++ b/examples/documents/dataloader-glue.swift
@@ -14,12 +14,15 @@ struct TaskListView: View {
       Text(task.title)
     }
     .task {
-      guard let tasks = appState.tasks else { return } // TypedModel<TaskRecord>
-      loader.bind(client: appState.client, subscribeTo: [.onModelChange(tasks)]) { _ in
-        tasks.findAll()
+      loader.documentReady = appState.selectedDocId != nil
+      loader.bind(client: appState.client, subscribeTo: [.onModel(subscribe: TaskRecord.subscribe)]) { _ in
+        TaskRecord.findAll()
           .filter { !$0.completed }
           .sorted { $0.priority > $1.priority }
       }
+    }
+    .onChange(of: appState.selectedDocId) { _, id in
+      loader.documentReady = id != nil
     }
   }
   // #endregion example

--- a/examples/sharing/share-remove.swift
+++ b/examples/sharing/share-remove.swift
@@ -7,7 +7,7 @@ func removeShare(
   userId: String
 ) async throws {
   // #region example
-  _ = try await client.documents.removePermission(documentId: documentId, userId: userId)
-  _ = try await client.documents.removePermission(documentId: documentId, email: "alice@example.com")
+  try await client.documents.removePermission(documentId: documentId, .userId(userId))
+  try await client.documents.removePermission(documentId: documentId, .email("alice@example.com"))
   // #endregion example
 }

--- a/examples/users-and-groups/me-profile.swift
+++ b/examples/users-and-groups/me-profile.swift
@@ -23,12 +23,12 @@ func manageMyProfile(client: JsBaoClient, avatar: Data) async throws {
   )
 
   // Upload an image directly; the server hosts it and returns a URL.
-  let uploaded = try await client.me.uploadAvatar(imageData: avatar, contentType: "image/png")
+  let uploaded = try await client.me.uploadAvatar(imageData: avatar, contentType: .png)
   let avatarUrl = uploaded.avatarUrl
 
   // update() and uploadAvatar() clear the cache automatically; reach for
   // these only when you need to inspect or force a refresh yourself.
-  let info = await client.me.cacheInfo()  // (updatedAt?, ageMs?)
+  let info = await client.me.cacheInfo()  // MeCacheInfo(updatedAt?, ageMs?)
   await client.me.clearCache()  // next get() hits the network
   // #endregion example
   _ = (profile, avatarUrl, info)

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_ACCESS_CONTROL.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_ACCESS_CONTROL.md
@@ -37,7 +37,7 @@ primitive rule-sets create "team-management" \
   }'
 ```
 
-Bind via the type config: `config/group-type-configs/<type>.toml` / `config/collection-type-configs/<type>.toml` (synced), or `client.groupTypeConfigs.create({ groupType, ruleSetId })` / `client.collectionTypeConfigs.create(...)`.
+Bind via the type config: `config/group-type-configs/<type>.toml` / `config/collection-type-configs/<type>.toml` (synced), or `client.groupTypeConfigs.create({ groupType, ruleSetId })` / `client.collectionTypeConfigs.create(...)`. A **blob bucket** attaches a rule set directly via its `ruleSetId` (TOML, or `--rule-set-id` on `primitive blob-buckets create`), where it governs member-level reads/writes — see the Blob Buckets guide for precedence semantics.
 
 Semantics:
 - **App owners/admins bypass rule sets entirely**; rules apply to regular members.

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_ACCESS_CONTROL.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_ACCESS_CONTROL.template.md
@@ -37,7 +37,7 @@ primitive rule-sets create "team-management" \
   }'
 ```
 
-Bind via the type config: `config/group-type-configs/<type>.toml` / `config/collection-type-configs/<type>.toml` (synced), or `client.groupTypeConfigs.create({ groupType, ruleSetId })` / `client.collectionTypeConfigs.create(...)`.
+Bind via the type config: `config/group-type-configs/<type>.toml` / `config/collection-type-configs/<type>.toml` (synced), or `client.groupTypeConfigs.create({ groupType, ruleSetId })` / `client.collectionTypeConfigs.create(...)`. A **blob bucket** attaches a rule set directly via its `ruleSetId` (TOML, or `--rule-set-id` on `primitive blob-buckets create`), where it governs member-level reads/writes — see the Blob Buckets guide for precedence semantics.
 
 Semantics:
 - **App owners/admins bypass rule sets entirely**; rules apply to regular members.

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_ANALYTICS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_ANALYTICS.swift.md
@@ -60,6 +60,7 @@ Workflow and prompt events also record `duration_ms` and LLM token counts (`inpu
 
 Events are buffered on the device and persisted locally while offline; persisted events are flushed automatically when the WebSocket reconnects. A rate limiter caps emission at **300 events/minute with a 60-token burst** — events over the cap are dropped silently. No special code needed.
 
+The offline buffer is persisted with a **~1 MiB** cap; when it exceeds the cap the **oldest** events are dropped.
 
 ---
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_ANALYTICS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_ANALYTICS.template.md
@@ -88,9 +88,7 @@ Every event (auto or custom) gets these populated automatically:
 
 Events are buffered on the device and persisted locally while offline; persisted events are flushed automatically when the WebSocket reconnects. A rate limiter caps emission at **300 events/minute with a 60-token burst** — events over the cap are dropped silently. No special code needed.
 
-{{#lang ts}}
-The offline buffer is persisted to IndexedDB with a **1 MiB** cap; when it exceeds the cap the **oldest** events are dropped.
-{{/lang}}
+The offline buffer is persisted with a **~1 MiB** cap; when it exceeds the cap the **oldest** events are dropped.
 
 ---
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_ANALYTICS.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_ANALYTICS.ts.md
@@ -84,7 +84,7 @@ Every event (auto or custom) gets these populated automatically:
 
 Events are buffered on the device and persisted locally while offline; persisted events are flushed automatically when the WebSocket reconnects. A rate limiter caps emission at **300 events/minute with a 60-token burst** — events over the cap are dropped silently. No special code needed.
 
-The offline buffer is persisted to IndexedDB with a **1 MiB** cap; when it exceeds the cap the **oldest** events are dropped.
+The offline buffer is persisted with a **~1 MiB** cap; when it exceeds the cap the **oldest** events are dropped.
 
 ---
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_AUTHENTICATION.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_AUTHENTICATION.swift.md
@@ -140,7 +140,7 @@ let token = try await client.handleOAuthCallback(code: code, state: state)
   let isNewUser = result.isNewUser ?? false
 ```
 
-`auth.magicLinkRequest(email:redirectUri:)` takes the `redirectUri` as a required argument. `auth.magicLinkVerify(token:)` returns a `MagicLinkVerifyResult` (`.user`, `.promptAddPasskey?`, `.isNewUser?`).
+`auth.magicLinkRequest(email:redirectUri:)` takes the `redirectUri` as a required argument. `auth.magicLinkVerify(token:inviteToken:)` returns a `MagicLinkVerifyResult` (`.user`, `.promptAddPasskey?`, `.isNewUser?`).
 
 ### Reading the token (callback page)
 
@@ -158,6 +158,12 @@ The callback delivers the token as a `magic_token` value — **not** `token`, `m
   }
 ```
 
+
+To accept an invitation server-side at verify time (so the deferred grant resolves to the signing-in user even when emails differ), pass `inviteToken`:
+
+```swift
+let result = try await client.auth.magicLinkVerify(token: magicToken, inviteToken: inviteTokenFromUrl)
+```
 
 ---
 
@@ -323,11 +329,12 @@ The client persists the token to the Keychain across app launches. `waitForAuthB
 
 ```swift
   try await client.auth.logout(options: LogoutOptions(
-    wipeLocal: true // delete locally cached document data + KV cache
+    wipeLocal: true, // delete locally cached document data + KV cache
+    waitForDisconnect: true // wait for the WS to close before resolving
   ))
 ```
 
-`auth.logout(options:)` takes a `LogoutOptions` — `wipeLocal` (delete locally cached document data + KV cache), `revokeOffline` (also revoke any stored offline grant), `clearOfflineIdentity` (defaults `true`).
+`auth.logout(options:)` takes a `LogoutOptions` — `wipeLocal` (delete locally cached document data + KV cache), `revokeOffline` (also revoke any stored offline grant), `clearOfflineIdentity` (defaults `true`), `waitForDisconnect` (await WebSocket teardown before returning; defaults `false`).
 
 ---
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_AUTHENTICATION.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_AUTHENTICATION.template.md
@@ -142,7 +142,7 @@ let token = try await client.handleOAuthCallback(code: code, state: state)
 `magicLinkRequest` accepts an optional `redirectUri` (defaulting to the client's `oauthRedirectUri`) and throws `Error("Redirect URI not configured")` if neither is set.
 {{/lang}}
 {{#lang swift}}
-`auth.magicLinkRequest(email:redirectUri:)` takes the `redirectUri` as a required argument. `auth.magicLinkVerify(token:)` returns a `MagicLinkVerifyResult` (`.user`, `.promptAddPasskey?`, `.isNewUser?`).
+`auth.magicLinkRequest(email:redirectUri:)` takes the `redirectUri` as a required argument. `auth.magicLinkVerify(token:inviteToken:)` returns a `MagicLinkVerifyResult` (`.user`, `.promptAddPasskey?`, `.isNewUser?`).
 {{/lang}}
 
 ### Reading the token (callback page)
@@ -153,11 +153,18 @@ The callback delivers the token as a `magic_token` value — **not** `token`, `m
 
 {{#lang ts}}
 The callback URL may also carry `?purpose=login-add-passkey`. The server appends this when the link was sent for an existing user the platform thinks should add a passkey (e.g. they signed in via OTP/magic-link but have no passkey on file). The `magicLinkVerify` call itself is unchanged — apps that read `purpose` from the URL can use it as a hint to route the user to passkey registration after sign-in instead of straight to the home screen.
+{{/lang}}
 
 To accept an invitation server-side at verify time (so the deferred grant resolves to the signing-in user even when emails differ), pass `inviteToken`:
 
+{{#lang ts}}
 ```typescript
 await client.magicLinkVerify(magicToken, { inviteToken: inviteTokenFromUrl });
+```
+{{/lang}}
+{{#lang swift}}
+```swift
+let result = try await client.auth.magicLinkVerify(token: magicToken, inviteToken: inviteTokenFromUrl)
 ```
 {{/lang}}
 
@@ -418,7 +425,7 @@ await client.logout({
 Logout fires `auth:logout` immediately and `auth:logout:complete` when finished.
 {{/lang}}
 {{#lang swift}}
-`auth.logout(options:)` takes a `LogoutOptions` — `wipeLocal` (delete locally cached document data + KV cache), `revokeOffline` (also revoke any stored offline grant), `clearOfflineIdentity` (defaults `true`).
+`auth.logout(options:)` takes a `LogoutOptions` — `wipeLocal` (delete locally cached document data + KV cache), `revokeOffline` (also revoke any stored offline grant), `clearOfflineIdentity` (defaults `true`), `waitForDisconnect` (await WebSocket teardown before returning; defaults `false`).
 {{/lang}}
 
 ---

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_BLOBS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_BLOBS.swift.md
@@ -169,6 +169,13 @@ let tasks = blobs.uploads()
 _ = blobs.pauseUpload(blobId: blobId)
 _ = blobs.resumeUpload(blobId: blobId)
 
+blobs.pauseAll()
+blobs.resumeAll()
+
+// Concurrency is set on the client (global, all documents)
+client.setBlobUploadConcurrency(5) // min 1; default 2
+_ = client.getBlobUploadConcurrency()
+
 // Warm the local cache; per-blob errors are logged and swallowed
 await blobs.prefetch(blobIds: [blobId1, blobId2], concurrency: 4)
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_BLOBS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_BLOBS.template.md
@@ -364,6 +364,13 @@ let tasks = blobs.uploads()
 _ = blobs.pauseUpload(blobId: blobId)
 _ = blobs.resumeUpload(blobId: blobId)
 
+blobs.pauseAll()
+blobs.resumeAll()
+
+// Concurrency is set on the client (global, all documents)
+client.setBlobUploadConcurrency(5) // min 1; default 2
+_ = client.getBlobUploadConcurrency()
+
 // Warm the local cache; per-blob errors are logged and swallowed
 await blobs.prefetch(blobIds: [blobId1, blobId2], concurrency: 4)
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_CONFIGURATION.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_CONFIGURATION.md
@@ -13,6 +13,19 @@ primitive sync push --dir ./config    # apply local TOML to the server
 
 With project-scoped environments (`.primitive/config.json`), omit `--dir` and the sync directory auto-resolves to `.primitive/sync/<env>/<appId>/` — one isolated slot per environment, so a `pull --env staging` never touches production state.
 
+## Pull snapshots and revert
+
+Every `sync pull` snapshots the sync directory before writing anything; if the snapshot can't be written, the pull aborts with no files changed. Snapshots older than 28 days are pruned automatically. Location follows the sync-dir resolution: in project mode `<projectRoot>/.primitive/sync-backups/<env>/<appId>/` (gitignored local state); with an explicit `--dir`, `<dir>/.snapshots/`.
+
+```bash
+primitive sync revert --list            # enumerate snapshots, newest first
+primitive sync revert                   # restore the most recent
+primitive sync revert --snapshot <id>   # timestamp dirname, or a unique >=8-char prefix
+primitive sync revert -y                # skip the confirmation prompt
+```
+
+`revert` replaces the entire sync directory with the snapshot, including `.primitive-sync.json` (the local sync state). It warns when the config directory has uncommitted git changes (the restore overwrites them), and refuses to restore a partial/corrupted snapshot. After reverting, run `primitive sync diff` to inspect the restored state versus the server.
+
 ## Directory map
 
 ```

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_CONFIGURATION.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_CONFIGURATION.template.md
@@ -13,6 +13,19 @@ primitive sync push --dir ./config    # apply local TOML to the server
 
 With project-scoped environments (`.primitive/config.json`), omit `--dir` and the sync directory auto-resolves to `.primitive/sync/<env>/<appId>/` — one isolated slot per environment, so a `pull --env staging` never touches production state.
 
+## Pull snapshots and revert
+
+Every `sync pull` snapshots the sync directory before writing anything; if the snapshot can't be written, the pull aborts with no files changed. Snapshots older than 28 days are pruned automatically. Location follows the sync-dir resolution: in project mode `<projectRoot>/.primitive/sync-backups/<env>/<appId>/` (gitignored local state); with an explicit `--dir`, `<dir>/.snapshots/`.
+
+```bash
+primitive sync revert --list            # enumerate snapshots, newest first
+primitive sync revert                   # restore the most recent
+primitive sync revert --snapshot <id>   # timestamp dirname, or a unique >=8-char prefix
+primitive sync revert -y                # skip the confirmation prompt
+```
+
+`revert` replaces the entire sync directory with the snapshot, including `.primitive-sync.json` (the local sync state). It warns when the config directory has uncommitted git changes (the restore overwrites them), and refuses to restore a partial/corrupted snapshot. After reverting, run `primitive sync diff` to inspect the restored state versus the server.
+
 ## Directory map
 
 ```

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DEVTOOLS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DEVTOOLS.swift.md
@@ -95,29 +95,30 @@ Create a record by hand:
 
 ### Surfacing your models
 
-Models created with `makeTypedModel(doc:documentId:)` appear in the Records
-table automatically — the base `PrimitiveAppState` conforms to
-`InspectableModelHost`, and its default `inspectableModels` reads the registry
-that `makeTypedModel(...)` populates. The standard path needs no inspector glue.
+Models appear in the Records table automatically — the base `PrimitiveAppState`
+conforms to `InspectableModelHost`, and its default `inspectableModels` reads the
+client's shared cross-document store (one entry per model per open document). A
+model is listed as soon as it's registered (`client.registerModels([...])`) or
+read/written once through its codegen'd facade. The standard path needs no
+inspector glue.
 
-For models that don't go through `makeTypedModel` (a hand-built `BaoModel<T>`,
-a `DynamicModel`), `override` the `open var inspectableModels` and append:
+For a hand-built runtime-schema `DynamicModel` that doesn't go through the
+facade, `override` the `open var inspectableModels` and append:
 
 ```swift
 class MyAppState: PrimitiveAppState {
   override var inspectableModels: [InspectableModel] {
     guard let docId = modelsDocId else { return super.inspectableModels }
-    var out = super.inspectableModels        // keep the auto-registered models
-    if let m = legacyTaskModel { out.append(.from(m, documentId: docId)) }
+    var out = super.inspectableModels        // keep the auto-surfaced models
+    if let m = runtimeTaskModel { out.append(.from(m, documentId: docId)) }
     return out
   }
 }
 ```
 
-`InspectableModel.from(...)` picks the right factory by overload (`TypedModel<T>`,
-`DynamicModel`, or a typed `BaoModel<T>`) and wires `loadAll` / `deleteById` /
-`createWith` so the table, delete buttons, and create form all work with no extra
-code. Field descriptors come from the model's schema.
+`InspectableModel.from(...)` takes the `DynamicModel` and wires `loadAll` /
+`deleteById` / `createWith` so the table, delete buttons, and create form all
+work with no extra code. Field descriptors come from the model's schema.
 
 ## Tests
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DEVTOOLS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DEVTOOLS.template.md
@@ -615,29 +615,30 @@ Create a record by hand:
 
 ### Surfacing your models
 
-Models created with `makeTypedModel(doc:documentId:)` appear in the Records
-table automatically — the base `PrimitiveAppState` conforms to
-`InspectableModelHost`, and its default `inspectableModels` reads the registry
-that `makeTypedModel(...)` populates. The standard path needs no inspector glue.
+Models appear in the Records table automatically — the base `PrimitiveAppState`
+conforms to `InspectableModelHost`, and its default `inspectableModels` reads the
+client's shared cross-document store (one entry per model per open document). A
+model is listed as soon as it's registered (`client.registerModels([...])`) or
+read/written once through its codegen'd facade. The standard path needs no
+inspector glue.
 
-For models that don't go through `makeTypedModel` (a hand-built `BaoModel<T>`,
-a `DynamicModel`), `override` the `open var inspectableModels` and append:
+For a hand-built runtime-schema `DynamicModel` that doesn't go through the
+facade, `override` the `open var inspectableModels` and append:
 
 ```swift
 class MyAppState: PrimitiveAppState {
   override var inspectableModels: [InspectableModel] {
     guard let docId = modelsDocId else { return super.inspectableModels }
-    var out = super.inspectableModels        // keep the auto-registered models
-    if let m = legacyTaskModel { out.append(.from(m, documentId: docId)) }
+    var out = super.inspectableModels        // keep the auto-surfaced models
+    if let m = runtimeTaskModel { out.append(.from(m, documentId: docId)) }
     return out
   }
 }
 ```
 
-`InspectableModel.from(...)` picks the right factory by overload (`TypedModel<T>`,
-`DynamicModel`, or a typed `BaoModel<T>`) and wires `loadAll` / `deleteById` /
-`createWith` so the table, delete buttons, and create form all work with no extra
-code. Field descriptors come from the model's schema.
+`InspectableModel.from(...)` takes the `DynamicModel` and wires `loadAll` /
+`deleteById` / `createWith` so the table, delete buttons, and create form all
+work with no extra code. Field descriptors come from the model's schema.
 
 ## Tests
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.swift.md
@@ -65,7 +65,7 @@ Documents are ready to be queried once the `.open()` call finishes. Applications
 Open only the documents you need to query or want real-time updates from — every open document syncs continuously. Don't open documents you don't need, and close ones you're done with (see [Closing Documents](#closing-documents)).
 
 
-The document-open lifecycle is owned by `PrimitiveAppState` (see [The `PrimitiveAppState` document lifecycle](#the-primitiveappstate-document-lifecycle) below). Subclass it, drive doc setup from `connectClient()`, and bind `TypedModel`s in `onDocumentOpened(doc:documentId:)`. For session-scoped documents (small bounded set), open once at launch; for transient per-item docs, open on view appear and close on disappear.
+The document-open lifecycle is owned by `PrimitiveAppState` (see [The `PrimitiveAppState` document lifecycle](#the-primitiveappstate-document-lifecycle) below). Subclass it and drive doc setup from `connectClient()`; reads and writes go through the codegen'd model facade (`TaskRecord.query(...)`, `record.save(in:)`), so there is no per-document binding step. For session-scoped documents (small bounded set), open once at launch; for transient per-item docs, open on view appear and close on disappear. Stray opens widen query scope — facade queries span every open document by default.
 
 ### 2. Finding documents a user can access
 
@@ -228,7 +228,22 @@ The generated model statics route through the process-wide default client — ca
     sort: AggregateSort(field: "count", direction: -1),
     limit: 10
   ))
+
+  // Grouping by a stringset field counts per member value (facet):
+  let tagCounts = Task.aggregate(AggregateOptions(
+    groupBy: ["tags"],
+    operations: [AggregateOperation(type: .count)]
+  ))
+
+  // Group by whether the set contains a value (membership) — rows carry
+  // a "has_tags_urgent" key of "true" / "false":
+  let urgentSplit = Task.aggregate(AggregateOptions(
+    groupBy: [.stringSetMembership(field: "tags", contains: "urgent")],
+    operations: [AggregateOperation(type: .count)]
+  ))
 ```
+
+Grouping by a `stringset` field counts per member value (facet); a membership `groupBy` entry groups by whether the set contains one specific value. Only one stringset facet field is allowed per aggregation, and a facet can't be mixed with other `groupBy` entries — unsupported mixes degrade (the facet is dropped or the result is empty) rather than throw.
 
 ### Subscribe to changes
 
@@ -329,22 +344,24 @@ List with `me.ownedDocuments()` and `open()` the selected document; create a new
 All documents that need live updates or cross-document queries must be open. Tag documents so you can fetch a set with `me.ownedDocuments({ tag })` (and `me.sharedDocuments({ tag })` if the user can also be a non-owner), open each, and track per-document readiness yourself. For collective sharing of multiple documents as a unit, prefer the server-side Collections API (`client.collections.*` — see [Collections](#collections) below) over local tracking.
 
 
-The most common multi-doc shape is one ambient library/index document plus N per-item documents (each shareable independently); see [Index doc + per-item docs](#index-doc--per-item-docs-keying-tombstones-reconcile) below for keying, tombstones, and the reconcile pass. Open auxiliary docs with `appState.openAuxiliaryDoc(_:modelType:)` and close them with `appState.closeAuxiliaryDoc(_:)`.
+The most common multi-doc shape is one ambient library/index document plus N per-item documents (each shareable independently); see [Index doc + per-item docs](#index-doc--per-item-docs-keying-tombstones-reconcile) below for keying, tombstones, and the reconcile pass. Open auxiliary docs with `appState.openAuxiliaryDoc(_:)` and close them with `appState.closeAuxiliaryDoc(_:)`.
 
 ### The `PrimitiveAppState` document lifecycle
 
-The document-open lifecycle is owned by `PrimitiveAppState`. Subclass it for app-specific state, override `connectClient()` to drive doc setup after connect, and override `onDocumentOpened(doc:documentId:)` to bind `TypedModel`s — the base class opens the doc once and hands you the live `YDocument`, so don't call `openDocument(...)` again just to get one.
+The document-open lifecycle is owned by `PrimitiveAppState`. Subclass it for app-specific state and override `connectClient()` to drive doc setup after connect. Models need no per-document binding — the codegen'd facade statics read from every open document, backed by the process-wide default client (`JsBaoClient.configureDefault`, wired for you during `initialize()`).
 
 ```swift
 @MainActor
 final class MyAppState: PrimitiveAppState {
-    @Published private(set) var todos: TypedModel<TodoItem>?
-
     // connectClient is `open` — call super first (it connects and fetches
     // /me + the document list), then run app-specific setup. Don't reach
     // for a Combine sink on `$isConnected`; this override is the path.
     override func connectClient() async {
         await super.connectClient()
+        // Optional but recommended: pre-register models so every open
+        // document is mirrored into the client's shared store immediately
+        // (the facade also lazily registers on first read).
+        client?.registerModels([TodoItem.self])
         await openLibraryDoc()
     }
 
@@ -358,39 +375,35 @@ final class MyAppState: PrimitiveAppState {
                 alias: DocumentAlias(scope: .user, aliasKey: "library"),
                 title: "Library"
             )
-            // selectDocumentAwaiting opens the doc, routes the base class's
-            // sync hooks at it, and fires onDocumentOpened below.
+            // selectDocumentAwaiting opens the doc and routes the base
+            // class's sync hooks at it; facade reads see it immediately.
             await selectDocumentAwaiting(result.documentId)
         } catch {
             errorMessage = "Failed to open library: \(error.localizedDescription)"
         }
     }
-
-    override func onDocumentOpened(doc: YDocument, documentId: String) async {
-        todos = makeTypedModel(doc: doc, documentId: documentId)
-    }
 }
 ```
 
+For per-document setup beyond models, override the `onDocumentOpened(doc:documentId:)` hook — the base class opens the doc once and hands you the live `YDocument`, so don't call `openDocument(...)` again just to get one.
+
 For a **fresh doc you'll write immediately**, use `client.createDocument(options:)` — it returns `(documentId, doc: YDocument?)` and the returned `YDocument` is writable at once (local-first). Re-opening a freshly-created empty doc with `waitForLoad: .network` parks ~15s waiting for a sync event that never has anything to deliver.
 
-**Multi-doc apps (one ambient library doc + N per-item docs).** `selectDocumentAwaiting(_:)` is the *single*-selected-doc lifecycle — it closes the previously selected doc first, so using it for a per-item detail view closes your library/index doc. For one ambient doc plus transient detail docs, use `appState.openAuxiliaryDoc(_:modelType:)` from the detail view's `.task` and `appState.closeAuxiliaryDoc(_:)` from `.onDisappear`. These register the doc for sync and the inspector picks up the `TypedModel`, but they don't touch `selectedDocId` or fire `onDocumentOpened`:
+**Multi-doc apps (one ambient library doc + N per-item docs).** `selectDocumentAwaiting(_:)` is the *single*-selected-doc lifecycle — it closes the previously selected doc first, so using it for a per-item detail view closes your library/index doc. For one ambient doc plus transient detail docs, use `appState.openAuxiliaryDoc(_:)` from the detail view's `.task` and `appState.closeAuxiliaryDoc(_:)` from `.onDisappear`. These register the doc for sync, but they don't touch `selectedDocId` or fire `onDocumentOpened`. Once open, read the doc's records through the facade scoped to that document:
 
 ```swift
 struct ItemDetailView: View {
     let documentId: String
     @EnvironmentObject var appState: MyAppState
-    @State private var todos: TypedModel<TodoItem>?
+    @State private var todos: [TodoItem]?
 
     var body: some View {
         Group {
             if let todos { /* render */ } else { ProgressView() }
         }
         .task {
-            let (_, model) = try? await appState.openAuxiliaryDoc(
-                documentId, modelType: TodoItem.self
-            )
-            todos = model
+            _ = try? await appState.openAuxiliaryDoc(documentId)
+            todos = TodoItem.query([:], options: QueryOptions(documents: [documentId]))
         }
         .onDisappear { Task { await appState.closeAuxiliaryDoc(documentId) } }
     }
@@ -449,9 +462,9 @@ You can also create a tagged document and filter locally:
 Models are declared in a TOML schema and the client model types are generated from it by codegen. The field types and options are the same across platforms; the schema file, codegen command, and generated artifacts differ.
 
 
-### `schema.toml` + codegen + `TypedModel<T>`
+### `schema.toml` + codegen + the model facade
 
-Define models in `Sources/MyApp/Models/schema.toml`; `swift-bao-codegen` emits one `PrimitiveModel` struct per `[models.X]` block into a gitignored `Models/Generated/`; bind a generated type to an open document with `TypedModel<T>` and do all CRUD/queries through that instance.
+Define models in `Sources/MyApp/Models/schema.toml`; `swift-bao-codegen` emits one `PrimitiveModel` struct per `[models.X]` block into a gitignored `Models/Generated/`. The generated type IS the API: static reads across all open documents (`TodoItem.query(...)`, `find`, `findAll`, `count`, `aggregate`, `subscribe`), instance writes targeting one document (`try record.save(in: documentId)`, `try record.delete(in: documentId)`), backed by the process-wide default client.
 
 ```toml
 [models.todos]
@@ -515,9 +528,9 @@ public extension TodoItem {
 - **No `nil` in CRDT-backed fields** — the CRDT layer doesn't model `nil`. Use `""` for absent strings, `0` for absent numbers, sentinel timestamps for "never", and check those values explicitly.
 - **Wire field names are forever.** TOML keys are the wire field names; renaming a key after data is on disk orphans every existing record (Swift *and* JS clients reading the same doc). **snake_case is the cross-client convention** when web/Node and Swift read the same doc; **camelCase is fine for Swift-only docs**. The tool preserves whatever you write — add camelCase aliases in the companion if snake_case wire keys read awkwardly.
 - **IDs are `String`** — supply `UUID().uuidString` (or a ULID) when not provided.
-- Bind via `appState.makeTypedModel(doc:documentId:)`, not `TypedModel<T>(doc:)` directly, so the model registers with the in-app debug inspector. One `TypedModel` per record type per document.
+- Register models with `client.registerModels([TodoItem.self])` at connect time (or rely on the facade's lazy registration on first read) — registered models are mirrored into the client's shared store and listed in the in-app debug inspector automatically.
 
-CRUD through the bound `TypedModel<T>` is local-first (applied to the CRDT immediately, synced in the background). `create` is the only method that throws — it validates the new record against the schema; `update`/`delete` operate on already-validated records (a misspelled key in an `update` payload is dropped silently, not thrown). Reads (`find`, `findAll`, `query(["completed": false], options: QueryOptions(sort: ["sortOrder": 1], limit: 50))`, `count`) are synchronous against the local CRDT and `@MainActor`-isolated. Predicate operators: equality, `$gt`/`$gte`/`$lt`/`$lte`, `$containsText`, `$or`/`$and`/`$not`.
+CRUD through the facade is local-first (applied to the CRDT immediately, synced in the background). Writes throw — `try record.save(in: documentId)` inserts or updates in place and returns `self`; `save(in:upsertOn:)` matches on a single-field unique constraint instead of `id`; `try record.delete(in: documentId)`; all three throw if the target document isn't open. Reads (`find`, `findAll`, `queryOne`, `query(["completed": false], options: QueryOptions(sort: ["sortOrder": 1], limit: 50))`, `count`) are synchronous, span every open document by default (scope with `QueryOptions(documents: [...])`), and are `@MainActor`-isolated. Predicate operators: equality, `$gt`/`$gte`/`$lt`/`$lte`, `$containsText`, `$or`/`$and`/`$not`.
 
 > **SourceKit footgun, first time only.** Editing the companion before codegen has ever run shows a red `No such module 'PrimitiveApp'` underline. The real cause is that the generated type doesn't exist yet — run `swift build` once (or the `run-ios.sh` codegen step) and it clears. Only the very first scaffold hits this.
 
@@ -620,27 +633,27 @@ struct TodoListView: View {
             case .loaded(let todos): List(todos) { /* row */ }
             }
         }
-        // `.task(id:)`, NOT a bare `.task`. `appState.todos` is bound
-        // asynchronously in `onDocumentOpened` (after connect + doc open),
-        // so it's nil on first appearance. A bare `.task { guard let … else
-        // { return } }` runs once, sees nil, bails, and never binds — the
-        // screen sticks on its spinner. Keying the task on readiness re-runs
-        // it the instant the model arrives. (Or gate the subtree behind
-        // `ReadyGate(appState.todos) { _ in … }` and use a plain `.task`.)
-        .task(id: appState.todos == nil) {
-            guard let todos = appState.todos else { return }
+        // Bind once, from a plain `.task`. Don't conditionally bind on
+        // doc readiness — set `loader.documentReady` instead: the loader
+        // fires its initial load when it flips to true, and resets
+        // `initialDataLoaded` if the doc closes.
+        .task {
+            loader.documentReady = appState.selectedDocId != nil
             loader.bind(
                 client: appState.client,
-                subscribeTo: [.onModelChange(todos)]
+                subscribeTo: [.onModel(subscribe: TodoItem.subscribe)]
             ) { _ in
-                todos.findAll().sorted { $0.sortOrder < $1.sortOrder }
+                TodoItem.findAll().sorted { $0.sortOrder < $1.sortOrder }
             }
+        }
+        .onChange(of: appState.selectedDocId) { _, id in
+            loader.documentReady = id != nil
         }
     }
 }
 ```
 
-`.onModelChange(model)` fires on **any** add/update/delete on that model — local writes (synchronous) and remote writes (observer drain) both — so `reloadNow()` after a write is unneeded; call it only when the `load` closure reads something the loader can't subscribe to (a REST resource). Other triggers (`LoaderTrigger`): `.onSync`, `.onRemoteUpdate`, `.onDocumentEvents`, `.onConnect`, and `.custom((client, reload) -> EventSubscription?)`.
+`.onModel(subscribe: TodoItem.subscribe)` fires on **any** add/update/delete recorded in that model's shared store — local writes and remote writes both — so `reloadNow()` after a write is unneeded; call it only when the `load` closure reads something the loader can't subscribe to (a REST resource). Other triggers (`LoaderTrigger`): `.onSync`, `.onRemoteUpdate`, `.onDocumentEvents`, `.onConnect`, `.onModelChange(_:)` for a hand-built runtime-schema `DynamicModel`, and `.custom((client, reload) -> EventSubscription?)`.
 
 `loader.phase` is a trinary: `.loading` (first load not complete), `.empty` (first load complete, data conforms to `LoaderEmptiness` and is empty), `.loaded(Data)`. `[T]`, `String`, and `Optional` get `LoaderEmptiness` out of the box.
 
@@ -654,7 +667,7 @@ struct TodoListView: View {
 
 ## Saving Data
 
-Writes go through the bound `TypedModel<T>` and are local-first — applied to the CRDT immediately and synced in the background (see [`schema.toml` + codegen + `TypedModel<T>`](#schematoml--codegen--typedmodelt) for the create/update/delete contract). `save()` uses merge semantics: only the fields you set are written; unset fields are preserved.
+Writes go through record instances and are local-first — applied to the CRDT immediately and synced in the background (see [`schema.toml` + codegen + the model facade](#schematoml--codegen--the-model-facade) for the save/delete contract). `try record.save(in: documentId)` uses merge semantics: `nil` optional fields are not written, so fields you didn't set are preserved on update.
 
 
 ## Design Patterns
@@ -849,6 +862,17 @@ Repeated email-based calls are idempotent: a second `updatePermissions(documentI
 
 **There is no `permission: null` to remove.** Removal is a separate call (`removePermission` by userId or by email; `transferOwnership` to hand a document to a new owner):
 
+```swift
+// Remove a current member by userId (a bare string literal also works):
+try await client.documents.removePermission(documentId: documentId, .userId("user-abc"))
+
+// Cancel a pending email-based invite, OR remove a current member matched by email:
+try await client.documents.removePermission(documentId: documentId, .email("alice@example.com"))
+
+try await client.documents.transferOwnership(documentId: documentId, newOwnerId: newOwnerId)
+```
+
+There is no `setPermissions`, and `updatePermissions` with a lower permission does **not** lower a higher group-derived permission — the user keeps access via the group.
 
 Lowering a user's direct permission while they still have a higher one via a group is a no-op — the group wins (effective = MAX). To actually lower it, also lower or revoke the group permission.
 
@@ -1014,7 +1038,7 @@ The canonical sharing panel: people with access + people invited but not yet sig
 
 `accessibleDocumentSummaries` does the merged owned + shared set in one call.
 
-For **writes**, use the typed params factories — `documents.updatePermissions(documentId:params: .email("…", permission: "read-write", sendEmail: false, documentUrl: …))` (or `.user(…)` / `.batch([…])`) and `collections.addMember(collectionId:params: .email("…", permission: .readWrite))` (or `.user(…)`). To cancel a pending email invite, read the row's `deferredId` via `pendingInvitationSummaries(...)`, then `client.invitations.revokeDeferredGrant(deferredId:type:)` (`.document` for a per-doc invite, `.group` for a collection one).
+For **writes**, use the typed params factories — `documents.updatePermissions(documentId:params: .email("…", permission: "read-write", sendEmail: false, documentUrl: …))` (or `.user(…)` / `.batch([…])`) and `collections.addMember(collectionId:params: .email("…", permission: .readWrite))` (or `.user(…)`). To cancel a pending email invite on a document, call `documents.removePermission(documentId:, .email("…"))`; alternatively, read the row's `deferredId` via `pendingInvitationSummaries(...)` and call `client.invitations.revokeDeferredGrant(deferredId:type:)` (`.document` for a per-doc invite, `.group` for a collection one).
 
 ### Sharing Discovery Cheat Sheet
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.template.md
@@ -93,7 +93,7 @@ const result = await TodoItem.query({});         // throws DocumentClosedError o
 {{/lang}}
 
 {{#lang swift}}
-The document-open lifecycle is owned by `PrimitiveAppState` (see [The `PrimitiveAppState` document lifecycle](#the-primitiveappstate-document-lifecycle) below). Subclass it, drive doc setup from `connectClient()`, and bind `TypedModel`s in `onDocumentOpened(doc:documentId:)`. For session-scoped documents (small bounded set), open once at launch; for transient per-item docs, open on view appear and close on disappear.
+The document-open lifecycle is owned by `PrimitiveAppState` (see [The `PrimitiveAppState` document lifecycle](#the-primitiveappstate-document-lifecycle) below). Subclass it and drive doc setup from `connectClient()`; reads and writes go through the codegen'd model facade (`TaskRecord.query(...)`, `record.save(in:)`), so there is no per-document binding step. For session-scoped documents (small bounded set), open once at launch; for transient per-item docs, open on view appear and close on disappear. Stray opens widen query scope — facade queries span every open document by default.
 {{/lang}}
 
 ### 2. Finding documents a user can access
@@ -179,6 +179,8 @@ The generated model statics route through the process-wide default client — ca
 ### Aggregation
 
 {{ example: documents/aggregate }}
+
+Grouping by a `stringset` field counts per member value (facet); a membership `groupBy` entry groups by whether the set contains one specific value. Only one stringset facet field is allowed per aggregation, and a facet can't be mixed with other `groupBy` entries — unsupported mixes degrade (the facet is dropped or the result is empty) rather than throw.
 
 ### Subscribe to changes
 
@@ -304,22 +306,24 @@ The same pattern adapts to "the K most recent" or "channels the user belongs to"
 {{/lang}}
 
 {{#lang swift}}
-The most common multi-doc shape is one ambient library/index document plus N per-item documents (each shareable independently); see [Index doc + per-item docs](#index-doc--per-item-docs-keying-tombstones-reconcile) below for keying, tombstones, and the reconcile pass. Open auxiliary docs with `appState.openAuxiliaryDoc(_:modelType:)` and close them with `appState.closeAuxiliaryDoc(_:)`.
+The most common multi-doc shape is one ambient library/index document plus N per-item documents (each shareable independently); see [Index doc + per-item docs](#index-doc--per-item-docs-keying-tombstones-reconcile) below for keying, tombstones, and the reconcile pass. Open auxiliary docs with `appState.openAuxiliaryDoc(_:)` and close them with `appState.closeAuxiliaryDoc(_:)`.
 
 ### The `PrimitiveAppState` document lifecycle
 
-The document-open lifecycle is owned by `PrimitiveAppState`. Subclass it for app-specific state, override `connectClient()` to drive doc setup after connect, and override `onDocumentOpened(doc:documentId:)` to bind `TypedModel`s — the base class opens the doc once and hands you the live `YDocument`, so don't call `openDocument(...)` again just to get one.
+The document-open lifecycle is owned by `PrimitiveAppState`. Subclass it for app-specific state and override `connectClient()` to drive doc setup after connect. Models need no per-document binding — the codegen'd facade statics read from every open document, backed by the process-wide default client (`JsBaoClient.configureDefault`, wired for you during `initialize()`).
 
 ```swift
 @MainActor
 final class MyAppState: PrimitiveAppState {
-    @Published private(set) var todos: TypedModel<TodoItem>?
-
     // connectClient is `open` — call super first (it connects and fetches
     // /me + the document list), then run app-specific setup. Don't reach
     // for a Combine sink on `$isConnected`; this override is the path.
     override func connectClient() async {
         await super.connectClient()
+        // Optional but recommended: pre-register models so every open
+        // document is mirrored into the client's shared store immediately
+        // (the facade also lazily registers on first read).
+        client?.registerModels([TodoItem.self])
         await openLibraryDoc()
     }
 
@@ -333,39 +337,35 @@ final class MyAppState: PrimitiveAppState {
                 alias: DocumentAlias(scope: .user, aliasKey: "library"),
                 title: "Library"
             )
-            // selectDocumentAwaiting opens the doc, routes the base class's
-            // sync hooks at it, and fires onDocumentOpened below.
+            // selectDocumentAwaiting opens the doc and routes the base
+            // class's sync hooks at it; facade reads see it immediately.
             await selectDocumentAwaiting(result.documentId)
         } catch {
             errorMessage = "Failed to open library: \(error.localizedDescription)"
         }
     }
-
-    override func onDocumentOpened(doc: YDocument, documentId: String) async {
-        todos = makeTypedModel(doc: doc, documentId: documentId)
-    }
 }
 ```
 
+For per-document setup beyond models, override the `onDocumentOpened(doc:documentId:)` hook — the base class opens the doc once and hands you the live `YDocument`, so don't call `openDocument(...)` again just to get one.
+
 For a **fresh doc you'll write immediately**, use `client.createDocument(options:)` — it returns `(documentId, doc: YDocument?)` and the returned `YDocument` is writable at once (local-first). Re-opening a freshly-created empty doc with `waitForLoad: .network` parks ~15s waiting for a sync event that never has anything to deliver.
 
-**Multi-doc apps (one ambient library doc + N per-item docs).** `selectDocumentAwaiting(_:)` is the *single*-selected-doc lifecycle — it closes the previously selected doc first, so using it for a per-item detail view closes your library/index doc. For one ambient doc plus transient detail docs, use `appState.openAuxiliaryDoc(_:modelType:)` from the detail view's `.task` and `appState.closeAuxiliaryDoc(_:)` from `.onDisappear`. These register the doc for sync and the inspector picks up the `TypedModel`, but they don't touch `selectedDocId` or fire `onDocumentOpened`:
+**Multi-doc apps (one ambient library doc + N per-item docs).** `selectDocumentAwaiting(_:)` is the *single*-selected-doc lifecycle — it closes the previously selected doc first, so using it for a per-item detail view closes your library/index doc. For one ambient doc plus transient detail docs, use `appState.openAuxiliaryDoc(_:)` from the detail view's `.task` and `appState.closeAuxiliaryDoc(_:)` from `.onDisappear`. These register the doc for sync, but they don't touch `selectedDocId` or fire `onDocumentOpened`. Once open, read the doc's records through the facade scoped to that document:
 
 ```swift
 struct ItemDetailView: View {
     let documentId: String
     @EnvironmentObject var appState: MyAppState
-    @State private var todos: TypedModel<TodoItem>?
+    @State private var todos: [TodoItem]?
 
     var body: some View {
         Group {
             if let todos { /* render */ } else { ProgressView() }
         }
         .task {
-            let (_, model) = try? await appState.openAuxiliaryDoc(
-                documentId, modelType: TodoItem.self
-            )
-            todos = model
+            _ = try? await appState.openAuxiliaryDoc(documentId)
+            todos = TodoItem.query([:], options: QueryOptions(documents: [documentId]))
         }
         .onDisappear { Task { await appState.closeAuxiliaryDoc(documentId) } }
     }
@@ -463,9 +463,9 @@ import { Todo } from "@/models";
 {{/lang}}
 
 {{#lang swift}}
-### `schema.toml` + codegen + `TypedModel<T>`
+### `schema.toml` + codegen + the model facade
 
-Define models in `Sources/MyApp/Models/schema.toml`; `swift-bao-codegen` emits one `PrimitiveModel` struct per `[models.X]` block into a gitignored `Models/Generated/`; bind a generated type to an open document with `TypedModel<T>` and do all CRUD/queries through that instance.
+Define models in `Sources/MyApp/Models/schema.toml`; `swift-bao-codegen` emits one `PrimitiveModel` struct per `[models.X]` block into a gitignored `Models/Generated/`. The generated type IS the API: static reads across all open documents (`TodoItem.query(...)`, `find`, `findAll`, `count`, `aggregate`, `subscribe`), instance writes targeting one document (`try record.save(in: documentId)`, `try record.delete(in: documentId)`), backed by the process-wide default client.
 
 ```toml
 [models.todos]
@@ -529,9 +529,9 @@ public extension TodoItem {
 - **No `nil` in CRDT-backed fields** — the CRDT layer doesn't model `nil`. Use `""` for absent strings, `0` for absent numbers, sentinel timestamps for "never", and check those values explicitly.
 - **Wire field names are forever.** TOML keys are the wire field names; renaming a key after data is on disk orphans every existing record (Swift *and* JS clients reading the same doc). **snake_case is the cross-client convention** when web/Node and Swift read the same doc; **camelCase is fine for Swift-only docs**. The tool preserves whatever you write — add camelCase aliases in the companion if snake_case wire keys read awkwardly.
 - **IDs are `String`** — supply `UUID().uuidString` (or a ULID) when not provided.
-- Bind via `appState.makeTypedModel(doc:documentId:)`, not `TypedModel<T>(doc:)` directly, so the model registers with the in-app debug inspector. One `TypedModel` per record type per document.
+- Register models with `client.registerModels([TodoItem.self])` at connect time (or rely on the facade's lazy registration on first read) — registered models are mirrored into the client's shared store and listed in the in-app debug inspector automatically.
 
-CRUD through the bound `TypedModel<T>` is local-first (applied to the CRDT immediately, synced in the background). `create` is the only method that throws — it validates the new record against the schema; `update`/`delete` operate on already-validated records (a misspelled key in an `update` payload is dropped silently, not thrown). Reads (`find`, `findAll`, `query(["completed": false], options: QueryOptions(sort: ["sortOrder": 1], limit: 50))`, `count`) are synchronous against the local CRDT and `@MainActor`-isolated. Predicate operators: equality, `$gt`/`$gte`/`$lt`/`$lte`, `$containsText`, `$or`/`$and`/`$not`.
+CRUD through the facade is local-first (applied to the CRDT immediately, synced in the background). Writes throw — `try record.save(in: documentId)` inserts or updates in place and returns `self`; `save(in:upsertOn:)` matches on a single-field unique constraint instead of `id`; `try record.delete(in: documentId)`; all three throw if the target document isn't open. Reads (`find`, `findAll`, `queryOne`, `query(["completed": false], options: QueryOptions(sort: ["sortOrder": 1], limit: 50))`, `count`) are synchronous, span every open document by default (scope with `QueryOptions(documents: [...])`), and are `@MainActor`-isolated. Predicate operators: equality, `$gt`/`$gte`/`$lt`/`$lte`, `$containsText`, `$or`/`$and`/`$not`.
 
 > **SourceKit footgun, first time only.** Editing the companion before codegen has ever run shows a red `No such module 'PrimitiveApp'` underline. The real cause is that the generated type doesn't exist yet — run `swift build` once (or the `run-ios.sh` codegen step) and it clears. Only the very first scaffold hits this.
 {{/lang}}
@@ -980,27 +980,27 @@ struct TodoListView: View {
             case .loaded(let todos): List(todos) { /* row */ }
             }
         }
-        // `.task(id:)`, NOT a bare `.task`. `appState.todos` is bound
-        // asynchronously in `onDocumentOpened` (after connect + doc open),
-        // so it's nil on first appearance. A bare `.task { guard let … else
-        // { return } }` runs once, sees nil, bails, and never binds — the
-        // screen sticks on its spinner. Keying the task on readiness re-runs
-        // it the instant the model arrives. (Or gate the subtree behind
-        // `ReadyGate(appState.todos) { _ in … }` and use a plain `.task`.)
-        .task(id: appState.todos == nil) {
-            guard let todos = appState.todos else { return }
+        // Bind once, from a plain `.task`. Don't conditionally bind on
+        // doc readiness — set `loader.documentReady` instead: the loader
+        // fires its initial load when it flips to true, and resets
+        // `initialDataLoaded` if the doc closes.
+        .task {
+            loader.documentReady = appState.selectedDocId != nil
             loader.bind(
                 client: appState.client,
-                subscribeTo: [.onModelChange(todos)]
+                subscribeTo: [.onModel(subscribe: TodoItem.subscribe)]
             ) { _ in
-                todos.findAll().sorted { $0.sortOrder < $1.sortOrder }
+                TodoItem.findAll().sorted { $0.sortOrder < $1.sortOrder }
             }
+        }
+        .onChange(of: appState.selectedDocId) { _, id in
+            loader.documentReady = id != nil
         }
     }
 }
 ```
 
-`.onModelChange(model)` fires on **any** add/update/delete on that model — local writes (synchronous) and remote writes (observer drain) both — so `reloadNow()` after a write is unneeded; call it only when the `load` closure reads something the loader can't subscribe to (a REST resource). Other triggers (`LoaderTrigger`): `.onSync`, `.onRemoteUpdate`, `.onDocumentEvents`, `.onConnect`, and `.custom((client, reload) -> EventSubscription?)`.
+`.onModel(subscribe: TodoItem.subscribe)` fires on **any** add/update/delete recorded in that model's shared store — local writes and remote writes both — so `reloadNow()` after a write is unneeded; call it only when the `load` closure reads something the loader can't subscribe to (a REST resource). Other triggers (`LoaderTrigger`): `.onSync`, `.onRemoteUpdate`, `.onDocumentEvents`, `.onConnect`, `.onModelChange(_:)` for a hand-built runtime-schema `DynamicModel`, and `.custom((client, reload) -> EventSubscription?)`.
 
 `loader.phase` is a trinary: `.loading` (first load not complete), `.empty` (first load complete, data conforms to `LoaderEmptiness` and is empty), `.loaded(Data)`. `[T]`, `String`, and `Optional` get `LoaderEmptiness` out of the box.
 
@@ -1016,7 +1016,7 @@ struct TodoListView: View {
 ## Saving Data
 
 {{#lang swift}}
-Writes go through the bound `TypedModel<T>` and are local-first — applied to the CRDT immediately and synced in the background (see [`schema.toml` + codegen + `TypedModel<T>`](#schematoml--codegen--typedmodelt) for the create/update/delete contract). `save()` uses merge semantics: only the fields you set are written; unset fields are preserved.
+Writes go through record instances and are local-first — applied to the CRDT immediately and synced in the background (see [`schema.toml` + codegen + the model facade](#schematoml--codegen--the-model-facade) for the save/delete contract). `try record.save(in: documentId)` uses merge semantics: `nil` optional fields are not written, so fields you didn't set are preserved on update.
 {{/lang}}
 
 {{#lang ts}}
@@ -1490,6 +1490,19 @@ await client.documents.updatePermissions(documentId, {
 // Correct: also lower or revoke the group permission.
 ```
 {{/lang}}
+{{#lang swift}}
+```swift
+// Remove a current member by userId (a bare string literal also works):
+try await client.documents.removePermission(documentId: documentId, .userId("user-abc"))
+
+// Cancel a pending email-based invite, OR remove a current member matched by email:
+try await client.documents.removePermission(documentId: documentId, .email("alice@example.com"))
+
+try await client.documents.transferOwnership(documentId: documentId, newOwnerId: newOwnerId)
+```
+
+There is no `setPermissions`, and `updatePermissions` with a lower permission does **not** lower a higher group-derived permission — the user keeps access via the group.
+{{/lang}}
 
 Lowering a user's direct permission while they still have a higher one via a group is a no-op — the group wins (effective = MAX). To actually lower it, also lower or revoke the group permission.
 
@@ -1824,7 +1837,7 @@ await client.invitations.delete(invitationId);
 
 `accessibleDocumentSummaries` does the merged owned + shared set in one call.
 
-For **writes**, use the typed params factories — `documents.updatePermissions(documentId:params: .email("…", permission: "read-write", sendEmail: false, documentUrl: …))` (or `.user(…)` / `.batch([…])`) and `collections.addMember(collectionId:params: .email("…", permission: .readWrite))` (or `.user(…)`). To cancel a pending email invite, read the row's `deferredId` via `pendingInvitationSummaries(...)`, then `client.invitations.revokeDeferredGrant(deferredId:type:)` (`.document` for a per-doc invite, `.group` for a collection one).
+For **writes**, use the typed params factories — `documents.updatePermissions(documentId:params: .email("…", permission: "read-write", sendEmail: false, documentUrl: …))` (or `.user(…)` / `.batch([…])`) and `collections.addMember(collectionId:params: .email("…", permission: .readWrite))` (or `.user(…)`). To cancel a pending email invite on a document, call `documents.removePermission(documentId:, .email("…"))`; alternatively, read the row's `deferredId` via `pendingInvitationSummaries(...)` and call `client.invitations.revokeDeferredGrant(deferredId:type:)` (`.document` for a per-doc invite, `.group` for a collection one).
 {{/lang}}
 
 ### Sharing Discovery Cheat Sheet

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.ts.md
@@ -265,7 +265,21 @@ Every example below is compiled against the real client as part of the docs buil
     sort: { field: "count", direction: -1 },
     limit: 10,
   });
+
+  // Grouping by a stringset field counts per member value (facet):
+  const tagCounts = await Task.aggregate({
+    groupBy: ["tags"],
+    operations: [{ type: "count" }],
+  });
+
+  // Group by whether the set contains a value (membership):
+  const urgentSplit = await Task.aggregate({
+    groupBy: [{ field: "tags", contains: "urgent" }],
+    operations: [{ type: "count" }],
+  });
 ```
+
+Grouping by a `stringset` field counts per member value (facet); a membership `groupBy` entry groups by whether the set contains one specific value. Only one stringset facet field is allowed per aggregation, and a facet can't be mixed with other `groupBy` entries — unsupported mixes degrade (the facet is dropped or the result is empty) rather than throw.
 
 ### Subscribe to changes
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.swift.md
@@ -181,12 +181,12 @@ The current authenticated user has its own namespace. Use it for "me"-scoped rea
   )
 
   // Upload an image directly; the server hosts it and returns a URL.
-  let uploaded = try await client.me.uploadAvatar(imageData: avatar, contentType: "image/png")
+  let uploaded = try await client.me.uploadAvatar(imageData: avatar, contentType: .png)
   let avatarUrl = uploaded.avatarUrl
 
   // update() and uploadAvatar() clear the cache automatically; reach for
   // these only when you need to inspect or force a refresh yourself.
-  let info = await client.me.cacheInfo()  // (updatedAt?, ageMs?)
+  let info = await client.me.cacheInfo()  // MeCacheInfo(updatedAt?, ageMs?)
   await client.me.clearCache()  // next get() hits the network
 ```
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.swift.md
@@ -589,6 +589,7 @@ primitive sync push --dir ./config
 | `user.role` | yes | Requesting user's app role (`"owner"` / `"admin"` / `"member"`). NOT `user.appRole`. |
 | `group.groupType` | yes | Target group's type |
 | `group.groupId` | yes | Target group's ID (also present at `create` time — server passes the requested ID) |
+| `group.contextId` | yes | Read-alias of `group.groupId` — the same value under the `contextId` name collection rules use, so group and collection rule sets can share expressions |
 | `group.name` | yes | Target group's display name |
 | `group.createdBy` | yes (after create) | userId of the group creator |
 | `target.userId` | only `category: "member"`, ops `create`/`edit`/`delete` | Target user being added/removed. Absent for `member.list`. |

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.template.md
@@ -454,6 +454,7 @@ primitive sync push --dir ./config
 | `user.role` | yes | Requesting user's app role (`"owner"` / `"admin"` / `"member"`). NOT `user.appRole`. |
 | `group.groupType` | yes | Target group's type |
 | `group.groupId` | yes | Target group's ID (also present at `create` time — server passes the requested ID) |
+| `group.contextId` | yes | Read-alias of `group.groupId` — the same value under the `contextId` name collection rules use, so group and collection rule sets can share expressions |
 | `group.name` | yes | Target group's display name |
 | `group.createdBy` | yes (after create) | userId of the group creator |
 | `target.userId` | only `category: "member"`, ops `create`/`edit`/`delete` | Target user being added/removed. Absent for `member.list`. |

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.ts.md
@@ -572,6 +572,7 @@ primitive sync push --dir ./config
 | `user.role` | yes | Requesting user's app role (`"owner"` / `"admin"` / `"member"`). NOT `user.appRole`. |
 | `group.groupType` | yes | Target group's type |
 | `group.groupId` | yes | Target group's ID (also present at `create` time — server passes the requested ID) |
+| `group.contextId` | yes | Read-alias of `group.groupId` — the same value under the `contextId` name collection rules use, so group and collection rule sets can share expressions |
 | `group.name` | yes | Target group's display name |
 | `group.createdBy` | yes (after create) | userId of the group creator |
 | `target.userId` | only `category: "member"`, ops `create`/`edit`/`delete` | Target user being added/removed. Absent for `member.list`. |

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.swift.md
@@ -1310,21 +1310,17 @@ The `workflowStatus` event uses `"completed"`; `getStatus` returns `"complete"`.
 For workflows with `requiresClientApply = true`, register an apply handler so a client deterministically runs follow-up logic exactly once.
 
 
-For "start a run and await its result", use `runAndApply`. It tracks each call by `runKey` (so N concurrent runs of the same `workflowKey` coexist), runs the full claim → getStatus → confirm flow internally, and returns a `WorkflowApplyContext` carrying the output:
-
 ```swift
-let ctx = try await client.workflows.runAndApply(
-    workflowKey: "ocr-content",
-    input: ["attachments": [["data": image.base64EncodedString(), "type": "image/jpeg"]]],
-    options: StartWorkflowOptions(contextDocId: documentId),
-    timeout: 120                          // default 120s; raise for slow LLM workflows
-)
-let output = ctx.output                   // Any? — cast to the final step's JSON shape
-// Terminal non-success throws WorkflowRunError.terminalFailure(status:message:);
-// missing output within the window throws .timedOut; task cancellation propagates.
+client.workflows.define("my-workflow-key") { ctx in
+    // Runs on exactly one connected client: the client claims the lease,
+    // fetches the run output, calls this handler, then confirms the apply.
+    // A thrown error releases the claim so another client (or a retry)
+    // can pick it up.
+    // ctx: workflowKey, runKey, runId, contextDocId?, output, startedByUserId?, meta?
+}
 ```
 
-Use the lower-level `define` + `start` pair when you need a long-lived per-`workflowKey` handler rather than a per-call awaiter. When you do, the mandatory guards are: **register `define(...)` before `start(...)`** (else the apply may deliver before you subscribe); **guard the handler on a matching `runKey`** (a `.workflowStatus` event from a prior app session can otherwise resolve a fresh continuation); and a **`resolved` flag** (server retries can fire the handler more than once, and a `CheckedContinuation` traps on double-resume). If the device was offline when the server finished the run, call `client.workflows.deliverPendingApplies(contextDocId:)` after reconnect to drive the queued apply.
+Register `define(...)` before `start(...)` so the apply can't arrive before the handler is in place. After an offline gap, `getPendingApplies(contextDocId:)` lists runs still awaiting apply.
 
 Manual flow if you need it: `claimApply` → run logic → `confirmApply` (success) or `releaseApply` (failure). 30s lease timeout for crashed clients.
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.swift.md
@@ -175,6 +175,8 @@ text = "Summarize: {{ input.content }}"
 
 `prompt` may be an object (forwarded as the body) or an array of messages. `gemini.generateRaw` is the same shape, forwarded as a raw API payload. `gemini.countTokens` returns a token count.
 
+The effective model — `prompt.model` when `prompt` is an object, otherwise the top-level `model` — is validated against the server's Gemini model allow-list **at save time**: a disallowed model rejects the workflow save (the error names the step index and lists the allowed models) instead of failing at run time. A model containing template syntax resolves at run time and is validated then.
+
 ### `prompt.execute`
 
 Execute a managed prompt (configured separately via the prompts API/CLI).

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md
@@ -1248,21 +1248,17 @@ Manual flow if you need it: `claimApply` → run logic → `confirmApply` (succe
 {{/lang}}
 
 {{#lang swift}}
-For "start a run and await its result", use `runAndApply`. It tracks each call by `runKey` (so N concurrent runs of the same `workflowKey` coexist), runs the full claim → getStatus → confirm flow internally, and returns a `WorkflowApplyContext` carrying the output:
-
 ```swift
-let ctx = try await client.workflows.runAndApply(
-    workflowKey: "ocr-content",
-    input: ["attachments": [["data": image.base64EncodedString(), "type": "image/jpeg"]]],
-    options: StartWorkflowOptions(contextDocId: documentId),
-    timeout: 120                          // default 120s; raise for slow LLM workflows
-)
-let output = ctx.output                   // Any? — cast to the final step's JSON shape
-// Terminal non-success throws WorkflowRunError.terminalFailure(status:message:);
-// missing output within the window throws .timedOut; task cancellation propagates.
+client.workflows.define("my-workflow-key") { ctx in
+    // Runs on exactly one connected client: the client claims the lease,
+    // fetches the run output, calls this handler, then confirms the apply.
+    // A thrown error releases the claim so another client (or a retry)
+    // can pick it up.
+    // ctx: workflowKey, runKey, runId, contextDocId?, output, startedByUserId?, meta?
+}
 ```
 
-Use the lower-level `define` + `start` pair when you need a long-lived per-`workflowKey` handler rather than a per-call awaiter. When you do, the mandatory guards are: **register `define(...)` before `start(...)`** (else the apply may deliver before you subscribe); **guard the handler on a matching `runKey`** (a `.workflowStatus` event from a prior app session can otherwise resolve a fresh continuation); and a **`resolved` flag** (server retries can fire the handler more than once, and a `CheckedContinuation` traps on double-resume). If the device was offline when the server finished the run, call `client.workflows.deliverPendingApplies(contextDocId:)` after reconnect to drive the queued apply.
+Register `define(...)` before `start(...)` so the apply can't arrive before the handler is in place. After an offline gap, `getPendingApplies(contextDocId:)` lists runs still awaiting apply.
 
 Manual flow if you need it: `claimApply` → run logic → `confirmApply` (success) or `releaseApply` (failure). 30s lease timeout for crashed clients.
 {{/lang}}

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md
@@ -175,6 +175,8 @@ text = "Summarize: {{ input.content }}"
 
 `prompt` may be an object (forwarded as the body) or an array of messages. `gemini.generateRaw` is the same shape, forwarded as a raw API payload. `gemini.countTokens` returns a token count.
 
+The effective model — `prompt.model` when `prompt` is an object, otherwise the top-level `model` — is validated against the server's Gemini model allow-list **at save time**: a disallowed model rejects the workflow save (the error names the step index and lists the allowed models) instead of failing at run time. A model containing template syntax resolves at run time and is validated then.
+
 ### `prompt.execute`
 
 Execute a managed prompt (configured separately via the prompts API/CLI).

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.ts.md
@@ -175,6 +175,8 @@ text = "Summarize: {{ input.content }}"
 
 `prompt` may be an object (forwarded as the body) or an array of messages. `gemini.generateRaw` is the same shape, forwarded as a raw API payload. `gemini.countTokens` returns a token count.
 
+The effective model — `prompt.model` when `prompt` is an object, otherwise the top-level `model` — is validated against the server's Gemini model allow-list **at save time**: a disallowed model rejects the workflow save (the error names the step index and lists the allowed models) instead of failing at run time. A model containing template syntax resolves at run time and is validated then.
+
 ### `prompt.execute`
 
 Execute a managed prompt (configured separately via the prompts API/CLI).

--- a/guides/latest/guides.json
+++ b/guides/latest/guides.json
@@ -7,9 +7,9 @@
     "stampedAt": "2026-06-05",
     "channel": "next",
     "packages": {
-      "js-bao-wss-client": "2.0.0",
+      "js-bao-wss-client": "2.0.1",
       "js-bao": "0.5.1",
-      "primitive-admin": "1.0.49",
+      "primitive-admin": "1.0.50",
       "primitive-app": "3.0.1"
     }
   },


### PR DESCRIPTION
## Summary

Two passes on `next`, one commit each:

### 1. Backfill: Production release 2026-06-03 (bd035ced) — `2a20f007`

Item-by-item verification of the release backfill note found four developer-facing changes from the `88aa8174..bd035ced` window that never reached the docs:

- **`sync pull` snapshots + `primitive sync revert`** (#921/#578 in js-bao-wss) — every pull snapshots the sync directory first (28-day retention); `sync revert` restores (`--list`, `--snapshot <id>`, `-y`). Human side on *Configuring Your Backend* and the CLI page; reference depth (storage paths, integrity refusal, dirty-git warning) in the CONFIGURATION guide.
- **`group.contextId` CEL read-alias** (#989/#879) — new row in the USERS_AND_GROUPS guide's rule-context table. Guide-only: the human pages don't enumerate rule-context variables.
- **Blob-bucket `ruleSetId` — human-docs side** (#1003/#913) — the BLOB_BUCKETS guide already documented rule-set precedence; *Blobs and Files* and *Access Control* now carry it at tutorial altitude (new surfaces row + binding sentence, mirrored into the ACCESS_CONTROL guide).
- **Gemini model allow-list validated at workflow save time** (#920/#903) — `gemini.*` step models are rejected at save, not run time; noted on *Workflows* and in the WORKFLOWS guide (effective-model rule, template-syntax carve-out). The PROMPTS guide is untouched — managed prompts still validate at execution, so its existing wording is accurate.

Deliberately **not** documented: the `<DevTools>` test-user switcher / `primitive tokens inject` / client `/dev` entrypoint surface (parked per Carl), language-aware `guides get` (transparent CLI behavior), web-admin Bulk Import (below the admin-console page's altitude), and opt-in request-body validation (inert, no developer surface).

### 2. Next truing pass against library main tips — `dd615888`

Merged-but-unreleased library work (js-bao-wss PR #1071 Swift parity waves; swift-primitive-app-dev PR #34), documentable on `next` now and held back from the published site until a production release contains it:

- **Swift API changes the compile gate would have broken on**: `removePermission` takes a `DocumentPermissionTarget` union (`share-remove.swift`), `uploadAvatar` takes a typed `AvatarContentType` (`me-profile.swift`), `databases.subscribe` throws on empty ids (`db-subscribe*.swift`).
- **Examples upgraded to parity**: `logout.swift` shows `waitForDisconnect`; `aggregate.{ts,swift}` both gain StringSet **facet + membership** grouping (new in Swift, #1068).
- **Guides unscoped where Swift caught up**: `magicLinkVerify` `inviteToken` (AUTHENTICATION), the ~1 MiB offline analytics persistence cap (ANALYTICS), app-wide blob upload-queue controls (BLOBS), `LogoutOptions.waitForDisconnect`.
- **Workflows apply pattern**: Swift `runAndApply`/`awaitRun` were removed for strict JS parity — *Workflows* page + WORKFLOWS guide now document `define` + claim/confirm on both clients.
- **swift-primitive-app model facade (PR #34)**: per-document `TypedModel`/`makeTypedModel` binding replaced by the codegen facade (static reads, `record.save(in:)` writes, `registerModels`, inspector auto-surfacing via the shared store, `BaoDataLoader` `.onModel(subscribe:)`) across *Working with Documents*, *DevTools*, the DOCUMENTS and DEVTOOLS guides, and `dataloader-glue.swift`.

Upstream drift filed during the pass: js-bao-wss#1077 (`otpVerify` lacks `inviteToken`), swift-primitive-app-dev#35 (library README missed in PR #34).

## Validation

- `pnpm check:examples` ✅ (TS + Swift example compilation against submodule source, TOML, 435 CLI invocations, stamp gate)
- `npx vitepress build docs` ✅
- `pnpm render:guides` + guides.json sync ✅
- docs-page-review + docs-sync-check passes done; all facts verified against the library submodule sources at their new tips

🤖 Generated with [Claude Code](https://claude.com/claude-code)