### PR TITLE
docs-next-sync: js-bao-wss changes (automated)

### DIFF
--- a/docs-sources.json
+++ b/docs-sources.json
@@ -3,7 +3,7 @@
   "stampedAt": "2026-06-22",
   "libraries": {
     "js-bao-wss": {
-      "commit": "e5dbf431613a946a54d604805ef8fae5ea7781bd",
+      "commit": "be98bb8117e0fee8dbb62563cfbbe93f76067e8b",
       "npm": {
         "js-bao-wss-client": "2.0.1",
         "js-bao": "0.5.1",

--- a/docs/getting-started/authentication.md
+++ b/docs/getting-started/authentication.md
@@ -14,7 +14,7 @@ Authentication runs against server-side **app settings** that must line up with 
 | Setting | What it does | Where it lives |
 |---|---|---|
 | **CORS allowed origins** | The whitelist of origins allowed to call the Primitive API from a browser. Your serving origin (scheme + host + port) must be listed. | `[cors].allowedOrigins` in `app.toml` |
-| **Redirect URIs** | The whitelist of OAuth callback URLs. The callback your app uses must match exactly, or the OAuth callback fails with `Invalid redirect URI`. | Admin Console only (not in `app.toml`) |
+| **Redirect URIs** | The whitelist of OAuth callback URLs. The callback your app uses must match exactly, or the OAuth callback fails with `Invalid redirect URI`. | `primitive apps update --redirect-uris` or Admin Console (not in `app.toml`) |
 | **Base URL** | Where the app is served — used for links in auth emails and redirects. | `[app].baseUrl` in `app.toml` |
 
 Inspect all three anytime with `primitive apps get`.
@@ -88,7 +88,7 @@ When deploying to production, add your production domain to these settings along
 
 ### 2. Configure in Primitive
 
-Enter your **Client ID** and **Client Secret** in the [Admin Console](https://admin.primitiveapi.com/login) under your app's Google OAuth settings, then enable the provider and allow your dev origin (see [Server App Settings](#server-app-settings-must-match-your-apps-origin) — the OAuth callback URL must also be in the app's **Redirect URIs**, set in the Admin Console). Set the provider toggle and origin in `app.toml` and push:
+Enter your **Client ID** and **Client Secret** in the [Admin Console](https://admin.primitiveapi.com/login) under your app's Google OAuth settings, then enable the provider and allow your dev origin (see [Server App Settings](#server-app-settings-must-match-your-apps-origin) — the OAuth callback URL must also be in the app's **Redirect URIs** — set via `primitive apps update --redirect-uris` or the Admin Console). Set the provider toggle and origin in `app.toml` and push:
 
 ```toml
 # config/app.toml

--- a/docs/getting-started/primitive-cli.md
+++ b/docs/getting-started/primitive-cli.md
@@ -225,6 +225,12 @@ primitive sync push
 
 The equivalent `primitive apps update --google-oauth true` / `--cors-origins "…"` flags set the same values imperatively for a quick one-off — but they mutate the server without touching `app.toml`, so the next `sync push` reverts them unless you mirror the change back. See [Configuration Sync](#configuration-sync) for which app settings are TOML-syncable.
 
+OAuth **redirect URIs** are not TOML-syncable — set the callback whitelist with the flag (non-localhost entries must be https; pass `''` to clear) or in the Admin Console:
+
+```bash
+primitive apps update --redirect-uris "https://myapp.com/auth/callback,http://localhost:5173/auth/callback"
+```
+
 ### Accessing Guides
 
 The CLI includes built-in guides for various Primitive features:
@@ -299,7 +305,7 @@ This creates a directory structure like:
 - `[auth]` — `googleOAuthEnabled`, `magicLinkEnabled`, `passkeyEnabled`, and `[auth.passkeys]` relying-party config
 - `[cors]` (when `mode = "custom"`) — `allowedOrigins`, `allowCredentials`, `allowedMethods`, `maxAge`
 
-Two app settings are not part of `app.toml`: **OTP** is toggled with `primitive apps update --otp <bool>` only, and **redirect URIs** are managed in the [Admin Console](https://admin.primitiveapi.com/login) (no TOML key and no CLI flag). For everything else, edit `app.toml` and `primitive sync push`.
+Two app settings are not part of `app.toml`: **OTP** is toggled with `primitive apps update --otp <bool>` only, and **redirect URIs** are set with `primitive apps update --redirect-uris "<uri1>,<uri2>"` or in the [Admin Console](https://admin.primitiveapi.com/login) (no TOML key). For everything else, edit `app.toml` and `primitive sync push`.
 
 ### When `sync push` fails
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_AUTHENTICATION.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_AUTHENTICATION.swift.md
@@ -59,12 +59,12 @@ Server-side app settings must align with the origin the client app is served fro
 | Server field | Contract | Set via |
 |---|---|---|
 | `corsAllowedOrigins` | Must contain the exact serving origin (scheme+host+port). `corsMode` defaults to `custom` — an empty list blocks every cross-origin request. | `[cors]` (`mode`, `allowedOrigins`, `allowCredentials`) in `app.toml` → `sync push`; `--cors-origins "<o1>,<o2>"` for a one-off |
-| `redirectUris` | OAuth callbacks are validated against this whitelist — a non-listed callback URL returns 400 `Invalid redirect URI`. | Admin Console only — not in `app.toml`, no CLI flag |
+| `redirectUris` | OAuth callbacks are validated against this whitelist — a non-listed callback URL returns 400 `Invalid redirect URI`. | Not in `app.toml` — `primitive apps update --redirect-uris "<uri1>,<uri2>"` (non-localhost must be https) or the Admin Console |
 | `baseUrl` | Used for links in auth emails / redirects. | `[app].baseUrl` in `app.toml` → `sync push`; `--base-url <url>` for a one-off |
 | Provider toggles | What `getAuthConfig()` reports. | `[auth]` in `app.toml` (`googleOAuthEnabled`, `magicLinkEnabled`) → `sync push`. `otp` has no TOML key — set it with `--otp <bool>` only. |
 
 
-Dev → prod checklist: add the production origin to `[cors].allowedOrigins` and set `[app].baseUrl` in `app.toml`, `primitive sync push`, add the production OAuth callback to `redirectUris` (Admin Console — not synced), and re-check `getAuthConfig()` reports the expected methods.
+Dev → prod checklist: add the production origin to `[cors].allowedOrigins` and set `[app].baseUrl` in `app.toml`, `primitive sync push`, add the production OAuth callback to `redirectUris` (`primitive apps update --redirect-uris` or Admin Console — not in `app.toml`), and re-check `getAuthConfig()` reports the expected methods.
 
 ---
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_AUTHENTICATION.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_AUTHENTICATION.template.md
@@ -57,7 +57,7 @@ Server-side app settings must align with the origin the client app is served fro
 | Server field | Contract | Set via |
 |---|---|---|
 | `corsAllowedOrigins` | Must contain the exact serving origin (scheme+host+port). `corsMode` defaults to `custom` — an empty list blocks every cross-origin request. | `[cors]` (`mode`, `allowedOrigins`, `allowCredentials`) in `app.toml` → `sync push`; `--cors-origins "<o1>,<o2>"` for a one-off |
-| `redirectUris` | OAuth callbacks are validated against this whitelist — a non-listed callback URL returns 400 `Invalid redirect URI`. | Admin Console only — not in `app.toml`, no CLI flag |
+| `redirectUris` | OAuth callbacks are validated against this whitelist — a non-listed callback URL returns 400 `Invalid redirect URI`. | Not in `app.toml` — `primitive apps update --redirect-uris "<uri1>,<uri2>"` (non-localhost must be https) or the Admin Console |
 | `baseUrl` | Used for links in auth emails / redirects. | `[app].baseUrl` in `app.toml` → `sync push`; `--base-url <url>` for a one-off |
 {{#lang ts}}
 | Provider toggles | What `getAuthConfig()` reports. | `[auth]` in `app.toml` (`googleOAuthEnabled`, `magicLinkEnabled`, `passkeyEnabled` + `[auth.passkeys]`) → `sync push`. `otp` has no TOML key — set it with `--otp <bool>` only. |
@@ -70,7 +70,7 @@ Server-side app settings must align with the origin the client app is served fro
 **CORS misconfiguration blocks bootstrap.** When the serving origin is missing from `corsAllowedOrigins`, the browser blocks the client's bootstrap refresh (`POST …/api/auth/refresh` → 403, no `access-control-allow-origin`): `initializeClient` throws `initializeClient refresh failed (network)` before `getAuthConfig()` is reached, and the template app's login surfaces the error. Fix by adding the serving origin (`primitive apps update --cors-origins`; inspect with `primitive apps get`). Common triggers: serving on a non-default port, or a newly deployed domain.
 {{/lang}}
 
-Dev → prod checklist: add the production origin to `[cors].allowedOrigins` and set `[app].baseUrl` in `app.toml`, `primitive sync push`, add the production OAuth callback to `redirectUris` (Admin Console — not synced), and re-check `getAuthConfig()` reports the expected methods.
+Dev → prod checklist: add the production origin to `[cors].allowedOrigins` and set `[app].baseUrl` in `app.toml`, `primitive sync push`, add the production OAuth callback to `redirectUris` (`primitive apps update --redirect-uris` or Admin Console — not in `app.toml`), and re-check `getAuthConfig()` reports the expected methods.
 
 ---
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_AUTHENTICATION.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_AUTHENTICATION.ts.md
@@ -75,13 +75,13 @@ Server-side app settings must align with the origin the client app is served fro
 | Server field | Contract | Set via |
 |---|---|---|
 | `corsAllowedOrigins` | Must contain the exact serving origin (scheme+host+port). `corsMode` defaults to `custom` — an empty list blocks every cross-origin request. | `[cors]` (`mode`, `allowedOrigins`, `allowCredentials`) in `app.toml` → `sync push`; `--cors-origins "<o1>,<o2>"` for a one-off |
-| `redirectUris` | OAuth callbacks are validated against this whitelist — a non-listed callback URL returns 400 `Invalid redirect URI`. | Admin Console only — not in `app.toml`, no CLI flag |
+| `redirectUris` | OAuth callbacks are validated against this whitelist — a non-listed callback URL returns 400 `Invalid redirect URI`. | Not in `app.toml` — `primitive apps update --redirect-uris "<uri1>,<uri2>"` (non-localhost must be https) or the Admin Console |
 | `baseUrl` | Used for links in auth emails / redirects. | `[app].baseUrl` in `app.toml` → `sync push`; `--base-url <url>` for a one-off |
 | Provider toggles | What `getAuthConfig()` reports. | `[auth]` in `app.toml` (`googleOAuthEnabled`, `magicLinkEnabled`, `passkeyEnabled` + `[auth.passkeys]`) → `sync push`. `otp` has no TOML key — set it with `--otp <bool>` only. |
 
 **CORS misconfiguration blocks bootstrap.** When the serving origin is missing from `corsAllowedOrigins`, the browser blocks the client's bootstrap refresh (`POST …/api/auth/refresh` → 403, no `access-control-allow-origin`): `initializeClient` throws `initializeClient refresh failed (network)` before `getAuthConfig()` is reached, and the template app's login surfaces the error. Fix by adding the serving origin (`primitive apps update --cors-origins`; inspect with `primitive apps get`). Common triggers: serving on a non-default port, or a newly deployed domain.
 
-Dev → prod checklist: add the production origin to `[cors].allowedOrigins` and set `[app].baseUrl` in `app.toml`, `primitive sync push`, add the production OAuth callback to `redirectUris` (Admin Console — not synced), and re-check `getAuthConfig()` reports the expected methods.
+Dev → prod checklist: add the production origin to `[cors].allowedOrigins` and set `[app].baseUrl` in `app.toml`, `primitive sync push`, add the production OAuth callback to `redirectUris` (`primitive apps update --redirect-uris` or Admin Console — not in `app.toml`), and re-check `getAuthConfig()` reports the expected methods.
 
 ---
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_CONFIGURATION.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_CONFIGURATION.md
@@ -55,7 +55,7 @@ App-level settings sync from `app.toml`; editing the TOML and `sync push` is the
 - `[auth]` — `googleOAuthEnabled`, `magicLinkEnabled`, `passkeyEnabled`, `[auth.passkeys]` relying-party config
 - `[cors]` (serialized only when `mode = "custom"`) — `allowedOrigins`, `allowCredentials`, `allowedMethods`, `maxAge`
 
-Not in `app.toml` (see [What sync does NOT carry](#what-sync-does-not-carry)): `otp` (set via `--otp <bool>` only) and `redirectUris` (Admin Console only — no TOML key, no CLI flag).
+Not in `app.toml` (see [What sync does NOT carry](#what-sync-does-not-carry)): `otp` (set via `--otp <bool>` only) and `redirectUris` (set via `--redirect-uris "<uri1>,<uri2>"` or the Admin Console — no TOML key).
 
 ## Environment resolution
 
@@ -75,7 +75,7 @@ primitive workflows update <id> --sync-callable true
 primitive apps update --otp true                                          # no TOML key
 primitive apps update --member-invitations-enabled true --member-invitation-limit 5
 primitive apps update --test-account-bases alice@example.com
-# redirectUris: Admin Console only — no TOML key, no CLI flag
+primitive apps update --redirect-uris "https://app.example.com/auth/callback"  # no TOML key
 ```
 
 ## Secrets

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_CONFIGURATION.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_CONFIGURATION.template.md
@@ -55,7 +55,7 @@ App-level settings sync from `app.toml`; editing the TOML and `sync push` is the
 - `[auth]` — `googleOAuthEnabled`, `magicLinkEnabled`, `passkeyEnabled`, `[auth.passkeys]` relying-party config
 - `[cors]` (serialized only when `mode = "custom"`) — `allowedOrigins`, `allowCredentials`, `allowedMethods`, `maxAge`
 
-Not in `app.toml` (see [What sync does NOT carry](#what-sync-does-not-carry)): `otp` (set via `--otp <bool>` only) and `redirectUris` (Admin Console only — no TOML key, no CLI flag).
+Not in `app.toml` (see [What sync does NOT carry](#what-sync-does-not-carry)): `otp` (set via `--otp <bool>` only) and `redirectUris` (set via `--redirect-uris "<uri1>,<uri2>"` or the Admin Console — no TOML key).
 
 ## Environment resolution
 
@@ -75,7 +75,7 @@ primitive workflows update <id> --sync-callable true
 primitive apps update --otp true                                          # no TOML key
 primitive apps update --member-invitations-enabled true --member-invitation-limit 5
 primitive apps update --test-account-bases alice@example.com
-# redirectUris: Admin Console only — no TOML key, no CLI flag
+primitive apps update --redirect-uris "https://app.example.com/auth/callback"  # no TOML key
 ```
 
 ## Secrets


### PR DESCRIPTION
Automated `docs-next-sync` pass against the library main tips, triggered by changes in **js-bao-wss** (`be98bb8117e0fee8dbb62563cfbbe93f76067e8b`).

# docs-next-sync report — 2026-06-22

Pass trued `next` against `js-bao-wss` tip `be98bb81`.

## Commit disposition

| Commit | Message | Classification | Action |
|--------|---------|----------------|--------|
| `be98bb81` | Merge PR #1128 (redirect-uris-cli) | Developer-facing (new CLI flag) | Updated docs — see below |
| `eda25cfb` | Merge PR #1131 (codebase-refactor-clarity) | Internal — pure refactor, "No functional changes; all behavior preserved" per commit message | No doc change |
| `e1d2ba4e` | Merge PR #1127 (issue-1011-deprecate-client-llm) | Developer-facing (deprecation) | No doc change needed — see below |
| `4906856b` | refactor: reduce duplication in app-api, index, and controllers | Internal (part of PR #1131) | No doc change |
| `a7b1a809` | add manual test page for #1001 | Internal (sample-app test page) | No doc change |
| `99777964` | feat(cli): add --redirect-uris to 'primitive apps update' | Developer-facing | Covered by PR #1128 updates |
| `9ac2fcab` | feat(api): wire validateRedirectUris into all three writers | Developer-facing (API hardening) | No doc change (internal validation consolidation, no user-visible behavioral change beyond the CLI flag) |
| `7ad31ca5` | feat(auth): add shared validateRedirectUris validator | Internal plumbing | No doc change |
| `81c3982e` | fix test failures (#1011) | Internal | No doc change |
| `6f128630` | docs: deprecate direct client LLM/Gemini APIs (#1011) | Developer-facing (deprecation) | Covered by PR #1127 analysis — see below |

## Changes made

### PR #1128 — `--redirect-uris` on `primitive apps update`

The `primitive apps update` command now accepts `--redirect-uris` (comma-separated; non-localhost must be HTTPS; max 50; pass `''` to clear). Previously the redirect URI whitelist was Admin Console-only. Three files updated:

**`docs/getting-started/authentication.md`**
- Updated the "Server App Settings" table: Redirect URIs row now shows `primitive apps update --redirect-uris "https://myapp.com/auth/callback"` or Admin Console (previously "Admin Console" only).
- Updated the Google OAuth setup paragraph to mention the CLI option alongside the Admin Console.

**`docs/getting-started/primitive-cli.md`**
- Added `--redirect-uris` example to the OAuth Configuration section.

**`guides/latest/AGENT_GUIDE_TO_PRIMITIVE_AUTHENTICATION.template.md`** (+ rendered `.ts.md` / `.swift.md` builds)
- Updated `redirectUris` table row: removed "Admin Console only (no CLI flag)", added `primitive apps update --redirect-uris "<uri1>,<uri2>"` or Admin Console.
- Updated the dev→prod checklist to reference `primitive apps update --redirect-uris` alongside the Admin Console.

### PR #1127 — Deprecation of direct `client.llm` / `client.gemini` APIs

No human-authored doc page documents `client.llm` or `client.gemini` directly. A search of all `docs/getting-started/*.md` files found zero references to `client.llm` or `client.gemini` as user-facing instructions. These APIs surface only in the auto-generated reference docs (`docs/reference/js-bao-wss-client/api/`), which are regenerated by `pnpm gen:reference` and noted in CLAUDE.md as "not a published surface on next."

The deprecated `primitive llm models` CLI command is also not documented in `primitive-cli.md` — no section exists for `primitive llm`. No workflow-step deprecations occurred (workflow `llm.chat` / `gemini.generate` steps are **not** deprecated).

**No doc changes for this PR.**

## Items deferred / requiring human judgment

None. All commits were either internal or handled with well-verified factual updates to existing pages.

## Parity gaps

None found in this pass.

## Gates

- `pnpm check:examples` — passed (436 CLI invocations validated, all examples compile, guides.json current)
- `npx vitepress build docs` — passed (build complete, no dead links)
- `pnpm stamp:sources` — restamped to 2026-06-22 (channel: next)

---
Review the doc changes and the disposition above, then merge into `next`. Publishing to `main` happens separately at a production release.

> Generated unattended by the Claude Code CLI. Verify facts against source before merging.