### PR TITLE
DOCUMENTS guide: promote field-concept fences to corpus + fix stringset AND query (#87)

### DIFF
--- a/examples/documents/date-handling.swift
+++ b/examples/documents/date-handling.swift
@@ -1,0 +1,25 @@
+import Foundation
+import JsBaoClient
+
+// Dates are stored as ISO-8601 strings — lexicographic order matches
+// chronological order, so string comparison works in queries.
+func dateHandling(documentId: String, taskId: String) throws {
+  // #region example
+  let now = ISO8601DateFormatter().string(from: Date())
+
+  // Store
+  if var task = Task.find(taskId) {
+    task.dueDate = now
+    try task.save(in: documentId)
+
+    // Compare
+    if let dueDate = task.dueDate, dueDate < now {
+      // overdue
+    }
+  }
+
+  // Query with date comparison
+  let overdue = Task.query(["dueDate": ["$lt": now]])
+  // #endregion example
+  _ = overdue
+}

--- a/examples/documents/date-handling.ts
+++ b/examples/documents/date-handling.ts
@@ -1,0 +1,22 @@
+import { Task } from "../_harness/generated/ts/Task.generated";
+
+// Dates are stored as ISO-8601 strings — lexicographic order matches
+// chronological order, so string comparison works in queries.
+export async function dateHandling(task: Task) {
+  // #region example
+  // Store
+  task.dueDate = new Date().toISOString();
+
+  // Compare
+  const due = new Date(task.dueDate);
+  if (due < new Date()) {
+    // overdue
+  }
+
+  // Query with date comparison
+  const overdue = await Task.query({
+    dueDate: { $lt: new Date().toISOString() },
+  });
+  // #endregion example
+  return overdue.data;
+}

--- a/examples/documents/stringset-ops.swift
+++ b/examples/documents/stringset-ops.swift
@@ -1,0 +1,20 @@
+import JsBaoClient
+
+// Stringset fields are a native Set<String>: mutate the set, test
+// membership, then save the record to persist the change.
+func stringsetOps(documentId: String, taskId: String) throws {
+  // #region example
+  if var task = Task.find(taskId) {
+    // Add/remove tags
+    task.tags?.insert("urgent")
+    task.tags?.remove("low-priority")
+
+    // Check membership
+    if task.tags?.contains("urgent") == true {
+      // ...
+    }
+
+    try task.save(in: documentId)
+  }
+  // #endregion example
+}

--- a/examples/documents/stringset-ops.ts
+++ b/examples/documents/stringset-ops.ts
@@ -1,0 +1,20 @@
+import type { Task } from "../_harness/generated/ts/Task.generated";
+
+// Stringset fields hold a set of strings (tags, labels): mutate with
+// add/remove, test membership, convert to an array for display.
+export function stringsetOps(task: Task) {
+  // #region example
+  // Add/remove tags
+  task.tags?.add("urgent");
+  task.tags?.remove("low-priority");
+
+  // Check membership
+  if (task.tags?.has("urgent")) {
+    // ...
+  }
+
+  // Convert to array for display
+  const tagList = task.tags?.toArray() ?? [];
+  // #endregion example
+  return tagList;
+}

--- a/examples/documents/tag-filter-local.swift
+++ b/examples/documents/tag-filter-local.swift
@@ -1,0 +1,15 @@
+import JsBaoClient
+
+// Create a tagged document, then filter the owned list locally by tag.
+func tagFilterLocal(client: JsBaoClient) async throws {
+  // #region example
+  let result = try await client.documents.create(
+    options: CreateDocumentOptions(title: "My List", tags: ["todolist"])
+  )
+
+  // Filter locally
+  let owned = try await client.me.ownedDocuments()
+  let todoLists = owned.filter { $0.tags?.contains("todolist") == true }
+  // #endregion example
+  _ = (result, todoLists)
+}

--- a/examples/documents/tag-filter-local.ts
+++ b/examples/documents/tag-filter-local.ts
@@ -1,0 +1,16 @@
+import type { JsBaoClient } from "js-bao-wss-client";
+
+// Create a tagged document, then filter the owned list locally by tag.
+export async function tagFilterLocal(client: JsBaoClient) {
+  // #region example
+  const { metadata } = await client.documents.create({
+    title: "My List",
+    tags: ["todolist"],
+  });
+
+  // Filter locally
+  const owned = await client.me.ownedDocuments();
+  const todoLists = owned.filter((doc) => doc.tags?.includes("todolist"));
+  // #endregion example
+  return { metadata, todoLists };
+}

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.swift.md
@@ -456,6 +456,15 @@ Use tags to categorize documents by type. Pass `tags` to `create()`, filter the 
 
 You can also create a tagged document and filter locally:
 
+```swift
+  let result = try await client.documents.create(
+    options: CreateDocumentOptions(title: "My List", tags: ["todolist"])
+  )
+
+  // Filter locally
+  let owned = try await client.me.ownedDocuments()
+  let todoLists = owned.filter { $0.tags?.contains("todolist") == true }
+```
 
 ## Defining Models
 
@@ -609,6 +618,44 @@ fields = ["name", "parentId"]
 unique_constraints = [["name", "parentId"]]
 ```
 
+### Working with StringSets
+
+```swift
+  if var task = Task.find(taskId) {
+    // Add/remove tags
+    task.tags?.insert("urgent")
+    task.tags?.remove("low-priority")
+
+    // Check membership
+    if task.tags?.contains("urgent") == true {
+      // ...
+    }
+
+    try task.save(in: documentId)
+  }
+```
+
+### Working with Dates
+
+Dates are stored as ISO-8601 strings. Convert for comparisons:
+
+```swift
+  let now = ISO8601DateFormatter().string(from: Date())
+
+  // Store
+  if var task = Task.find(taskId) {
+    task.dueDate = now
+    try task.save(in: documentId)
+
+    // Compare
+    if let dueDate = task.dueDate, dueDate < now {
+      // overdue
+    }
+  }
+
+  // Query with date comparison
+  let overdue = Task.query(["dueDate": ["$lt": now]])
+```
 
 ## Querying Data
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.template.md
@@ -410,18 +410,7 @@ Use tags to categorize documents by type. Pass `tags` to `create()`, filter the 
 
 You can also create a tagged document and filter locally:
 
-{{#lang ts}}
-```typescript
-const { metadata } = await jsBaoClient.documents.create({
-  title: "My List",
-  tags: ["todolist"],
-});
-
-// Filter locally
-const owned = await jsBaoClient.me.ownedDocuments();
-const todoListsLocal = owned.filter((doc) => doc.tags?.includes("todolist"));
-```
-{{/lang}}
+{{ example: documents/tag-filter-local }}
 
 ## Defining Models
 
@@ -657,41 +646,15 @@ fields = ["name", "parentId"]
 unique_constraints = [["name", "parentId"]]
 ```
 
-{{#lang ts}}
 ### Working with StringSets
 
-```typescript
-// Add/remove tags
-task.tags.add("urgent");
-task.tags.remove("low-priority");
-
-// Check membership
-if (task.tags.has("urgent")) { ... }
-
-// Convert to array for display
-const tagList = task.tags.toArray();
-```
+{{ example: documents/stringset-ops }}
 
 ### Working with Dates
 
 Dates are stored as ISO-8601 strings. Convert for comparisons:
 
-```typescript
-// Store
-task.dueDate = new Date().toISOString();
-
-// Compare
-const due = new Date(task.dueDate);
-if (due < new Date()) {
-  console.log("Overdue!");
-}
-
-// Query with date comparison
-const result = await Task.query({
-  dueDate: { $lt: new Date().toISOString() },
-});
-```
-{{/lang}}
+{{ example: documents/date-handling }}
 
 ## Querying Data
 
@@ -746,7 +709,7 @@ items.map(...);  // TypeError: items.map is not a function
 const result = await Task.query({
   completed: false,
   priority: { $gte: 3 },
-  tags: { $in: ["work", "urgent"] },
+  category: { $in: ["work", "urgent"] },
 });
 ```
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.ts.md
@@ -475,14 +475,14 @@ Use tags to categorize documents by type. Pass `tags` to `create()`, filter the 
 You can also create a tagged document and filter locally:
 
 ```typescript
-const { metadata } = await jsBaoClient.documents.create({
-  title: "My List",
-  tags: ["todolist"],
-});
+  const { metadata } = await client.documents.create({
+    title: "My List",
+    tags: ["todolist"],
+  });
 
-// Filter locally
-const owned = await jsBaoClient.me.ownedDocuments();
-const todoListsLocal = owned.filter((doc) => doc.tags?.includes("todolist"));
+  // Filter locally
+  const owned = await client.me.ownedDocuments();
+  const todoLists = owned.filter((doc) => doc.tags?.includes("todolist"));
 ```
 
 ## Defining Models
@@ -645,15 +645,17 @@ unique_constraints = [["name", "parentId"]]
 ### Working with StringSets
 
 ```typescript
-// Add/remove tags
-task.tags.add("urgent");
-task.tags.remove("low-priority");
+  // Add/remove tags
+  task.tags?.add("urgent");
+  task.tags?.remove("low-priority");
 
-// Check membership
-if (task.tags.has("urgent")) { ... }
+  // Check membership
+  if (task.tags?.has("urgent")) {
+    // ...
+  }
 
-// Convert to array for display
-const tagList = task.tags.toArray();
+  // Convert to array for display
+  const tagList = task.tags?.toArray() ?? [];
 ```
 
 ### Working with Dates
@@ -661,19 +663,19 @@ const tagList = task.tags.toArray();
 Dates are stored as ISO-8601 strings. Convert for comparisons:
 
 ```typescript
-// Store
-task.dueDate = new Date().toISOString();
+  // Store
+  task.dueDate = new Date().toISOString();
 
-// Compare
-const due = new Date(task.dueDate);
-if (due < new Date()) {
-  console.log("Overdue!");
-}
+  // Compare
+  const due = new Date(task.dueDate);
+  if (due < new Date()) {
+    // overdue
+  }
 
-// Query with date comparison
-const result = await Task.query({
-  dueDate: { $lt: new Date().toISOString() },
-});
+  // Query with date comparison
+  const overdue = await Task.query({
+    dueDate: { $lt: new Date().toISOString() },
+  });
 ```
 
 ## Querying Data
@@ -728,7 +730,7 @@ items.map(...);  // TypeError: items.map is not a function
 const result = await Task.query({
   completed: false,
   priority: { $gte: 3 },
-  tags: { $in: ["work", "urgent"] },
+  category: { $in: ["work", "urgent"] },
 });
 ```
 


### PR DESCRIPTION
Re-applies the still-applicable slice of #100 against `next`'s facade-rewritten DOCUMENTS guide.

### Why this supersedes #100
#100 (Jun 5) restructured the DOCUMENTS template against the **pre-facade** Swift prose. Since then `next` landed the full `TypedModel<T>` → model-facade rewrite, which **independently absorbed nearly all of #100's content** with ts/swift parity: `removePermission` (correct `.userId(...)`/`.email(...)` facade API), `share-email-deferred` (sendEmail/documentUrl preconditions), collection `addMember` by email, `users.lookup`, batch share, and stringset facet aggregation are all already documented. Promoting those again would duplicate or fight `next`'s deliberate ts-scoping of the JS-specific query/aggregate deep-dives.

What remained genuinely additive — and is what this PR does:

**Three ts-only inline fences promoted to compile-gated corpus pairs** (gaining Swift parity the rewrite left as ts-only):
- `documents/tag-filter-local` — create a tagged doc, filter the owned list locally
- `documents/stringset-ops` — JS `StringSet` methods ↔ Swift native `Set<String>` + `save(in:)`
- `documents/date-handling` — ISO-8601 storage, comparison, `$lt` query

**One live fact bug fixed:** the AND-query fence used `tags: { $in: [...] }` — `$in` is invalid on a `stringset` field (they take `$contains`/`$all`, as the operators table on the same page shows). Changed to a scalar `category` field.

### Validation
- All three Swift examples verified against `swift-client` source (`removePermission`/`DocumentPermissionTarget`, native `Set`, facade `save(in:)`/`query`) — they compile against `next`'s current client.
- `pnpm check:examples` ✓ (TS + Swift compile, parity, render, CLI, stamp), `npx vitepress build docs` ✓.
- Swift build now contains all three examples; ts build retains its versions; bug fixed in both. Human page unaffected (it carries only reference tables, no parallel example) — guide-sync rule satisfied.

Closes the actionable remainder of #100; #100 will be closed as superseded.

Part of #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)