### PR TITLE
ci: agent receiver to run docs-next-sync on library main pushes

### DIFF
--- a/.github/workflows/receive-submodule-update.yml
+++ b/.github/workflows/receive-submodule-update.yml
@@ -1,0 +1,214 @@
+# Docs next-sync (agent automation)
+#
+# Receives the `submodule-update` repository_dispatch that the library repos
+# (js-bao-wss, primitive-app-dev) fire on every push to their main branch, and
+# runs the project's docs-next-sync skill with Claude Code to true the docs on
+# the `next` branch against the library main tips. The result is opened as a
+# pull request into `next` for human review — this workflow never merges.
+#
+# NOTE: repository_dispatch only triggers workflows that live on the default
+# branch (main), so this file must stay on main even though the work it does
+# targets `next`.
+#
+# Secrets used (already configured in this repo):
+#   ANTHROPIC_API_KEY — Claude Code Action
+#   DOCS_REPO_PAT     — checkout + private submodule auth + opening the PR
+#   GITHUB_TOKEN      — Claude Code Action github_token
+
+name: Docs Next-Sync (agent)
+
+on:
+  repository_dispatch:
+    types: [submodule-update]
+
+  # Manual trigger for testing / on-demand runs.
+  workflow_dispatch:
+    inputs:
+      submodule:
+        description: 'Submodule that changed (context only; the skill triages all)'
+        required: false
+        type: choice
+        default: js-bao-wss
+        options:
+          - js-bao-wss
+          - primitive-app-dev
+          - swift-primitive-app-dev
+
+# One truing pass at a time: the skill moves submodule pins and restamps, so
+# concurrent runs would clobber each other. Queue rather than cancel.
+concurrency:
+  group: docs-next-sync
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
+
+jobs:
+  next-sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout primitive-docs (next)
+        uses: actions/checkout@v4
+        with:
+          ref: next
+          token: ${{ secrets.DOCS_REPO_PAT }}
+          fetch-depth: 0
+
+      - name: Configure git auth for private submodules
+        run: |
+          git config --global url."https://x-access-token:${{ secrets.DOCS_REPO_PAT }}@github.com/".insteadOf "https://github.com/"
+          git config --global user.email "docs-bot@primitivelabs.com"
+          git config --global user.name "primitive-docs-bot"
+
+      - name: Initialize submodules at their pinned SHAs
+        # Pinned (not tip) on purpose: the skill's --changes scan reads the
+        # stamped-commit→origin/main diff, then fast-forwards to tip itself.
+        run: git submodule update --init --recursive
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build context from dispatch payload
+        id: ctx
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          P_SUBMODULE: ${{ github.event.client_payload.submodule }}
+          P_REF: ${{ github.event.client_payload.ref }}
+          P_CHANGED: ${{ github.event.client_payload.changed_files }}
+          P_COMMITS: ${{ github.event.client_payload.commit_messages }}
+          P_COMPARE: ${{ github.event.client_payload.compare_url }}
+          I_SUBMODULE: ${{ github.event.inputs.submodule }}
+        run: |
+          if [ "$EVENT_NAME" = "repository_dispatch" ]; then
+            SUBMODULE="$P_SUBMODULE"; REF="$P_REF"; CHANGED="$P_CHANGED"
+            COMMITS="$P_COMMITS"; COMPARE="$P_COMPARE"
+          else
+            SUBMODULE="$I_SUBMODULE"; REF="main"; CHANGED="(manual run)"
+            COMMITS="(manual run)"; COMPARE=""
+          fi
+          {
+            echo "submodule=$SUBMODULE"
+            echo "ref=$REF"
+            echo "compare=$COMPARE"
+            echo "changed<<EOF"; echo "$CHANGED"; echo "EOF"
+            echo "commits<<EOF"; echo "$COMMITS"; echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Run docs-next-sync with Claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Tunable: bump to a larger model for higher-stakes batches.
+          claude_args: |
+            --model claude-sonnet-4-6
+            --max-turns 200
+          prompt: |
+            You are running UNATTENDED in CI. True the documentation on the
+            current `next` branch against the library main tips by running the
+            project skill. Invoke it now:
+
+            /docs-next-sync
+
+            Supplementary context from the push that triggered this run (the
+            skill re-derives the authoritative diff itself — treat this as a hint
+            only):
+            - Submodule: ${{ steps.ctx.outputs.submodule }}
+            - Library commit: ${{ steps.ctx.outputs.ref }}
+            - Changed files:
+            ${{ steps.ctx.outputs.changed }}
+            - Commit messages:
+            ${{ steps.ctx.outputs.commits }}
+
+            CRITICAL unattended-run rules:
+            - This is non-interactive. NEVER ask a question or wait for input.
+              For any decision the skill would normally escalate (creating a
+              brand-new page, splitting a large batch, an ambiguous editorial
+              call), make the CONSERVATIVE choice: apply only well-verified
+              factual updates to EXISTING pages and their matching agent guides,
+              and leave anything needing human judgment or a new page undone —
+              listing it prominently in your report for a human to follow up.
+            - Do the full truing the skill specifies: triage every changed
+              commit, VERIFY each fact against the submodule source (do not trust
+              PR summaries), update human docs AND the matching agent guides,
+              run `pnpm render:guides`, restamp, and run the gates
+              (`pnpm check:examples`, `npx vitepress build docs`). Fix whatever
+              the gates flag before finishing.
+            - Do NOT run `git commit`, `git push`, `git checkout -b`,
+              `git merge`, or `gh pr create`/`gh pr merge`. Leave every change in
+              the working tree; this workflow opens the pull request.
+            - Do NOT file GitHub issues. If you find a Swift/JS parity gap or
+              another library bug you would normally file, describe it in the
+              report instead.
+            - Finish by writing your complete Step 4 disposition report (the
+              per-commit table plus any deferred/held items and parity gaps) to
+              `.docs-next-sync-report.md` at the repo root. If the pass made no
+              doc changes, say so there and reset the submodules so the working
+              tree is clean.
+
+      - name: Read agent report
+        id: report
+        run: |
+          if [ -f .docs-next-sync-report.md ]; then
+            {
+              echo "body<<REPORT_EOF"
+              cat .docs-next-sync-report.md
+              echo "REPORT_EOF"
+            } >> "$GITHUB_OUTPUT"
+            rm -f .docs-next-sync-report.md
+          else
+            echo "body=The agent did not produce a report file. Review the run logs." >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Detect changes
+        id: diff
+        run: |
+          git add -A
+          if git diff --cached --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open pull request into next
+        if: steps.diff.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.DOCS_REPO_PAT }}
+          base: next
+          branch: docs-next-sync/auto-${{ github.run_number }}
+          delete-branch: true
+          commit-message: |
+            docs-next-sync: true next against ${{ steps.ctx.outputs.submodule }} (automated)
+          title: "docs-next-sync: ${{ steps.ctx.outputs.submodule }} changes (automated)"
+          body: |
+            Automated `docs-next-sync` pass against the library main tips, triggered by changes in **${{ steps.ctx.outputs.submodule }}** (`${{ steps.ctx.outputs.ref }}`).
+
+            ${{ steps.report.outputs.body }}
+
+            ---
+            Review the doc changes and the disposition above, then merge into `next`. Publishing to `main` happens separately at a production release.
+
+            > Generated unattended by Claude Code. Verify facts against source before merging.
+
+      - name: Run summary
+        if: always()
+        run: |
+          if [ "${{ steps.diff.outputs.changed }}" = "true" ]; then
+            echo "## docs-next-sync opened a PR into \`next\`" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "## docs-next-sync: no doc changes needed" >> "$GITHUB_STEP_SUMMARY"
+            echo "All triggering commits were internal / already documented." >> "$GITHUB_STEP_SUMMARY"
+          fi


### PR DESCRIPTION
## What this adds

A receiver workflow (`.github/workflows/receive-submodule-update.yml`) that closes the loop on the existing — but until now dead — notification wiring:

- **Library side (already live):** `js-bao-wss` and `primitive-app-dev` each have a `notify-docs-repo.yml` that fires a `repository_dispatch` (`event-type: submodule-update`) at this repo on every push to their `main` (under source paths), with a payload of changed files / commit messages / API diff.
- **Docs side (was missing):** this repo had **no** `repository_dispatch` listener, so those dispatches did nothing. This PR adds the listener.

On dispatch (or manual `workflow_dispatch`), it:
1. Checks out `next` + submodules (PAT-authed), installs deps.
2. Runs the **`docs-next-sync` skill** with `anthropics/claude-code-action@v1` — triage every changed commit, verify against source, update human docs + matching agent guides, render guides, restamp, run the gates.
3. Opens a **PR into `next`** with the agent's disposition report as the body. **It never merges** — every change is human-reviewed.

## Design notes

- **Lives on `main` by necessity:** `repository_dispatch` only triggers workflows on the default branch, even though the work targets `next`.
- **Reuses existing secrets:** `ANTHROPIC_API_KEY`, `DOCS_REPO_PAT`, `GITHUB_TOKEN` (all already configured — recovered from the prior `receive-submodule-update.yml` that used the same pattern).
- **Guardrails:** the agent edits + runs gates only (no `git push`/`merge`/`gh pr create`); the workflow opens the PR via `peter-evans/create-pull-request`. A `concurrency` group serializes runs (the skill moves submodule pins and restamps). 60-min timeout. Unattended prompt rules: never block on a question, make the conservative choice on anything needing human judgment, verify every fact against source.
- **Model:** `claude-sonnet-4-6` by default (tunable in `claude_args`).

## Known follow-ups (not in this PR)

- **`swift-primitive-app-dev` has no `notify-docs-repo.yml`** — its `main` pushes won't trigger this. Adding a notifier there is a separate library-repo change.
- **Production-release tier** (→ `docs-publish-release`) is still manual. This receiver is the **nightly tier** (every main push → `docs-next-sync`). The two-tier split is tracked in #88.

🤖 Generated with [Claude Code](https://claude.com/claude-code)