### PR TITLE
ci: tier docs automation by release — nightly→next-sync, production→publish (#88)

### DIFF
--- a/.github/workflows/docs-next-sync.yml
+++ b/.github/workflows/docs-next-sync.yml
@@ -1,10 +1,15 @@
 # Docs next-sync (agent automation)
 #
-# Receives the `submodule-update` repository_dispatch that the library repos
-# (js-bao-wss, primitive-app-dev) fire on every push to their main branch, and
-# runs the project's docs-next-sync skill with the Claude Code CLI to true the
-# docs on the `next` branch against the library main tips. The result is opened
-# as a pull request into `next` for human review — this workflow never merges.
+# Receives the `nightly-release` repository_dispatch that the library repos
+# (js-bao-wss, …) fire once per night, and runs the project's docs-next-sync
+# skill with the Claude Code CLI to true the docs on the `next` branch against
+# the library main tips. The result is opened as a pull request into `next` for
+# human review — this workflow never merges.
+#
+# The nightly cadence deliberately supersedes the old per-commit trigger: the
+# skill batches a whole day of library commits into one truing pass rather than
+# firing on every push. Production releases are a separate tier — they trigger
+# `docs-publish-release` via receive-production-release.yml, not this workflow.
 #
 # NOTE: repository_dispatch only triggers workflows that live on the default
 # branch (main), so this file must stay on main even though the work it does
@@ -19,7 +24,7 @@ name: Docs Next-Sync (agent)
 
 on:
   repository_dispatch:
-    types: [submodule-update]
+    types: [nightly-release]
 
   # Manual trigger for testing / on-demand runs.
   workflow_dispatch:
@@ -85,25 +90,29 @@ jobs:
         run: pnpm install
 
       - name: Build context from dispatch payload
+        # The dispatch is fired by js-bao-wss's notify-docs-on-release.yml when a
+        # `release:nightly` issue is marked `status:deployed`. It forwards that
+        # issue's number/url/body — the body's "What shipped" PR list is a useful
+        # hint, but the scan below re-derives the authoritative diff regardless.
         id: ctx
         env:
           EVENT_NAME: ${{ github.event_name }}
           P_SUBMODULE: ${{ github.event.client_payload.submodule }}
-          P_REF: ${{ github.event.client_payload.ref }}
-          P_CHANGED: ${{ github.event.client_payload.changed_files }}
-          P_COMMITS: ${{ github.event.client_payload.commit_messages }}
+          P_ISSUE: ${{ github.event.client_payload.source_issue }}
+          P_URL: ${{ github.event.client_payload.source_url }}
+          P_NOTES: ${{ github.event.client_payload.release_notes }}
           I_SUBMODULE: ${{ github.event.inputs.submodule }}
         run: |
           if [ "$EVENT_NAME" = "repository_dispatch" ]; then
-            SUBMODULE="$P_SUBMODULE"; REF="$P_REF"; CHANGED="$P_CHANGED"; COMMITS="$P_COMMITS"
+            SUBMODULE="${P_SUBMODULE:-js-bao-wss}"; ISSUE="$P_ISSUE"; URL="$P_URL"; NOTES="$P_NOTES"
           else
-            SUBMODULE="$I_SUBMODULE"; REF="main"; CHANGED="(manual run)"; COMMITS="(manual run)"
+            SUBMODULE="$I_SUBMODULE"; ISSUE="(manual run)"; URL=""; NOTES="(manual run)"
           fi
           {
             echo "submodule=$SUBMODULE"
-            echo "ref=$REF"
-            echo "changed<<EOF"; echo "$CHANGED"; echo "EOF"
-            echo "commits<<EOF"; echo "$COMMITS"; echo "EOF"
+            echo "issue=$ISSUE"
+            echo "url=$URL"
+            echo "notes<<EOF"; echo "$NOTES"; echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
       - name: Scan for documentable changes since the last stamp
@@ -133,9 +142,9 @@ jobs:
           # library repos; gh reads GH_TOKEN.
           GH_TOKEN: ${{ secrets.DOCS_REPO_PAT }}
           SUBMODULE: ${{ steps.ctx.outputs.submodule }}
-          LIB_REF: ${{ steps.ctx.outputs.ref }}
-          CHANGED: ${{ steps.ctx.outputs.changed }}
-          COMMITS: ${{ steps.ctx.outputs.commits }}
+          ISSUE: ${{ steps.ctx.outputs.issue }}
+          URL: ${{ steps.ctx.outputs.url }}
+          NOTES: ${{ steps.ctx.outputs.notes }}
         run: |
           npm install -g @anthropic-ai/claude-code
 
@@ -176,13 +185,11 @@ jobs:
           # Append the (untrusted) payload context as plain data.
           {
             echo
-            echo "Triggering push context (a hint only; the skill re-derives the authoritative diff):"
-            echo "- Submodule: ${SUBMODULE:-unknown}"
-            echo "- Library commit: ${LIB_REF:-unknown}"
-            echo "- Changed files:"
-            echo "${CHANGED:-(none)}"
-            echo "- Commit messages:"
-            echo "${COMMITS:-(none)}"
+            echo "Triggering nightly-release context (a hint only; the skill re-derives the authoritative diff):"
+            echo "- Submodule: ${SUBMODULE:-js-bao-wss}"
+            echo "- Source release issue: ${SUBMODULE:-js-bao-wss}#${ISSUE:-unknown} ${URL:-}"
+            echo "- Release report (\"What shipped\" etc.):"
+            echo "${NOTES:-(none)}"
           } >> /tmp/prompt.txt
 
           set +e
@@ -253,7 +260,7 @@ jobs:
             docs-next-sync: true next against ${{ steps.ctx.outputs.submodule }} (automated)
           title: "docs-next-sync: ${{ steps.ctx.outputs.submodule }} changes (automated)"
           body: |
-            Automated `docs-next-sync` pass against the library main tips, triggered by changes in **${{ steps.ctx.outputs.submodule }}** (`${{ steps.ctx.outputs.ref }}`).
+            Automated `docs-next-sync` pass against the library main tips, triggered by the nightly release ${{ steps.ctx.outputs.submodule }}#${{ steps.ctx.outputs.issue }}.
 
             ${{ steps.report.outputs.body }}
 

--- a/.github/workflows/receive-production-release.yml
+++ b/.github/workflows/receive-production-release.yml
@@ -1,0 +1,106 @@
+# Docs publish-release (production tier)
+#
+# Receives the `production-release` repository_dispatch that js-bao-wss fires on
+# push to a `deploy/production/**` branch, and files an issue prompting a
+# human-in-the-loop `docs-publish-release` run (merge `next` → `main` at the
+# release SHA). This workflow does NOT publish anything itself — publishing is a
+# deliberate human action; it only surfaces the release so the skill has the
+# summary it needs.
+#
+# Pairs with the nightly tier (docs-next-sync.yml): nightlies true `next`,
+# production releases publish a slice of `next` to `main`.
+#
+# NOTE: repository_dispatch only triggers workflows on the default branch (main),
+# so this file must stay on main.
+#
+# Payload (client_payload) from js-bao-wss notify-docs-release.yml:
+#   sha           — full deployed js-bao-wss commit
+#   release_date  — YYYY-MM-DD
+#   release_file  — releases/YYYY-MM-DD-<sha8>.md (path in js-bao-wss)
+#   release_notes — the full contents of that release summary (starts with
+#                   "# Production release YYYY-MM-DD (sha8)")
+
+name: Docs Publish-Release (notify)
+
+on:
+  repository_dispatch:
+    types: [production-release]
+
+  # Manual trigger for testing: paste a release summary and a SHA.
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: 'Deployed js-bao-wss SHA (full)'
+        required: true
+        type: string
+      release_notes:
+        description: 'Release summary markdown (optional; a stub is filed if omitted)'
+        required: false
+        type: string
+
+permissions:
+  issues: write
+
+jobs:
+  file-publish-issue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build issue fields from payload
+        id: ctx
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          P_SHA: ${{ github.event.client_payload.sha }}
+          P_DATE: ${{ github.event.client_payload.release_date }}
+          P_FILE: ${{ github.event.client_payload.release_file }}
+          P_NOTES: ${{ github.event.client_payload.release_notes }}
+          P_SRC_URL: ${{ github.event.client_payload.source_url }}
+          I_SHA: ${{ github.event.inputs.sha }}
+          I_NOTES: ${{ github.event.inputs.release_notes }}
+        run: |
+          if [ "$EVENT_NAME" = "repository_dispatch" ]; then
+            SHA="$P_SHA"; DATE="$P_DATE"; FILE="$P_FILE"; NOTES="$P_NOTES"; SRC_URL="$P_SRC_URL"
+          else
+            SHA="$I_SHA"; DATE=""; FILE=""; NOTES="$I_NOTES"; SRC_URL=""
+          fi
+
+          SHA8="${SHA:0:8}"
+          # Fall back to deriving the date from the release filename, then to "unknown".
+          if [ -z "$DATE" ] && [ -n "$FILE" ]; then
+            DATE="$(basename "$FILE" | sed -E 's/^([0-9]{4}-[0-9]{2}-[0-9]{2})-.*/\1/')"
+          fi
+          [ -z "$DATE" ] && DATE="unknown"
+
+          echo "sha8=$SHA8" >> "$GITHUB_OUTPUT"
+          echo "src_url=$SRC_URL" >> "$GITHUB_OUTPUT"
+          echo "title=Production release $DATE ($SHA8) — publish docs" >> "$GITHUB_OUTPUT"
+          {
+            echo "notes<<NOTES_EOF"
+            if [ -n "$NOTES" ]; then echo "$NOTES"; else echo "_(no release summary in the payload — pull it from js-bao-wss \`$FILE\`.)_"; fi
+            echo "NOTES_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: File or skip the publish issue
+        env:
+          GH_TOKEN: ${{ secrets.DOCS_REPO_PAT }}
+          GH_REPO: ${{ github.repository }}
+          TITLE: ${{ steps.ctx.outputs.title }}
+          SHA8: ${{ steps.ctx.outputs.sha8 }}
+          NOTES: ${{ steps.ctx.outputs.notes }}
+          SRC_URL: ${{ steps.ctx.outputs.src_url }}
+        run: |
+          # Idempotent: a re-dispatch for the same release must not file a duplicate.
+          existing="$(gh issue list --state open --search "Production release ($SHA8) in:title" --json number --jq '.[0].number' || true)"
+          if [ -n "$existing" ]; then
+            echo "Open publish issue already exists (#$existing) for $SHA8 — skipping." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          {
+            printf '%s\n\n' "A production release has been deployed. Publish the docs by running the **docs-publish-release** skill (\`/docs-publish-release\`) against the summary below — it merges \`next\` into \`main\` at the release SHA, never past it. This is a human-in-the-loop step; the receiver only files this issue."
+            [ -n "$SRC_URL" ] && printf 'Source release issue: %s\n\n' "$SRC_URL"
+            printf '%s\n\n' "---"
+            printf '%s\n' "$NOTES"
+          } > /tmp/publish-issue-body.md
+
+          url="$(gh issue create --title "$TITLE" --body-file /tmp/publish-issue-body.md)"
+          echo "Filed publish issue: $url" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Implements the **primitive-docs receiver side** of #88: tier the docs automation by release instead of running docs-next-sync on every library commit.

## Approach (issue-keyed, not branch-push)

js-bao-wss already files a canonical issue for each release tier (`release:nightly` with a `status:running`→`status:deployed` lifecycle; `release:production` opened after a prod deploy). This wiring keys off **those issues** — the same finalized records humans read — rather than a parallel branch-push signal. The matching js-bao-wss sender is a separate PR: Primitive-Labs/js-bao-wss#1142.

## Changes (both receivers stay on `main` — `repository_dispatch` only triggers default-branch workflows)

- **`receive-submodule-update.yml` → `docs-next-sync.yml`**: trigger changed from `submodule-update` (every push) to `nightly-release`. The forwarded nightly issue body ("What shipped" PR list) is passed to the agent as context; the existing scan still re-derives the authoritative diff and no-ops when the stamped tips haven't moved. Manual `workflow_dispatch` retained.
- **`receive-production-release.yml`** (new): consumes a `production-release` dispatch and files a human-in-the-loop **"Production release … — publish docs"** issue embedding the `releases/<date>-<sha8>.md` summary (the exact `# Production release …` shape `docs-publish-release` expects), with a backlink to the source release issue. Idempotent — skips if an open publish issue already exists for the SHA.

## Validation

- Both workflows parse as valid YAML.
- No remaining references to removed dispatch fields.

Part of #88 (nightly → docs-next-sync, production → docs-publish-release).