### PR TITLE
Recommend app.toml sync over `primitive apps update` flags for app settings (#111)

### DIFF
--- a/docs/getting-started/authentication.md
+++ b/docs/getting-started/authentication.md
@@ -9,15 +9,17 @@ The two things you may want to configure are:
 
 ## Server App Settings Must Match Your App's Origin
 
-Authentication runs against server-side **app settings** that must line up with where your client app is actually served. Three settings matter, and a mismatch in the first one fails in a particularly confusing way:
+Authentication runs against server-side **app settings** that must line up with where your client app is actually served. These settings live in your synced `app.toml` — edit the TOML and run `primitive sync push` so the server matches what's checked into your repo. Three settings matter, and a mismatch in the first one fails in a particularly confusing way:
 
-| Setting | What it does | How to set |
+| Setting | What it does | Where it lives |
 |---|---|---|
-| **CORS allowed origins** | The whitelist of origins allowed to call the Primitive API from a browser. Your serving origin (scheme + host + port) must be listed. | `primitive apps update --cors-origins "http://localhost:5173,https://myapp.com"` or Admin Console |
-| **Redirect URIs** | The whitelist of OAuth callback URLs. The callback your app uses must match exactly, or the OAuth callback fails with `Invalid redirect URI`. | Admin Console |
-| **Base URL** | Where the app is served — used for links in auth emails and redirects. | `primitive apps update --base-url "https://myapp.com"` |
+| **CORS allowed origins** | The whitelist of origins allowed to call the Primitive API from a browser. Your serving origin (scheme + host + port) must be listed. | `[cors].allowedOrigins` in `app.toml` |
+| **Redirect URIs** | The whitelist of OAuth callback URLs. The callback your app uses must match exactly, or the OAuth callback fails with `Invalid redirect URI`. | Admin Console only (not in `app.toml`) |
+| **Base URL** | Where the app is served — used for links in auth emails and redirects. | `[app].baseUrl` in `app.toml` |
 
 Inspect all three anytime with `primitive apps get`.
+
+The `primitive apps update --cors-origins …` / `--base-url …` flags set the same values imperatively — useful for a quick one-off, but a flag change mutates the server without touching `app.toml`, so the next `primitive sync push` reverts it unless you mirror the change back into the TOML. Prefer editing `app.toml` and pushing.
 
 ## The Template Login
 
@@ -86,11 +88,20 @@ When deploying to production, add your production domain to these settings along
 
 ### 2. Configure in Primitive
 
-Enter your **Client ID** and **Client Secret** in the [Admin Console](https://admin.primitiveapi.com/login) under your app's Google OAuth settings, then enable the provider and allow your dev origin (see [Server App Settings](#server-app-settings-must-match-your-apps-origin) — the OAuth callback URL must also be in the app's **Redirect URIs**, set in the Admin Console):
+Enter your **Client ID** and **Client Secret** in the [Admin Console](https://admin.primitiveapi.com/login) under your app's Google OAuth settings, then enable the provider and allow your dev origin (see [Server App Settings](#server-app-settings-must-match-your-apps-origin) — the OAuth callback URL must also be in the app's **Redirect URIs**, set in the Admin Console). Set the provider toggle and origin in `app.toml` and push:
+
+```toml
+# config/app.toml
+[auth]
+googleOAuthEnabled = true
+
+[cors]
+mode = "custom"
+allowedOrigins = ["http://localhost:5173"]
+```
 
 ```bash
-primitive apps update --google-oauth true
-primitive apps update --cors-origins "http://localhost:5173"
+primitive sync push
 ```
 
 That's it — the template's login component automatically shows a "Sign in with Google" button when Google OAuth is configured.

--- a/docs/getting-started/primitive-cli.md
+++ b/docs/getting-started/primitive-cli.md
@@ -207,15 +207,23 @@ primitive users admin-invitations delete <invitation-id>
 
 ### OAuth Configuration
 
-Configure OAuth providers for your app (client credentials are entered in the [Admin Console](https://admin.primitiveapi.com/login) under the app's Google OAuth settings):
+Configure OAuth providers for your app (client credentials are entered in the [Admin Console](https://admin.primitiveapi.com/login) under the app's Google OAuth settings). The provider toggle and CORS origins are app settings synced from `app.toml`, so the drift-free path is to edit the TOML and push:
+
+```toml
+# config/app.toml
+[auth]
+googleOAuthEnabled = true
+
+[cors]
+mode = "custom"
+allowedOrigins = ["http://localhost:5173", "https://myapp.com"]
+```
 
 ```bash
-# Enable Google OAuth as a sign-in method
-primitive apps update --google-oauth true
-
-# Set allowed origins (for CORS; comma-separated list)
-primitive apps update --cors-origins "http://localhost:5173,https://myapp.com"
+primitive sync push
 ```
+
+The equivalent `primitive apps update --google-oauth true` / `--cors-origins "…"` flags set the same values imperatively for a quick one-off — but they mutate the server without touching `app.toml`, so the next `sync push` reverts them unless you mirror the change back. See [Configuration Sync](#configuration-sync) for which app settings are TOML-syncable.
 
 ### Accessing Guides
 
@@ -284,6 +292,14 @@ This creates a directory structure like:
 ```
 
 `workflow-fragments/<name>.toml` lets several workflows share a common run of `[[steps]]`. Reference them from a workflow file with `include = ["<name>"]`; the CLI expands fragments client-side before push (the server only stores the canonical flattened step list). Use `primitive workflows expand <workflow.toml>` to inspect the expanded result.
+
+`app.toml` holds the app-level settings, and pushing it is the preferred way to change them — the imperative `primitive apps update --flag` calls mutate the server directly and drift from the checked-in TOML, so a later `sync push` reverts them. The TOML-syncable settings are:
+
+- `[app]` — `name`, `mode`, `waitlistEnabled`, `baseUrl`
+- `[auth]` — `googleOAuthEnabled`, `magicLinkEnabled`, `passkeyEnabled`, and `[auth.passkeys]` relying-party config
+- `[cors]` (when `mode = "custom"`) — `allowedOrigins`, `allowCredentials`, `allowedMethods`, `maxAge`
+
+Two app settings are not part of `app.toml`: **OTP** is toggled with `primitive apps update --otp <bool>` only, and **redirect URIs** are managed in the [Admin Console](https://admin.primitiveapi.com/login) (no TOML key and no CLI flag). For everything else, edit `app.toml` and `primitive sync push`.
 
 ### When `sync push` fails
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_AUTHENTICATION.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_AUTHENTICATION.swift.md
@@ -54,17 +54,17 @@ In the starter template this wiring is owned for you by `PrimitiveAppState.initi
 
 ## Server App Settings ↔ Client Contract
 
-Server-side app settings must align with the origin the client app is served from. Inspect with `primitive apps get`; the relevant fields:
+Server-side app settings must align with the origin the client app is served from. These settings live in `config/app.toml` and sync with `primitive sync push` — **edit the TOML and push as the default path** so the server stays in lockstep with what's checked in. The `primitive apps update --flag` calls below are a quick imperative escape hatch; a flag change mutates the server but leaves `app.toml` stale, so the next `primitive sync push` silently reverts it unless you mirror the change back into the TOML. Inspect the live values with `primitive apps get`; the relevant fields:
 
 | Server field | Contract | Set via |
 |---|---|---|
-| `corsAllowedOrigins` | Must contain the exact serving origin (scheme+host+port). `corsMode` defaults to `custom` — an empty list blocks every cross-origin request. | `primitive apps update --cors-origins "<o1>,<o2>"` |
-| `redirectUris` | OAuth callbacks are validated against this whitelist — a non-listed callback URL returns 400 `Invalid redirect URI`. | Admin Console only (no CLI flag) |
-| `baseUrl` | Used for links in auth emails / redirects. | `primitive apps update --base-url <url>` |
-| Provider toggles | `--google-oauth`/`--magic-link`/`--otp <bool>` — what `getAuthConfig()` reports. | `primitive apps update` |
+| `corsAllowedOrigins` | Must contain the exact serving origin (scheme+host+port). `corsMode` defaults to `custom` — an empty list blocks every cross-origin request. | `[cors]` (`mode`, `allowedOrigins`, `allowCredentials`) in `app.toml` → `sync push`; `--cors-origins "<o1>,<o2>"` for a one-off |
+| `redirectUris` | OAuth callbacks are validated against this whitelist — a non-listed callback URL returns 400 `Invalid redirect URI`. | Admin Console only — not in `app.toml`, no CLI flag |
+| `baseUrl` | Used for links in auth emails / redirects. | `[app].baseUrl` in `app.toml` → `sync push`; `--base-url <url>` for a one-off |
+| Provider toggles | What `getAuthConfig()` reports. | `[auth]` in `app.toml` (`googleOAuthEnabled`, `magicLinkEnabled`) → `sync push`. `otp` has no TOML key — set it with `--otp <bool>` only. |
 
 
-Dev → prod checklist: add the production origin to `corsAllowedOrigins`, add the production OAuth callback to `redirectUris` (Admin Console), update `baseUrl`, and re-check `getAuthConfig()` reports the expected methods.
+Dev → prod checklist: add the production origin to `[cors].allowedOrigins` and set `[app].baseUrl` in `app.toml`, `primitive sync push`, add the production OAuth callback to `redirectUris` (Admin Console — not synced), and re-check `getAuthConfig()` reports the expected methods.
 
 ---
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_AUTHENTICATION.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_AUTHENTICATION.template.md
@@ -52,25 +52,25 @@ In the starter template this wiring is owned for you by `PrimitiveAppState.initi
 
 ## Server App Settings ↔ Client Contract
 
-Server-side app settings must align with the origin the client app is served from. Inspect with `primitive apps get`; the relevant fields:
+Server-side app settings must align with the origin the client app is served from. These settings live in `config/app.toml` and sync with `primitive sync push` — **edit the TOML and push as the default path** so the server stays in lockstep with what's checked in. The `primitive apps update --flag` calls below are a quick imperative escape hatch; a flag change mutates the server but leaves `app.toml` stale, so the next `primitive sync push` silently reverts it unless you mirror the change back into the TOML. Inspect the live values with `primitive apps get`; the relevant fields:
 
 | Server field | Contract | Set via |
 |---|---|---|
-| `corsAllowedOrigins` | Must contain the exact serving origin (scheme+host+port). `corsMode` defaults to `custom` — an empty list blocks every cross-origin request. | `primitive apps update --cors-origins "<o1>,<o2>"` |
-| `redirectUris` | OAuth callbacks are validated against this whitelist — a non-listed callback URL returns 400 `Invalid redirect URI`. | Admin Console only (no CLI flag) |
-| `baseUrl` | Used for links in auth emails / redirects. | `primitive apps update --base-url <url>` |
+| `corsAllowedOrigins` | Must contain the exact serving origin (scheme+host+port). `corsMode` defaults to `custom` — an empty list blocks every cross-origin request. | `[cors]` (`mode`, `allowedOrigins`, `allowCredentials`) in `app.toml` → `sync push`; `--cors-origins "<o1>,<o2>"` for a one-off |
+| `redirectUris` | OAuth callbacks are validated against this whitelist — a non-listed callback URL returns 400 `Invalid redirect URI`. | Admin Console only — not in `app.toml`, no CLI flag |
+| `baseUrl` | Used for links in auth emails / redirects. | `[app].baseUrl` in `app.toml` → `sync push`; `--base-url <url>` for a one-off |
 {{#lang ts}}
-| Provider toggles | `--google-oauth`/`--magic-link`/`--otp`/`--passkey <bool>` — what `getAuthConfig()` reports. | `primitive apps update` |
+| Provider toggles | What `getAuthConfig()` reports. | `[auth]` in `app.toml` (`googleOAuthEnabled`, `magicLinkEnabled`, `passkeyEnabled` + `[auth.passkeys]`) → `sync push`. `otp` has no TOML key — set it with `--otp <bool>` only. |
 {{/lang}}
 {{#lang swift}}
-| Provider toggles | `--google-oauth`/`--magic-link`/`--otp <bool>` — what `getAuthConfig()` reports. | `primitive apps update` |
+| Provider toggles | What `getAuthConfig()` reports. | `[auth]` in `app.toml` (`googleOAuthEnabled`, `magicLinkEnabled`) → `sync push`. `otp` has no TOML key — set it with `--otp <bool>` only. |
 {{/lang}}
 
 {{#lang ts}}
 **CORS misconfiguration blocks bootstrap.** When the serving origin is missing from `corsAllowedOrigins`, the browser blocks the client's bootstrap refresh (`POST …/api/auth/refresh` → 403, no `access-control-allow-origin`): `initializeClient` throws `initializeClient refresh failed (network)` before `getAuthConfig()` is reached, and the template app's login surfaces the error. Fix by adding the serving origin (`primitive apps update --cors-origins`; inspect with `primitive apps get`). Common triggers: serving on a non-default port, or a newly deployed domain.
 {{/lang}}
 
-Dev → prod checklist: add the production origin to `corsAllowedOrigins`, add the production OAuth callback to `redirectUris` (Admin Console), update `baseUrl`, and re-check `getAuthConfig()` reports the expected methods.
+Dev → prod checklist: add the production origin to `[cors].allowedOrigins` and set `[app].baseUrl` in `app.toml`, `primitive sync push`, add the production OAuth callback to `redirectUris` (Admin Console — not synced), and re-check `getAuthConfig()` reports the expected methods.
 
 ---
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_AUTHENTICATION.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_AUTHENTICATION.ts.md
@@ -70,18 +70,18 @@ In the starter template this wiring is owned for you by the template's `userStor
 
 ## Server App Settings ↔ Client Contract
 
-Server-side app settings must align with the origin the client app is served from. Inspect with `primitive apps get`; the relevant fields:
+Server-side app settings must align with the origin the client app is served from. These settings live in `config/app.toml` and sync with `primitive sync push` — **edit the TOML and push as the default path** so the server stays in lockstep with what's checked in. The `primitive apps update --flag` calls below are a quick imperative escape hatch; a flag change mutates the server but leaves `app.toml` stale, so the next `primitive sync push` silently reverts it unless you mirror the change back into the TOML. Inspect the live values with `primitive apps get`; the relevant fields:
 
 | Server field | Contract | Set via |
 |---|---|---|
-| `corsAllowedOrigins` | Must contain the exact serving origin (scheme+host+port). `corsMode` defaults to `custom` — an empty list blocks every cross-origin request. | `primitive apps update --cors-origins "<o1>,<o2>"` |
-| `redirectUris` | OAuth callbacks are validated against this whitelist — a non-listed callback URL returns 400 `Invalid redirect URI`. | Admin Console only (no CLI flag) |
-| `baseUrl` | Used for links in auth emails / redirects. | `primitive apps update --base-url <url>` |
-| Provider toggles | `--google-oauth`/`--magic-link`/`--otp`/`--passkey <bool>` — what `getAuthConfig()` reports. | `primitive apps update` |
+| `corsAllowedOrigins` | Must contain the exact serving origin (scheme+host+port). `corsMode` defaults to `custom` — an empty list blocks every cross-origin request. | `[cors]` (`mode`, `allowedOrigins`, `allowCredentials`) in `app.toml` → `sync push`; `--cors-origins "<o1>,<o2>"` for a one-off |
+| `redirectUris` | OAuth callbacks are validated against this whitelist — a non-listed callback URL returns 400 `Invalid redirect URI`. | Admin Console only — not in `app.toml`, no CLI flag |
+| `baseUrl` | Used for links in auth emails / redirects. | `[app].baseUrl` in `app.toml` → `sync push`; `--base-url <url>` for a one-off |
+| Provider toggles | What `getAuthConfig()` reports. | `[auth]` in `app.toml` (`googleOAuthEnabled`, `magicLinkEnabled`, `passkeyEnabled` + `[auth.passkeys]`) → `sync push`. `otp` has no TOML key — set it with `--otp <bool>` only. |
 
 **CORS misconfiguration blocks bootstrap.** When the serving origin is missing from `corsAllowedOrigins`, the browser blocks the client's bootstrap refresh (`POST …/api/auth/refresh` → 403, no `access-control-allow-origin`): `initializeClient` throws `initializeClient refresh failed (network)` before `getAuthConfig()` is reached, and the template app's login surfaces the error. Fix by adding the serving origin (`primitive apps update --cors-origins`; inspect with `primitive apps get`). Common triggers: serving on a non-default port, or a newly deployed domain.
 
-Dev → prod checklist: add the production origin to `corsAllowedOrigins`, add the production OAuth callback to `redirectUris` (Admin Console), update `baseUrl`, and re-check `getAuthConfig()` reports the expected methods.
+Dev → prod checklist: add the production origin to `[cors].allowedOrigins` and set `[app].baseUrl` in `app.toml`, `primitive sync push`, add the production OAuth callback to `redirectUris` (Admin Console — not synced), and re-check `getAuthConfig()` reports the expected methods.
 
 ---
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_CONFIGURATION.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_CONFIGURATION.md
@@ -47,6 +47,16 @@ config/
   collection-type-configs/*.toml  # Collection type configs
 ```
 
+## App settings (`app.toml`)
+
+App-level settings sync from `app.toml`; editing the TOML and `sync push` is the default path. The equivalent `primitive apps update --flag` calls mutate the server imperatively and drift from the checked-in TOML — the next `sync push` reverts them unless mirrored back. TOML-syncable settings:
+
+- `[app]` — `name`, `mode`, `waitlistEnabled`, `baseUrl`
+- `[auth]` — `googleOAuthEnabled`, `magicLinkEnabled`, `passkeyEnabled`, `[auth.passkeys]` relying-party config
+- `[cors]` (serialized only when `mode = "custom"`) — `allowedOrigins`, `allowCredentials`, `allowedMethods`, `maxAge`
+
+Not in `app.toml` (see [What sync does NOT carry](#what-sync-does-not-carry)): `otp` (set via `--otp <bool>` only) and `redirectUris` (Admin Console only — no TOML key, no CLI flag).
+
 ## Environment resolution
 
 Every command resolves its target environment in order: `--env <name>` flag → `PRIMITIVE_ENV` env var → `defaultEnvironment` in `.primitive/config.json` → the only defined environment → error. Manage environments with `primitive env add|list|show|use|remove`. Tokens are stored per-environment in `.primitive/credentials.json` (gitignored); `.primitive/config.json` is committed.
@@ -57,14 +67,15 @@ Every command resolves its target environment in order: `--env <name>` flag → 
 
 ## What sync does NOT carry
 
-Some flags are set with dedicated update commands rather than TOML:
+Some settings are set with dedicated update commands rather than TOML (app-level settings that *do* sync are listed under [App settings](#app-settings-app-toml)):
 
 ```bash
 primitive workflows update <id> --requires-client-apply false
 primitive workflows update <id> --sync-callable true
-primitive apps update --cors-origins "..." --base-url "..." --google-oauth true
+primitive apps update --otp true                                          # no TOML key
 primitive apps update --member-invitations-enabled true --member-invitation-limit 5
 primitive apps update --test-account-bases alice@example.com
+# redirectUris: Admin Console only — no TOML key, no CLI flag
 ```
 
 ## Secrets

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_CONFIGURATION.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_CONFIGURATION.template.md
@@ -47,6 +47,16 @@ config/
   collection-type-configs/*.toml  # Collection type configs
 ```
 
+## App settings (`app.toml`)
+
+App-level settings sync from `app.toml`; editing the TOML and `sync push` is the default path. The equivalent `primitive apps update --flag` calls mutate the server imperatively and drift from the checked-in TOML — the next `sync push` reverts them unless mirrored back. TOML-syncable settings:
+
+- `[app]` — `name`, `mode`, `waitlistEnabled`, `baseUrl`
+- `[auth]` — `googleOAuthEnabled`, `magicLinkEnabled`, `passkeyEnabled`, `[auth.passkeys]` relying-party config
+- `[cors]` (serialized only when `mode = "custom"`) — `allowedOrigins`, `allowCredentials`, `allowedMethods`, `maxAge`
+
+Not in `app.toml` (see [What sync does NOT carry](#what-sync-does-not-carry)): `otp` (set via `--otp <bool>` only) and `redirectUris` (Admin Console only — no TOML key, no CLI flag).
+
 ## Environment resolution
 
 Every command resolves its target environment in order: `--env <name>` flag → `PRIMITIVE_ENV` env var → `defaultEnvironment` in `.primitive/config.json` → the only defined environment → error. Manage environments with `primitive env add|list|show|use|remove`. Tokens are stored per-environment in `.primitive/credentials.json` (gitignored); `.primitive/config.json` is committed.
@@ -57,14 +67,15 @@ Every command resolves its target environment in order: `--env <name>` flag → 
 
 ## What sync does NOT carry
 
-Some flags are set with dedicated update commands rather than TOML:
+Some settings are set with dedicated update commands rather than TOML (app-level settings that *do* sync are listed under [App settings](#app-settings-app-toml)):
 
 ```bash
 primitive workflows update <id> --requires-client-apply false
 primitive workflows update <id> --sync-callable true
-primitive apps update --cors-origins "..." --base-url "..." --google-oauth true
+primitive apps update --otp true                                          # no TOML key
 primitive apps update --member-invitations-enabled true --member-invitation-limit 5
 primitive apps update --test-account-bases alice@example.com
+# redirectUris: Admin Console only — no TOML key, no CLI flag
 ```
 
 ## Secrets


### PR DESCRIPTION
## What the issue reported

The configuration and authentication guides presented individual `primitive apps update --flag` calls as *the* way to set server-side app settings (CORS origins, base URL, provider toggles), without steering readers toward the `app.toml` config-as-code (sync) path. This invites drift: updating settings imperatively mutates the server but leaves the checked-in `app.toml` stale, so the next `primitive sync push` silently reverts the change.

## Verified against source

`#111` flagged the full guidance as partly blocked on js-bao-wss#1033 ("Support TOML config sync for app settings"). **That blocker has landed and is in the stamped submodule** (`library_repos/js-bao-wss`): `cli/src/commands/sync.ts` both serializes app settings → `app.toml` (`serializeAppSettings`) and pushes `app.toml` → server (`updateAppSettings`). Confirmed the exact current coverage:

- **`[app]`** — `name`, `mode`, `waitlistEnabled`, `baseUrl`
- **`[auth]`** — `googleOAuthEnabled`, `magicLinkEnabled`, `passkeyEnabled`, `[auth.passkeys]`
- **`[cors]`** (serialized only when `mode = "custom"`) — `allowedOrigins`, `allowCredentials`, `allowedMethods`, `maxAge`

Two exceptions, also verified in source: **`otp`** is settable via `primitive apps update --otp` only (no TOML key), and **`redirectUris`** is settable via neither TOML nor a CLI flag (Admin Console only) — matching the issue's point 3.

Because the blocker is resolved, the docs now recommend TOML as the default (rather than merely "describe current coverage without overpromising").

## What changed

- **`docs/getting-started/authentication.md`** — "Server App Settings" table reframed around where each setting lives in `app.toml`; OAuth setup example uses a TOML block + `sync push`; drift caution added.
- **`docs/getting-started/primitive-cli.md`** — OAuth Configuration leads with the TOML path; Configuration Sync section enumerates the TOML-syncable app settings and the `otp`/`redirectUris` exceptions.
- **`AGENT_GUIDE_TO_PRIMITIVE_AUTHENTICATION.template.md`** — settings table + dev→prod checklist updated (per guide-sync rule with the human page).
- **`AGENT_GUIDE_TO_PRIMITIVE_CONFIGURATION.template.md`** — new "App settings (`app.toml`)" section; corrected the "What sync does NOT carry" list, which wrongly listed `--cors-origins`/`--base-url`/`--google-oauth` (now TOML-syncable).
- Guide builds re-rendered via `pnpm render:guides`.

## Validation

- `pnpm check:examples` — pass (parity, compilation, TOML, guide render/registry, CLI invocations validated against `primitive-admin`, source-stamp gate)
- `npx vitepress build docs` — pass (no dead links)

Fixes #111