### PR TITLE
Migrate inline ts/swift fences to the examples corpus (#87)

### DIFF
--- a/examples/analytics/feature-usage-tracking.swift
+++ b/examples/analytics/feature-usage-tracking.swift
@@ -1,0 +1,51 @@
+import JsBaoClient
+
+// End-to-end feature-usage tracking: configure auto events on the client, set
+// an app-version override once, then log a per-feature action and a pre-auth
+// landing event. client.destroy() flushes on teardown, so no manual flush.
+func setupFeatureTracking(currentUserUlid: String) -> JsBaoClient {
+  // #region example
+  let client = JsBaoClient(options: JsBaoClientOptions(
+    apiUrl: "https://primitiveapi.com",
+    wsUrl: "wss://primitiveapi.com",
+    appId: "YOUR_APP_ID",
+    analyticsAutoEvents: AnalyticsAutoEventsConfig(
+      blobUploadsStart: false,
+      blobUploadsSuccess: true,
+      blobUploadsFailure: true,
+      sessionEnd: true
+    )
+  ))
+
+  // Set version once after init (or after a deploy notification)
+  client.analytics.setAppVersionOverride("2.1.4")
+
+  func trackFeatureUsed(
+    _ userUlid: String,
+    feature: String,
+    action: String,
+    context: JSONValue? = nil
+  ) {
+    client.analytics.logEvent(AnalyticsEventInput(
+      action: action,
+      feature: feature,
+      user_ulid: userUlid,
+      context_json: context
+    ))
+  }
+
+  // Authenticated event
+  trackFeatureUsed(currentUserUlid, feature: "reports", action: "report_generated", context: [
+    "reportType": "quarterly",
+    "format": "pdf",
+  ])
+
+  // Pre-auth event (landing page)
+  client.analytics.logEvent(AnalyticsEventInput(
+    action: "landing_page_view",
+    feature: "onboarding",
+    user_ulid: AnalyticsEventInput.unauthenticatedUser
+  ))
+  // #endregion example
+  return client
+}

--- a/examples/analytics/feature-usage-tracking.ts
+++ b/examples/analytics/feature-usage-tracking.ts
@@ -1,0 +1,50 @@
+import { initializeClient, ANALYTICS_UNAUTHENTICATED_USER } from "js-bao-wss-client";
+
+// End-to-end feature-usage tracking: configure auto events on the client, set
+// an app-version override once, then log a per-feature action and a pre-auth
+// landing event. No beforeunload flush — the client adds one automatically.
+export async function setupFeatureTracking(currentUserUlid: string) {
+  // #region example
+  const client = await initializeClient({
+    apiUrl: "https://primitiveapi.com",
+    wsUrl: "wss://primitiveapi.com",
+    appId: "YOUR_APP_ID",
+    analyticsAutoEvents: {
+      sessionEnd: true,
+      blobUploads: { start: false, success: true, failure: true },
+      llm: { start: false, success: true, failure: true },
+    },
+  });
+
+  // Set version once after init (or after a deploy notification)
+  client.analytics.setAppVersionOverride("2.1.4");
+
+  function trackFeatureUsed(
+    userUlid: string,
+    feature: string,
+    action: string,
+    context?: Record<string, unknown>,
+  ) {
+    client.analytics.logEvent({
+      action,
+      feature,
+      user_ulid: userUlid,
+      context_json: context,
+    });
+  }
+
+  // Authenticated event
+  trackFeatureUsed(currentUserUlid, "reports", "report_generated", {
+    reportType: "quarterly",
+    format: "pdf",
+  });
+
+  // Pre-auth event (landing page)
+  client.analytics.logEvent({
+    action: "landing_page_view",
+    feature: "onboarding",
+    user_ulid: ANALYTICS_UNAUTHENTICATED_USER,
+  });
+  // #endregion example
+  return client;
+}

--- a/examples/analytics/manual-flush.swift
+++ b/examples/analytics/manual-flush.swift
@@ -1,0 +1,10 @@
+import JsBaoClient
+
+// Events are buffered and flushed automatically (every 100ms, or earlier when
+// batched). client.destroy() triggers a final flush on teardown, so a manual
+// flush is only needed to force an immediate send.
+func flushAnalytics(client: JsBaoClient) {
+  // #region example
+  client.analytics.flush()
+  // #endregion example
+}

--- a/examples/analytics/manual-flush.ts
+++ b/examples/analytics/manual-flush.ts
@@ -1,0 +1,10 @@
+import type { JsBaoClient } from "js-bao-wss-client";
+
+// Events are buffered and flushed automatically (every 100ms, on a full
+// buffer, on beforeunload/visibility-hidden, and on reconnect). Call flush
+// to force a send before an explicit teardown.
+export function flushAnalytics(client: JsBaoClient) {
+  // #region example
+  client.analytics.flush();
+  // #endregion example
+}

--- a/examples/auth/magic-link-invite.swift
+++ b/examples/auth/magic-link-invite.swift
@@ -1,0 +1,19 @@
+import JsBaoClient
+
+// Accept an invitation server-side at magic-link verify time, so the deferred
+// grant resolves to the signing-in user even when the invited email differs.
+func magicLinkVerifyWithInvite(
+  client: JsBaoClient,
+  magicToken: String,
+  inviteTokenFromUrl: String
+) async throws {
+  // #region example
+  let result = try await client.auth.magicLinkVerify(
+    token: magicToken,
+    inviteToken: inviteTokenFromUrl
+  )
+  let user = result.user
+  let isNewUser = result.isNewUser ?? false
+  // #endregion example
+  _ = (user, isNewUser)
+}

--- a/examples/auth/magic-link-invite.ts
+++ b/examples/auth/magic-link-invite.ts
@@ -1,0 +1,16 @@
+import type { JsBaoClient } from "js-bao-wss-client";
+
+// Accept an invitation server-side at magic-link verify time, so the deferred
+// grant resolves to the signing-in user even when the invited email differs.
+export async function magicLinkVerifyWithInvite(
+  client: JsBaoClient,
+  magicToken: string,
+  inviteTokenFromUrl: string,
+) {
+  // #region example
+  const { user, isNewUser } = await client.magicLinkVerify(magicToken, {
+    inviteToken: inviteTokenFromUrl,
+  });
+  // #endregion example
+  return { user, isNewUser };
+}

--- a/examples/blobs/bucket-positional-args.swift
+++ b/examples/blobs/bucket-positional-args.swift
@@ -1,0 +1,22 @@
+import Foundation
+import JsBaoClient
+
+// The bucket API is flat: there is no bucket() context object. The bucket
+// key (or id) is always the leading argument to each method.
+func bucketPositionalArgs(
+  client: JsBaoClient,
+  blobId: String,
+  filename: String,
+  contentType: String,
+  data: Data
+) async throws {
+  // #region example
+  // The bucket key/ID is a positional arg — there is no bucket() context object.
+  try await client.blobBuckets.upload(
+    bucketIdOrKey: "avatars", data: data, filename: filename, contentType: contentType
+  )
+  try await client.blobBuckets.getSignedUrl(
+    bucketIdOrKey: "avatars", blobId: blobId, expiresInSeconds: 3600
+  )
+  // #endregion example
+}

--- a/examples/blobs/bucket-positional-args.ts
+++ b/examples/blobs/bucket-positional-args.ts
@@ -1,0 +1,17 @@
+import type { JsBaoClient } from "js-bao-wss-client";
+
+// The bucket API is flat: there is NO bucket() context object. The bucket
+// key (or id) is always the first positional argument to each method.
+export async function bucketPositionalArgs(
+  client: JsBaoClient,
+  blobId: string,
+  filename: string,
+  contentType: string,
+  data: Uint8Array,
+) {
+  // #region example
+  // The bucket key/ID is a positional arg — there is no bucket() context object.
+  await client.blobBuckets.upload("avatars", { filename, contentType, data });
+  await client.blobBuckets.getSignedUrl("avatars", blobId, 3600);
+  // #endregion example
+}

--- a/examples/blobs/doc-blob-download-url.swift
+++ b/examples/blobs/doc-blob-download-url.swift
@@ -1,0 +1,20 @@
+import JsBaoClient
+
+// Build an authenticated download URL for a document blob. The URL is
+// authenticated via the user's session against the API origin. The endpoint
+// chooses Content-Disposition from this `disposition`, not the upload-time value.
+func buildDownloadUrl(
+  client: JsBaoClient,
+  documentId: String,
+  blobId: String
+) {
+  let blobs = client.documents.blobs(documentId: documentId)
+  // #region example
+  let url = blobs.downloadUrl(
+    blobId: blobId,
+    disposition: .attachment,            // or .inline
+    attachmentFilename: "report.pdf"     // optional override (RFC 5987-encoded)
+  )
+  // #endregion example
+  _ = url
+}

--- a/examples/blobs/doc-blob-download-url.ts
+++ b/examples/blobs/doc-blob-download-url.ts
@@ -1,0 +1,20 @@
+import type { JsBaoClient } from "js-bao-wss-client";
+
+// Build an authenticated download URL for a document blob. The URL is
+// authenticated via the user's session against the API origin and works in an
+// <a href download> or window.location. The endpoint chooses Content-Disposition
+// from this `disposition`, not the upload-time value.
+export function buildDownloadUrl(
+  client: JsBaoClient,
+  documentId: string,
+  blobId: string,
+) {
+  const blobs = client.document(documentId).blobs();
+  // #region example
+  const url = blobs.downloadUrl(blobId, {
+    disposition: "attachment",        // or "inline"
+    attachmentFilename: "report.pdf", // optional override (RFC 5987-encoded)
+  });
+  // #endregion example
+  return url;
+}

--- a/examples/blobs/doc-blob-events.swift
+++ b/examples/blobs/doc-blob-events.swift
@@ -1,0 +1,21 @@
+import JsBaoClient
+
+// Subscribe to the blob upload-queue lifecycle events, delivered as typed event
+// structs on `client.events`. `blobsUploadProgress` fires on status transitions
+// (not per-byte) — there is no per-byte progress callback.
+func wireBlobEvents(client: JsBaoClient) -> [EventSubscription] {
+  // #region example
+  let progress = client.events.on(.blobsUploadProgress) { (e: BlobUploadProgressEvent) in
+    print(e.queueId, e.blobId, e.status, e.numBytes, e.attempts)
+  }
+
+  let completed = client.events.on(.blobsUploadCompleted) { (e: BlobUploadCompletedEvent) in
+    print("done", e.blobId, e.queueId)
+  }
+
+  let failed = client.events.on(.blobsUploadFailed) { (e: BlobUploadFailedEvent) in
+    print("failed", e.blobId, e.lastError ?? "", "retry?", e.willRetry)
+  }
+  // #endregion example
+  return [progress, completed, failed]
+}

--- a/examples/blobs/doc-blob-events.ts
+++ b/examples/blobs/doc-blob-events.ts
@@ -1,0 +1,20 @@
+import type { JsBaoClient } from "js-bao-wss-client";
+
+// Subscribe to the blob upload-queue lifecycle events. `upload-progress` fires
+// on status transitions (not per-byte) — there is no per-byte progress callback.
+export function wireBlobEvents(client: JsBaoClient) {
+  // #region example
+  // status is one of: "queued" | "uploading" | "pending" | "paused"
+  client.on("blobs:upload-progress", (e) => {
+    console.log(e.queueId, e.blobId, e.status, e.numBytes, e.attempts);
+  });
+
+  client.on("blobs:upload-completed", (e) => {
+    console.log("done", e.blobId, e.queueId);
+  });
+
+  client.on("blobs:upload-failed", (e) => {
+    console.log("failed", e.blobId, e.lastError, "retry?", e.willRetry);
+  });
+  // #endregion example
+}

--- a/examples/blobs/doc-blob-list-paginate.swift
+++ b/examples/blobs/doc-blob-list-paginate.swift
@@ -1,0 +1,22 @@
+import JsBaoClient
+
+// Page through a document's blobs by following the opaque `cursor`. The cursor
+// is only present when more results exist.
+func paginateDocumentBlobs(
+  client: JsBaoClient,
+  documentId: String
+) async throws {
+  let blobs = client.documents.blobs(documentId: documentId)
+  // #region example
+  let page1 = try await blobs.list(limit: 50)
+  for b in page1.items {
+    print(b.blobId, b.filename, b.contentType, b.numBytes, b.sha256, b.createdAt)
+  }
+
+  // `cursor` is an opaque token; only present when more results remain.
+  if let cursor = page1.cursor {
+    let page2 = try await blobs.list(cursor: cursor)
+    _ = page2.items
+  }
+  // #endregion example
+}

--- a/examples/blobs/doc-blob-list-paginate.ts
+++ b/examples/blobs/doc-blob-list-paginate.ts
@@ -1,0 +1,23 @@
+import type { JsBaoClient } from "js-bao-wss-client";
+
+// Page through a document's blobs by following the opaque `cursor`. The cursor
+// is only present when more results exist.
+export async function paginateDocumentBlobs(
+  client: JsBaoClient,
+  documentId: string,
+) {
+  const blobs = client.document(documentId).blobs();
+  // #region example
+  const page1 = await blobs.list({ limit: 50 });
+  for (const b of page1.items) {
+    console.log(b.blobId, b.filename, b.contentType, b.numBytes, b.sha256, b.createdAt);
+  }
+
+  // `cursor` is an opaque token; only present when more results remain.
+  if (page1.cursor) {
+    const page2 = await blobs.list({ cursor: page1.cursor });
+    return page2.items;
+  }
+  // #endregion example
+  return page1.items;
+}

--- a/examples/blobs/doc-blob-offline.swift
+++ b/examples/blobs/doc-blob-offline.swift
@@ -1,0 +1,33 @@
+import Foundation
+import JsBaoClient
+
+// Work with document blobs offline: queue an upload while offline, read cached
+// bytes, warm the cache with prefetch, and resume the queue when back online.
+func workOffline(
+  client: JsBaoClient,
+  documentId: String,
+  data: Data,
+  blobIds: [String]
+) async throws {
+  let blobs = client.documents.blobs(documentId: documentId)
+  // #region example
+  client.setNetworkMode(.offline)
+
+  // Bytes are written to the local cache immediately and queued. upload()
+  // resolves without waiting for the network (bytesTransferred is 0).
+  let result = try await blobs.upload(
+    data: data,
+    options: BlobUploadSourceOptions(filename: "draft.txt", contentType: "text/plain")
+  )
+
+  // Reads served from cache for blobs uploaded or downloaded on this device.
+  let text = try await blobs.read(blobId: result.blobId, as: String.self)
+
+  // Warm the cache; per-blob errors are logged and swallowed.
+  await blobs.prefetch(blobIds: blobIds, concurrency: 4)
+
+  // Queue processing resumes automatically; listen for .blobsQueueDrained.
+  client.setNetworkMode(.online)
+  // #endregion example
+  _ = text
+}

--- a/examples/blobs/doc-blob-offline.ts
+++ b/examples/blobs/doc-blob-offline.ts
@@ -1,0 +1,32 @@
+import type { JsBaoClient } from "js-bao-wss-client";
+
+// Work with document blobs offline: queue an upload while offline, read cached
+// bytes, warm the cache with prefetch, and resume the queue when back online.
+export async function workOffline(
+  client: JsBaoClient,
+  documentId: string,
+  data: Uint8Array,
+  blobIds: string[],
+) {
+  const blobs = client.document(documentId).blobs();
+  // #region example
+  await client.setNetworkMode("offline");
+
+  // Bytes are written to the local cache immediately and queued. upload()
+  // resolves without waiting for the network (bytesTransferred is 0).
+  const { blobId } = await blobs.upload(data, {
+    filename: "draft.txt",
+    contentType: "text/plain",
+  });
+
+  // Reads served from cache for blobs uploaded or downloaded on this device.
+  const text = await blobs.read(blobId, { as: "text" });
+
+  // Warm the cache; per-blob errors are logged and swallowed.
+  await blobs.prefetch(blobIds, { concurrency: 4 });
+
+  // Queued uploads resume automatically once back online.
+  await client.setNetworkMode("online");
+  // #endregion example
+  return text;
+}

--- a/examples/blobs/doc-blob-queue.swift
+++ b/examples/blobs/doc-blob-queue.swift
@@ -1,0 +1,30 @@
+import JsBaoClient
+
+// Inspect and control the per-document upload queue. Failed uploads retry with
+// exponential backoff. Concurrency is a client-wide setting (applies to all
+// documents).
+func manageUploadQueue(
+  client: JsBaoClient,
+  documentId: String,
+  blobId: String
+) {
+  let blobs = client.documents.blobs(documentId: documentId)
+  // #region example
+  // Inspect what's queued for this document. Each BlobUploadStatus carries
+  // queueId, blobId, filename, contentType, numBytes, status, attempts,
+  // nextAttemptAt, lastError.
+  let tasks = blobs.uploads()
+
+  // Pause/resume by blobId (the queueId is the blobId for document uploads).
+  _ = blobs.pauseUpload(blobId: blobId)
+  _ = blobs.resumeUpload(blobId: blobId)
+
+  blobs.pauseAll()
+  blobs.resumeAll()
+
+  // Concurrency is set on the client (global, all documents).
+  client.setBlobUploadConcurrency(5) // min 1; default 2
+  let concurrency = client.getBlobUploadConcurrency()
+  // #endregion example
+  _ = (tasks, concurrency)
+}

--- a/examples/blobs/doc-blob-queue.ts
+++ b/examples/blobs/doc-blob-queue.ts
@@ -1,0 +1,29 @@
+import type { JsBaoClient } from "js-bao-wss-client";
+
+// Inspect and control the per-document upload queue. The queue is keyed by user
+// identity, retries with exponential backoff, and persists across reloads.
+// Concurrency is a client-wide setting (applies to all documents).
+export function manageUploadQueue(
+  client: JsBaoClient,
+  documentId: string,
+  blobId: string,
+) {
+  const blobs = client.document(documentId).blobs();
+  // #region example
+  // Inspect what's queued for this document. Each task carries queueId, blobId,
+  // filename, contentType, numBytes, status, attempts, nextAttemptAt, lastError.
+  const tasks = blobs.uploads();
+
+  // Pause/resume by blobId (the queueId is the blobId for document uploads).
+  blobs.pauseUpload(blobId);
+  blobs.resumeUpload(blobId);
+
+  blobs.pauseAll();
+  blobs.resumeAll();
+
+  // Concurrency is set on the client (global, all documents).
+  client.setBlobUploadConcurrency(5); // min 1; default 2
+  const concurrency = client.getBlobUploadConcurrency();
+  // #endregion example
+  return { tasks, concurrency };
+}

--- a/examples/blobs/doc-blob-read-formats.swift
+++ b/examples/blobs/doc-blob-read-formats.swift
@@ -1,0 +1,21 @@
+import Foundation
+import JsBaoClient
+
+// Read a document blob into memory with the typed `read` overloads. Reads check
+// the local cache first; on a miss they fetch from the server and cache the
+// response. Pass `force: true` to bypass the cache and re-fetch.
+func readDocumentBlobFormats(
+  client: JsBaoClient,
+  documentId: String,
+  blobId: String
+) async throws {
+  let blobs = client.documents.blobs(documentId: documentId)
+  // #region example
+  let bytes = try await blobs.read(blobId: blobId)                 // Data
+  let text = try await blobs.read(blobId: blobId, as: String.self) // UTF-8 String
+
+  // Bypass the local cache and re-fetch from the server.
+  let fresh = try await blobs.read(blobId: blobId, as: String.self, force: true)
+  // #endregion example
+  _ = (bytes, text, fresh)
+}

--- a/examples/blobs/doc-blob-read-formats.ts
+++ b/examples/blobs/doc-blob-read-formats.ts
@@ -1,0 +1,21 @@
+import type { JsBaoClient } from "js-bao-wss-client";
+
+// Read a document blob into memory, selecting the return format via `{ as }`.
+// `read` checks the local cache first; on a miss it fetches from the server and
+// writes the response into the cache. `forceRedownload` bypasses the cache.
+export async function readDocumentBlobFormats(
+  client: JsBaoClient,
+  documentId: string,
+  blobId: string,
+) {
+  const blobs = client.document(documentId).blobs();
+  // #region example
+  const text = await blobs.read(blobId, { as: "text" });
+  const buf = await blobs.read(blobId, { as: "arrayBuffer" });
+  const bytes = await blobs.read(blobId, { as: "uint8array" }); // default
+
+  // Bypass the local cache and re-fetch from the server.
+  const fresh = await blobs.read(blobId, { as: "text", forceRedownload: true });
+  // #endregion example
+  return { text, buf, bytes, fresh };
+}

--- a/examples/data-modeling/subscription-with-initial-load.swift
+++ b/examples/data-modeling/subscription-with-initial-load.swift
@@ -1,0 +1,24 @@
+import JsBaoClient
+
+// Real-time database reads: subscriptions deliver deltas only, so pair the
+// `subscribe` call with one operation call for the initial state. Keep the
+// operation's filter and the subscription's filter semantically equivalent.
+func liveOpenTickets(
+  client: JsBaoClient,
+  dbId: String,
+  applyChanges: @escaping ([DatabaseChangeEvent]) -> Void
+) async throws {
+  // #region example
+  let initial = try await client.databases.executeOperation(databaseId: dbId, name: "listMyTickets")
+  let unsub = try client.databases.subscribe(
+    databaseId: dbId,
+    subscriptionKey: "my-open-tickets",
+    options: DatabaseSubscribeOptions(onChange: { event in
+      if event.isOrigin { return } // this tab wrote it
+      applyChanges(event.changes)
+    })
+  )
+  // #endregion example
+  _ = initial
+  _ = unsub
+}

--- a/examples/data-modeling/subscription-with-initial-load.ts
+++ b/examples/data-modeling/subscription-with-initial-load.ts
@@ -1,0 +1,21 @@
+import type { JsBaoClient } from "js-bao-wss-client";
+
+// Real-time database reads: subscriptions deliver deltas only, so pair the
+// `subscribe` call with one operation call for the initial state. Keep the
+// operation's filter and the subscription's filter semantically equivalent.
+export async function liveOpenTickets(
+  client: JsBaoClient,
+  dbId: string,
+  applyChanges: (changes: unknown[]) => void,
+) {
+  // #region example
+  const initial = await client.databases.executeOperation(dbId, "listMyTickets", {});
+  const unsub = client.databases.subscribe(dbId, "my-open-tickets", {
+    onChange: (event) => {
+      if (event.isOrigin) return; // this tab wrote it
+      applyChanges(event.changes);
+    },
+  });
+  // #endregion example
+  return { initial, unsub };
+}

--- a/examples/databases/db-list-models.swift
+++ b/examples/databases/db-list-models.swift
@@ -1,0 +1,15 @@
+import JsBaoClient
+
+// Databases are schemaless. List the models (collections) a database has seen
+// via the raw records endpoint. Returns { models: ["contacts", "orders", ...] }.
+func listModels(client: JsBaoClient, databaseId: String) async throws {
+  // #region example
+  let result = try await client.makeRequest(
+    "GET",
+    "/databases/\(databaseId)/records/models"
+  )
+  let models = (result as? [String: Any])?["models"] as? [String]
+  // models: ["contacts", "orders", "products"]
+  // #endregion example
+  _ = models
+}

--- a/examples/databases/db-list-models.ts
+++ b/examples/databases/db-list-models.ts
@@ -1,0 +1,14 @@
+import type { JsBaoClient } from "js-bao-wss-client";
+
+// Databases are schemaless. List the models (collections) a database has seen
+// via the raw records endpoint. Returns { models: ["contacts", "orders", ...] }.
+export async function listModels(client: JsBaoClient, databaseId: string) {
+  // #region example
+  const { models } = await client.makeRequest(
+    "GET",
+    `/databases/${databaseId}/records/models`,
+  );
+  // models: ["contacts", "orders", "products"]
+  // #endregion example
+  return models;
+}

--- a/examples/databases/db-load-subscribe.swift
+++ b/examples/databases/db-load-subscribe.swift
@@ -1,0 +1,39 @@
+import JsBaoClient
+
+// Canonical real-time pattern: load the full current state once with a regular
+// operation, then subscribe for deltas. Keep the operation's filter and the
+// subscription's filter semantically equivalent so the UI doesn't flicker.
+// Returns the unsub teardown — call it on unmount.
+func liveTickets(
+  client: JsBaoClient,
+  databaseId: String,
+  render: @escaping ([Any]) -> Void
+) async throws -> () -> Void {
+  // #region example
+  // 1. Initial load — full current state.
+  let loaded = try await client.databases.executeOperation(
+    databaseId: databaseId, name: "list-my-open-tickets"
+  )
+  var byId: [String: Any] = [:]
+  for ticket in loaded["data"]?.arrayValue ?? [] {
+    if let id = ticket["id"]?.stringValue { byId[id] = ticket }
+  }
+  render(Array(byId.values))
+
+  // 2. Subscribe for delta updates.
+  let unsub = try client.databases.subscribe(
+    databaseId: databaseId,
+    subscriptionKey: "my-open-tickets",
+    options: DatabaseSubscribeOptions(onChange: { event in
+      for change in event.changes {
+        if change.op == "delete" { byId.removeValue(forKey: change.id) }
+        else { byId[change.id] = change.data } // save / patch / increment / addToSet / removeFromSet
+      }
+      render(Array(byId.values))
+    })
+  )
+
+  // 3. Return teardown — call this on unmount.
+  return unsub
+  // #endregion example
+}

--- a/examples/databases/db-load-subscribe.ts
+++ b/examples/databases/db-load-subscribe.ts
@@ -1,0 +1,35 @@
+import type { JsBaoClient } from "js-bao-wss-client";
+
+// Canonical real-time pattern: load the full current state once with a regular
+// operation, then subscribe for deltas. Keep the operation's filter and the
+// subscription's filter semantically equivalent so the UI doesn't flicker.
+// Returns the unsub teardown — call it on unmount.
+export async function liveTickets(
+  client: JsBaoClient,
+  databaseId: string,
+  render: (rows: unknown[]) => void,
+) {
+  // #region example
+  // 1. Initial load — full current state.
+  const { data: tickets } = await client.databases.executeOperation(
+    databaseId,
+    "list-my-open-tickets",
+  );
+  const byId = new Map<string, unknown>(tickets.map((t: { id: string }) => [t.id, t]));
+  render(Array.from(byId.values()));
+
+  // 2. Subscribe for delta updates.
+  const unsub = client.databases.subscribe(databaseId, "my-open-tickets", {
+    onChange: (event) => {
+      for (const change of event.changes) {
+        if (change.op === "delete") byId.delete(change.id);
+        else byId.set(change.id, change.data); // save / patch / increment / addToSet / removeFromSet
+      }
+      render(Array.from(byId.values()));
+    },
+  });
+
+  // 3. Return teardown — call this on unmount.
+  return unsub;
+  // #endregion example
+}

--- a/examples/databases/db-record-aggregate.swift
+++ b/examples/databases/db-record-aggregate.swift
@@ -1,0 +1,23 @@
+import JsBaoClient
+
+// Direct-record aggregation: group by one or more fields and compute
+// count/sum/avg/min/max, with an optional filter, sort, and limit.
+func recordAggregate(client: JsBaoClient, databaseId: String) async throws {
+  let db = client.databases.connect(databaseId: databaseId)
+  // #region example
+  let result = try await db.aggregate(modelName: "tasks", options: DoDbAggregationOptions(
+    groupBy: [.field("category")],
+    operations: [
+      DoDbAggregationOperation(type: .count),
+      DoDbAggregationOperation(type: .sum, field: "estimatedHours"),
+      DoDbAggregationOperation(type: .avg, field: "estimatedHours"),
+      DoDbAggregationOperation(type: .min, field: "priority"),
+      DoDbAggregationOperation(type: .max, field: "priority"),
+    ],
+    filter: ["completed": false],
+    limit: 10,
+    sort: DoDbAggregationSort(field: "count", direction: .descending)
+  ))
+  // #endregion example
+  _ = result
+}

--- a/examples/databases/db-record-aggregate.ts
+++ b/examples/databases/db-record-aggregate.ts
@@ -1,0 +1,23 @@
+import type { JsBaoClient } from "js-bao-wss-client";
+
+// Direct-record aggregation: group by one or more fields and compute
+// count/sum/avg/min/max, with an optional filter, sort, and limit.
+export async function recordAggregate(client: JsBaoClient, databaseId: string) {
+  const db = client.databases.connect(databaseId);
+  // #region example
+  const result = await db.aggregate("tasks", {
+    groupBy: ["category"],
+    operations: [
+      { type: "count" },
+      { type: "sum", field: "estimatedHours" },
+      { type: "avg", field: "estimatedHours" },
+      { type: "min", field: "priority" },
+      { type: "max", field: "priority" },
+    ],
+    filter: { completed: false },
+    sort: { field: "count", direction: -1 },
+    limit: 10,
+  });
+  // #endregion example
+  return result;
+}

--- a/examples/databases/db-record-atomic.swift
+++ b/examples/databases/db-record-atomic.swift
@@ -1,0 +1,19 @@
+import JsBaoClient
+
+// Atomic direct-record operations: numeric increment/decrement and StringSet
+// add/remove. These mutate without a read-modify-write round trip.
+func recordAtomicOps(client: JsBaoClient, databaseId: String) async throws {
+  let db = client.databases.connect(databaseId: databaseId)
+  // #region example
+  // Increment/decrement numeric fields; returns the post-increment values.
+  let newValues = try await db.increment(
+    modelName: "tasks", id: "task-1",
+    fields: ["priority": 1, "estimatedHours": -2]
+  )
+
+  // Atomically add/remove StringSet members.
+  try await db.addToSet(modelName: "tasks", id: "task-1", sets: ["tags": ["featured"]])
+  try await db.removeFromSet(modelName: "tasks", id: "task-1", sets: ["tags": ["sale"]])
+  // #endregion example
+  _ = newValues
+}

--- a/examples/databases/db-record-atomic.ts
+++ b/examples/databases/db-record-atomic.ts
@@ -1,0 +1,19 @@
+import type { JsBaoClient } from "js-bao-wss-client";
+
+// Atomic direct-record operations: numeric increment/decrement and StringSet
+// add/remove. These mutate without a read-modify-write round trip.
+export async function recordAtomicOps(client: JsBaoClient, databaseId: string) {
+  const db = client.databases.connect(databaseId);
+  // #region example
+  // Increment/decrement numeric fields; returns the post-increment values.
+  const newValues = await db.increment("tasks", "task-1", {
+    priority: 1,
+    estimatedHours: -2,
+  });
+
+  // Atomically add/remove StringSet members.
+  await db.addToSet("tasks", "task-1", { tags: ["featured"] });
+  await db.removeFromSet("tasks", "task-1", { tags: ["sale"] });
+  // #endregion example
+  return newValues;
+}

--- a/examples/databases/db-record-batch.swift
+++ b/examples/databases/db-record-batch.swift
@@ -1,0 +1,21 @@
+import JsBaoClient
+
+// db.batch executes multiple writes atomically at the storage layer. It returns
+// one result per input op; a per-item failure does NOT throw, so check .success.
+func recordBatch(client: JsBaoClient, databaseId: String) async throws {
+  let db = client.databases.connect(databaseId: databaseId)
+  // #region example
+  let results = try await db.batch([
+    DoDbBatchOperation(op: .save, modelName: "tasks", id: "t-1", data: ["title": "A"]),
+    DoDbBatchOperation(op: .patch, modelName: "tasks", id: "t-2", data: ["completed": true]),
+    DoDbBatchOperation(op: .delete, modelName: "tasks", id: "t-3"),
+    DoDbBatchOperation(op: .increment, modelName: "tasks", id: "t-4", fields: ["priority": 1]),
+    DoDbBatchOperation(op: .addToSet, modelName: "tasks", id: "t-5", stringSets: ["tags": ["urgent"]]),
+  ])
+
+  for r in results where !r.success {
+    print("op failed:", r.id, r.error ?? "")
+  }
+  // #endregion example
+  _ = results
+}

--- a/examples/databases/db-record-batch.ts
+++ b/examples/databases/db-record-batch.ts
@@ -1,0 +1,21 @@
+import type { JsBaoClient } from "js-bao-wss-client";
+
+// db.batch executes multiple writes atomically at the storage layer. It returns
+// one result per input op; a per-item failure does NOT throw, so check .success.
+export async function recordBatch(client: JsBaoClient, databaseId: string) {
+  const db = client.databases.connect(databaseId);
+  // #region example
+  const results = await db.batch([
+    { op: "save", modelName: "tasks", id: "t-1", data: { title: "A" } },
+    { op: "patch", modelName: "tasks", id: "t-2", data: { completed: true } },
+    { op: "delete", modelName: "tasks", id: "t-3" },
+    { op: "increment", modelName: "tasks", id: "t-4", fields: { priority: 1 } },
+    { op: "addToSet", modelName: "tasks", id: "t-5", stringSets: { tags: ["urgent"] } },
+  ]);
+
+  for (const r of results) {
+    if (!r.success) console.warn("op failed:", r.id, r.error);
+  }
+  // #endregion example
+  return results;
+}

--- a/examples/databases/db-record-crud.swift
+++ b/examples/databases/db-record-crud.swift
@@ -1,0 +1,49 @@
+import JsBaoClient
+
+// Direct record access (owner/manager only): connect() returns a DoDb handle.
+// The Swift handle addresses models by string name (there is no model-class
+// registry). For most apps, prefer registered operations over this path.
+func recordCrud(client: JsBaoClient, databaseId: String) async throws {
+  // #region example
+  let db = client.databases.connect(databaseId: databaseId)
+
+  // Save (upsert) — data must carry an "id" (or use upsertOn).
+  _ = try await db.save(modelName: "tasks", data: ["id": "task-1", "title": "Ship v1"])
+
+  // Insert only — fails if the record already exists.
+  _ = try await db.save(
+    modelName: "tasks", data: ["id": "task-3", "title": "Draft"],
+    options: DoDbSaveOptions(ifNotExists: true)
+  )
+
+  // Conditional write — only proceeds if the existing record matches.
+  _ = try await db.save(
+    modelName: "tasks", data: ["id": "task-3", "title": "Draft"],
+    options: DoDbSaveOptions(condition: ["completed": false])
+  )
+
+  // Seed StringSet fields on the write.
+  _ = try await db.save(
+    modelName: "tasks", data: ["id": "task-4", "title": "Tagged"],
+    options: DoDbSaveOptions(stringSets: ["tags": ["featured", "sale"]])
+  )
+
+  // Patch (partial update) — only the provided fields change.
+  _ = try await db.patch(modelName: "tasks", id: "task-1", data: ["priority": 5])
+  _ = try await db.patch(
+    modelName: "tasks", id: "task-1", data: ["priority": 7],
+    options: DoDbPatchOptions(condition: ["completed": false])
+  )
+
+  // Find a single record by id (or nil).
+  let task = try await db.find(modelName: "tasks", id: "task-1")
+
+  // Delete — true if a record existed.
+  let deleted = try await db.delete(modelName: "tasks", id: "task-2")
+
+  // Count, optionally filtered.
+  let total = try await db.count(modelName: "tasks")
+  let open = try await db.count(modelName: "tasks", filter: ["completed": false])
+  // #endregion example
+  _ = (task, deleted, total, open)
+}

--- a/examples/databases/db-record-crud.ts
+++ b/examples/databases/db-record-crud.ts
@@ -1,0 +1,37 @@
+import type { JsBaoClient } from "js-bao-wss-client";
+
+// Direct record access (owner/manager only): connect() returns a DoDb handle
+// whose methods address records by model name.
+// For most apps, prefer registered operations over this path.
+export async function recordCrud(client: JsBaoClient, databaseId: string) {
+  // #region example
+  const db = client.databases.connect(databaseId);
+
+  // Save (upsert).
+  await db.save("tasks", { id: "task-1", title: "Ship v1" });
+
+  // Insert only — fails if the record already exists.
+  await db.save("tasks", { id: "task-3", title: "Draft" }, { ifNotExists: true });
+
+  // Conditional write — only proceeds if the existing record matches.
+  await db.save("tasks", { id: "task-3", title: "Draft" }, { condition: { completed: false } });
+
+  // Seed StringSet fields on the write.
+  await db.save("tasks", { id: "task-4", title: "Tagged" }, { stringSets: { tags: ["featured", "sale"] } });
+
+  // Patch (partial update) — only the provided fields change.
+  await db.patch("tasks", "task-1", { priority: 5 });
+  await db.patch("tasks", "task-1", { priority: 7 }, { condition: { completed: false } });
+
+  // Find a single record by id (or null).
+  const task = await db.find("tasks", "task-1");
+
+  // Delete — true if a record existed.
+  const deleted = await db.delete("tasks", "task-2");
+
+  // Count, optionally filtered.
+  const total = await db.count("tasks");
+  const open = await db.count("tasks", { completed: false });
+  // #endregion example
+  return { task, deleted, total, open };
+}

--- a/examples/databases/db-record-indexes.swift
+++ b/examples/databases/db-record-indexes.swift
@@ -1,0 +1,36 @@
+import JsBaoClient
+
+// Index management on a DoDb handle. Add indexes to every field you filter or
+// sort on; without one the engine scans all records of that model.
+func manageIndexes(client: JsBaoClient, databaseId: String) async throws {
+  let db = client.databases.connect(databaseId: databaseId)
+  // #region example
+  // Sync the desired index state for one or more models (additive — the
+  // server registers only what's missing).
+  _ = try await db.syncIndexes(models: [
+    DoDbModelSyncState(
+      modelName: "tasks",
+      indexes: [
+        DoDbModelSyncState.Index(fieldName: "category"),
+        DoDbModelSyncState.Index(fieldName: "priority", fieldType: "number"),
+      ]
+    )
+  ])
+
+  // Or register indexes manually.
+  try await db.registerIndex(modelName: "tasks", fieldName: "category", fieldType: "string")
+  try await db.registerIndex(modelName: "tasks", fieldName: "priority", fieldType: "number")
+  try await db.registerIndex(modelName: "appUsers", fieldName: "email", fieldType: "string", unique: true)
+
+  // Composite unique constraint across multiple fields.
+  try await db.registerUniqueConstraint(modelName: "categories", constraintName: "name_parentId", fields: ["name", "parentId"])
+
+  // List and drop.
+  let indexes = try await db.listIndexes(modelName: "tasks")
+  try await db.dropIndex(modelName: "tasks", fieldName: "category")
+
+  let constraints = try await db.listUniqueConstraints(modelName: "categories")
+  try await db.dropUniqueConstraint(modelName: "categories", constraintName: "name_parentId")
+  // #endregion example
+  _ = (indexes, constraints)
+}

--- a/examples/databases/db-record-indexes.ts
+++ b/examples/databases/db-record-indexes.ts
@@ -1,0 +1,27 @@
+import type { JsBaoClient } from "js-bao-wss-client";
+
+// Index management on a DoDb handle. Add indexes to every field you filter or
+// sort on; without one the engine scans all records of that model.
+export async function manageIndexes(client: JsBaoClient, databaseId: string) {
+  const db = client.databases.connect(databaseId);
+  // #region example
+  // Register indexes (additive — never drops).
+  await db.registerIndex("tasks", "category", "string");
+  await db.registerIndex("tasks", "priority", "number");
+  await db.registerIndex("appUsers", "email", "string", true); // unique
+
+  // Composite unique constraint across multiple fields.
+  await db.registerUniqueConstraint("categories", "name_parentId", ["name", "parentId"]);
+
+  // List and drop.
+  const indexes = await db.listIndexes("tasks");
+  await db.dropIndex("tasks", "category");
+
+  const constraints = await db.listUniqueConstraints("categories");
+  await db.dropUniqueConstraint("categories", "name_parentId");
+
+  // Sync every model passed in the models array at init.
+  await db.syncAllIndexes();
+  // #endregion example
+  return { indexes, constraints };
+}

--- a/examples/databases/db-record-query.swift
+++ b/examples/databases/db-record-query.swift
@@ -1,0 +1,52 @@
+import JsBaoClient
+
+// Direct record queries on a DoDb handle: the filter grammar, multi-field AND,
+// $or/$and, sort + cursor pagination, projection, and related-data includes.
+func recordQueries(client: JsBaoClient, databaseId: String) async throws {
+  let db = client.databases.connect(databaseId: databaseId)
+  // #region example
+  // Filter operators: exact match, comparisons, set membership, text, $or/$and.
+  let result = try await db.query(modelName: "tasks", filter: [
+    "completed": false,
+    "priority": ["$gte": 5],
+    "category": ["$in": ["work", "urgent"]],
+    "title": ["$startsWith": "Ship"],
+    "tags": ["$contains": "featured"],
+    "$or": [["category": "work"], ["priority": ["$gte": 8]]],
+  ])
+
+  // Multiple fields on the same object are ANDed; use explicit $and to put
+  // two conditions on one field.
+  let priced = try await db.query(modelName: "tasks", filter: [
+    "$and": [["priority": ["$gte": 1]], ["priority": ["$lte": 5]]],
+  ])
+
+  // Sort, limit, and cursor pagination.
+  let page1 = try await db.query(
+    modelName: "tasks", filter: [:],
+    options: DoDbQueryOptions(sort: DoDbSort("priority", .descending), limit: 20)
+  )
+  var page2: DoDbQueryResult?
+  if page1.hasMore {
+    page2 = try await db.query(
+      modelName: "tasks", filter: [:],
+      options: DoDbQueryOptions(sort: DoDbSort("priority", .descending), limit: 20, uniqueStartKey: page1.nextCursor)
+    )
+  }
+
+  // Projection — return only the named fields.
+  let titles = try await db.query(
+    modelName: "tasks", filter: [:],
+    options: DoDbQueryOptions(projection: DoDbProjection([("title", .include), ("completed", .include)]))
+  )
+
+  // Include related records — they land under _related on each parent.
+  let withCategory = try await db.query(
+    modelName: "tasks", filter: [:],
+    options: DoDbQueryOptions(include: [
+      DoDbInclude(model: "categories", type: .refersTo, sourceField: "category", alias: "categoryInfo")
+    ])
+  )
+  // #endregion example
+  _ = (result, priced, page1, page2, titles, withCategory)
+}

--- a/examples/databases/db-record-query.ts
+++ b/examples/databases/db-record-query.ts
@@ -1,0 +1,43 @@
+import type { JsBaoClient } from "js-bao-wss-client";
+
+// Direct record queries on a DoDb handle: the filter grammar, multi-field AND,
+// $or/$and, sort + cursor pagination, projection, and related-data includes.
+export async function recordQueries(client: JsBaoClient, databaseId: string) {
+  const db = client.databases.connect(databaseId);
+  // #region example
+  // Filter operators: exact match, comparisons, set membership, text, $or/$and.
+  const result = await db.query("tasks", {
+    completed: false,
+    priority: { $gte: 5 },
+    category: { $in: ["work", "urgent"] },
+    title: { $startsWith: "Ship" },
+    tags: { $contains: "featured" },
+    $or: [{ category: "work" }, { priority: { $gte: 8 } }],
+  });
+
+  // Multiple fields on the same object are ANDed; use explicit $and to put
+  // two conditions on one field.
+  const priced = await db.query("tasks", {
+    $and: [{ priority: { $gte: 1 } }, { priority: { $lte: 5 } }],
+  });
+
+  // Sort, limit, and cursor pagination.
+  const page1 = await db.query("tasks", {}, { sort: { priority: -1 }, limit: 20 });
+  const page2 = page1.hasMore
+    ? await db.query("tasks", {}, {
+        sort: { priority: -1 },
+        limit: 20,
+        uniqueStartKey: page1.nextCursor,
+      })
+    : undefined;
+
+  // Projection — return only the named fields.
+  const titles = await db.query("tasks", {}, { projection: { title: 1, completed: 1 } });
+
+  // Include related records — they land under _related on each parent.
+  const withCategory = await db.query("tasks", {}, {
+    include: [{ model: "categories", type: "refersTo", sourceField: "category", as: "categoryInfo" }],
+  });
+  // #endregion example
+  return { result, priced, page1, page2, titles, withCategory };
+}

--- a/examples/documents/group-permission.swift
+++ b/examples/documents/group-permission.swift
@@ -1,0 +1,17 @@
+import JsBaoClient
+
+// Share a document with an entire group, then list and revoke the group's
+// permission. Member changes inside the group propagate automatically — no
+// per-membership permission calls.
+func manageGroupPermission(client: JsBaoClient, documentId: String) async throws {
+  // #region example
+  _ = try await client.documents.grantGroupPermission(
+    documentId: documentId,
+    params: GrantGroupPermissionParams(groupType: "team", groupId: "engineering", permission: "read-write")
+  )
+
+  // Listing / revoking
+  _ = try await client.documents.listGroupPermissions(documentId: documentId)
+  _ = try await client.documents.revokeGroupPermission(documentId: documentId, groupType: "team", groupId: "engineering")
+  // #endregion example
+}

--- a/examples/documents/group-permission.ts
+++ b/examples/documents/group-permission.ts
@@ -1,0 +1,18 @@
+import type { JsBaoClient } from "js-bao-wss-client";
+
+// Share a document with an entire group, then list and revoke the group's
+// permission. Member changes inside the group propagate automatically — no
+// per-membership permission calls.
+export async function manageGroupPermission(client: JsBaoClient, documentId: string) {
+  // #region example
+  await client.documents.grantGroupPermission(documentId, {
+    groupType: "team",
+    groupId: "engineering",
+    permission: "read-write", // owner | read-write | reader
+  });
+
+  // Listing / revoking
+  await client.documents.listGroupPermissions(documentId);
+  await client.documents.revokeGroupPermission(documentId, "team", "engineering");
+  // #endregion example
+}

--- a/examples/documents/manage-permissions.swift
+++ b/examples/documents/manage-permissions.swift
@@ -1,0 +1,19 @@
+import JsBaoClient
+
+// Remove a member or cancel a pending invite, and hand a document to a new
+// owner. There is no `permission: nil` to remove — removal is its own call.
+func managePermissions(
+  client: JsBaoClient,
+  documentId: String,
+  newOwnerId: String
+) async throws {
+  // #region example
+  // Remove a current member by userId (a bare string literal also works):
+  try await client.documents.removePermission(documentId: documentId, .userId("user-abc"))
+
+  // Cancel a pending email-based invite, OR remove a current member matched by email:
+  try await client.documents.removePermission(documentId: documentId, .email("alice@example.com"))
+
+  try await client.documents.transferOwnership(documentId: documentId, newOwnerId: newOwnerId)
+  // #endregion example
+}

--- a/examples/documents/manage-permissions.ts
+++ b/examples/documents/manage-permissions.ts
@@ -1,0 +1,20 @@
+import type { JsBaoClient } from "js-bao-wss-client";
+
+// Remove a member or cancel a pending invite, and hand a document to a new
+// owner. There is no `permission: null` to remove — removal is its own call.
+export async function managePermissions(
+  client: JsBaoClient,
+  documentId: string,
+  newOwnerId: string,
+) {
+  // #region example
+  // Remove a current member by userId:
+  await client.documents.removePermission(documentId, "user-abc");
+  await client.documents.removePermission(documentId, { userId: "user-abc" });
+
+  // Cancel a pending email-based invite, OR remove a current member matched by email:
+  await client.documents.removePermission(documentId, { email: "alice@example.com" });
+
+  await client.documents.transferOwnership(documentId, newOwnerId);
+  // #endregion example
+}

--- a/examples/documents/open-tagged-docs.swift
+++ b/examples/documents/open-tagged-docs.swift
@@ -1,0 +1,18 @@
+import JsBaoClient
+
+// Open every document carrying a given tag, then query across them. Queries
+// span all open documents by default, so once each tagged doc is open the
+// query sees them together.
+func openTaggedDocuments(client: JsBaoClient) async throws {
+  // #region example
+  // Open every document with a given tag
+  let channels = try await client.me.ownedDocuments(tag: "channel")
+  for channel in channels {
+    _ = try await client.documents.open(channel.documentId)
+  }
+
+  // Query runs across all open documents by default
+  let messages = Message.query([:])
+  // #endregion example
+  _ = messages
+}

--- a/examples/documents/open-tagged-docs.ts
+++ b/examples/documents/open-tagged-docs.ts
@@ -1,0 +1,19 @@
+import type { JsBaoClient } from "js-bao-wss-client";
+import { Message } from "../_harness/generated/ts/Message.generated";
+
+// Open every document carrying a given tag, then query across them. Queries
+// span all open documents by default, so once each tagged doc is open the
+// query sees them together.
+export async function openTaggedDocuments(client: JsBaoClient) {
+  // #region example
+  // Open every document with a given tag
+  const channels = await client.me.ownedDocuments({ tag: "channel" });
+  await Promise.all(
+    channels.map((ch) => client.documents.open(ch.documentId))
+  );
+
+  // Query runs across all open documents by default
+  const messages = await Message.query({});
+  // #endregion example
+  return messages.data;
+}

--- a/examples/performance/bulk-then-group.swift
+++ b/examples/performance/bulk-then-group.swift
@@ -1,0 +1,16 @@
+import JsBaoClient
+
+// Replace an N+1 (one per-item op call per parent) with ONE bulk query, then
+// group the rows client-side. The bulk op carries no per-parent filter; the
+// grouping happens in memory instead of in N round trips.
+func tasksByCategory(client: JsBaoClient, databaseId: String) async throws {
+  // #region example
+  let all = try await client.databases.executeOperation(databaseId: databaseId, name: "listAllTasks")
+  var byCategory: [String: [JSONValue]] = [:]
+  for task in all["data"]?.arrayValue ?? [] {
+    let key = task["category"]?.stringValue ?? "uncategorized"
+    byCategory[key, default: []].append(task)
+  }
+  // #endregion example
+  _ = byCategory
+}

--- a/examples/performance/bulk-then-group.ts
+++ b/examples/performance/bulk-then-group.ts
@@ -1,0 +1,19 @@
+import type { JsBaoClient } from "js-bao-wss-client";
+import type { TaskAttrs } from "../_harness/generated/ts/Task.generated";
+
+// Replace an N+1 (one per-item op call per parent) with ONE bulk query, then
+// group the rows client-side. The bulk op carries no per-parent filter; the
+// grouping happens in memory instead of in N round trips.
+export async function tasksByCategory(client: JsBaoClient, databaseId: string) {
+  // #region example
+  const all = await client.databases.executeOperation(databaseId, "listAllTasks");
+  const byCategory = new Map<string, TaskAttrs[]>();
+  for (const task of all.data as TaskAttrs[]) {
+    const key = task.category ?? "uncategorized";
+    const list = byCategory.get(key) ?? [];
+    list.push(task);
+    byCategory.set(key, list);
+  }
+  // #endregion example
+  return byCategory;
+}

--- a/examples/sharing/invitation-create-options.swift
+++ b/examples/sharing/invitation-create-options.swift
@@ -1,0 +1,38 @@
+import Foundation
+import JsBaoClient
+
+// Create invitations: any role (admin/owner), full options, and the
+// member path that gates on quota first.
+func createInvitationOptions(client: JsBaoClient, email: String) async throws {
+  // #region example
+  // Admins/owners: any role
+  _ = try await client.invitations.create(
+    params: CreateInvitationParams(
+      email: "alice@example.com",
+      role: "member" // or "admin" / "owner" (admin/owner only)
+    )
+  )
+
+  // Full options
+  let expiresAt = ISO8601DateFormatter().string(from: Date().addingTimeInterval(7 * 86400))
+  _ = try await client.invitations.create(
+    params: CreateInvitationParams(
+      email: "alice@example.com",
+      role: "member",
+      expiresAt: expiresAt, // optional override
+      source: "team-onboarding-flow",
+      note: "Backend hire — Q2 cohort",
+      sendEmail: true
+    )
+  )
+
+  // Members: gate on quota first
+  let quota = try await client.invitations.quota()
+  if !quota.unlimited && quota.remaining <= 0 {
+    return // quota exhausted — hide the invite UI
+  }
+  _ = try await client.invitations.create(
+    params: CreateInvitationParams(email: email, role: "member")
+  )
+  // #endregion example
+}

--- a/examples/sharing/invitation-create-options.ts
+++ b/examples/sharing/invitation-create-options.ts
@@ -1,0 +1,30 @@
+import type { JsBaoClient } from "js-bao-wss-client";
+
+// Create invitations: any role (admin/owner), full options, and the
+// member path that gates on quota first.
+export async function createInvitationOptions(client: JsBaoClient, email: string) {
+  // #region example
+  // Admins/owners: any role
+  await client.invitations.create({
+    email: "alice@example.com",
+    role: "member", // or "admin" / "owner" (admin/owner only)
+  });
+
+  // Full options
+  await client.invitations.create({
+    email: "alice@example.com",
+    role: "member",
+    expiresAt: new Date(Date.now() + 7 * 86400_000).toISOString(), // optional override
+    source: "team-onboarding-flow",
+    note: "Backend hire — Q2 cohort",
+    sendEmail: true,
+  });
+
+  // Members: gate on quota first
+  const quota = await client.invitations.quota();
+  if (!quota.unlimited && quota.remaining <= 0) {
+    return; // quota exhausted — hide the invite UI
+  }
+  await client.invitations.create({ email, role: "member" });
+  // #endregion example
+}

--- a/examples/sharing/invitation-events.swift
+++ b/examples/sharing/invitation-events.swift
@@ -1,0 +1,20 @@
+import JsBaoClient
+
+// Subscribe to invitation lifecycle events. Targeting is asymmetric: most
+// actions reach one side only (created/updated/cancelled -> invitee;
+// declined -> both; accepted -> inviter). Treat unknown actions as no-ops.
+func wireInvitationEvents(client: JsBaoClient) -> EventSubscription {
+  // #region example
+  let sub = client.events.on(.invitation) { (event: [String: Any]) in
+    switch event["action"] as? String {
+    case "created":   break  // invitee only
+    case "updated":   break  // invitee only
+    case "cancelled": break  // invitee only
+    case "declined":  break  // both invitee and inviter
+    case "accepted":  break  // inviter only — event["acceptedBy"] carries the userId
+    default:          break  // future-proof: no-op, don't throw
+    }
+  }
+  // #endregion example
+  return sub
+}

--- a/examples/sharing/invitation-events.ts
+++ b/examples/sharing/invitation-events.ts
@@ -1,0 +1,19 @@
+import type { JsBaoClient } from "js-bao-wss-client";
+
+// Subscribe to invitation lifecycle events. Targeting is asymmetric: most
+// actions reach one side only (created/updated/cancelled -> invitee;
+// declined -> both; accepted -> inviter). Treat unknown actions as no-ops.
+export function wireInvitationEvents(client: JsBaoClient) {
+  // #region example
+  client.on("invitation", (event) => {
+    switch (event.action) {
+      case "created":   /* invitee only */ break;
+      case "updated":   /* invitee only */ break;
+      case "cancelled": /* invitee only */ break;
+      case "declined":  /* both invitee and inviter */ break;
+      case "accepted":  /* inviter only — event.acceptedBy carries the userId */ break;
+      default: /* future-proof: no-op, don't throw */ break;
+    }
+  });
+  // #endregion example
+}

--- a/examples/sharing/invitation-get-token.swift
+++ b/examples/sharing/invitation-get-token.swift
@@ -1,0 +1,18 @@
+import JsBaoClient
+
+// Fetch an invitation by id and rebuild its accept-page URL from the
+// inviteToken — for resending a custom invitation email after the
+// original mint response is gone.
+func buildAcceptUrl(
+  client: JsBaoClient,
+  invitationId: String,
+  baseURL: String
+) async throws -> String {
+  // #region example
+  let inv = try await client.invitations.get(invitationId: invitationId)
+  let inviteToken = inv.inviteToken ?? ""
+  let acceptUrl = "\(baseURL)/invite/accept?inviteToken=\(inviteToken)"
+  // Send `acceptUrl` to `inv.email` from your own email provider.
+  // #endregion example
+  return acceptUrl
+}

--- a/examples/sharing/invitation-get-token.ts
+++ b/examples/sharing/invitation-get-token.ts
@@ -1,0 +1,17 @@
+import type { JsBaoClient } from "js-bao-wss-client";
+
+// Fetch an invitation by id and rebuild its accept-page URL from the
+// inviteToken — for resending a custom invitation email after the
+// original mint response is gone.
+export async function buildAcceptUrl(
+  client: JsBaoClient,
+  invitationId: string,
+  baseUrl: string,
+) {
+  // #region example
+  const inv = await client.invitations.get(invitationId);
+  const acceptUrl = `${baseUrl}/invite/accept?inviteToken=${inv.inviteToken}`;
+  // Send `acceptUrl` to `inv.email` from your own email provider.
+  // #endregion example
+  return acceptUrl;
+}

--- a/examples/sharing/list-deferred-grants.swift
+++ b/examples/sharing/list-deferred-grants.swift
@@ -1,0 +1,14 @@
+import JsBaoClient
+
+// Inspect pending deferred grants for an email (admin/debug only). End-user
+// "people with access + pending" UI uses the per-resource endpoints instead.
+func inspectDeferredGrants(client: JsBaoClient) async throws {
+  // #region example
+  let result = try await client.invitations.listDeferredGrants(
+    email: "alice@example.com"
+  )
+  let grants = result.grants
+  let nextCursor = result.nextCursor
+  // #endregion example
+  _ = (grants, nextCursor)
+}

--- a/examples/sharing/list-deferred-grants.ts
+++ b/examples/sharing/list-deferred-grants.ts
@@ -1,0 +1,12 @@
+import type { JsBaoClient } from "js-bao-wss-client";
+
+// Inspect pending deferred grants for an email (admin/debug only). End-user
+// "people with access + pending" UI uses the per-resource endpoints instead.
+export async function inspectDeferredGrants(client: JsBaoClient) {
+  // #region example
+  const { grants, nextCursor } = await client.invitations.listDeferredGrants({
+    email: "alice@example.com",
+  });
+  // #endregion example
+  return { grants, nextCursor };
+}

--- a/examples/users-and-groups/org-hierarchy.swift
+++ b/examples/users-and-groups/org-hierarchy.swift
@@ -1,0 +1,31 @@
+import JsBaoClient
+
+// Model nested organizational structure with multiple group types — org,
+// department, and team. A user can belong to groups at several levels at once,
+// and CEL can check any level: isMemberOf('org', ...), isMemberOf('dept', ...),
+// isMemberOf('team', ...).
+func setUpOrgHierarchy(client: JsBaoClient, userId: String) async throws {
+  // #region example
+  // Organization-level group.
+  _ = try await client.groups.create(params: CreateGroupParams(
+    groupType: "org", groupId: "acme-corp", name: "Acme Corp"))
+
+  // Department-level groups.
+  _ = try await client.groups.create(params: CreateGroupParams(
+    groupType: "dept", groupId: "engineering", name: "Engineering"))
+  _ = try await client.groups.create(params: CreateGroupParams(
+    groupType: "dept", groupId: "marketing", name: "Marketing"))
+
+  // Team-level group.
+  _ = try await client.groups.create(params: CreateGroupParams(
+    groupType: "team", groupId: "backend", name: "Backend Team"))
+
+  // A user can be in multiple groups at different levels.
+  _ = try await client.groups.addMember(
+    groupType: "org", groupId: "acme-corp", params: .userId(userId))
+  _ = try await client.groups.addMember(
+    groupType: "dept", groupId: "engineering", params: .userId(userId))
+  _ = try await client.groups.addMember(
+    groupType: "team", groupId: "backend", params: .userId(userId))
+  // #endregion example
+}

--- a/examples/users-and-groups/org-hierarchy.ts
+++ b/examples/users-and-groups/org-hierarchy.ts
@@ -1,0 +1,24 @@
+import type { JsBaoClient } from "js-bao-wss-client";
+
+// Model nested organizational structure with multiple group types — org,
+// department, and team. A user can belong to groups at several levels at once,
+// and CEL can check any level: isMemberOf('org', ...), isMemberOf('dept', ...),
+// isMemberOf('team', ...).
+export async function setUpOrgHierarchy(client: JsBaoClient, userId: string) {
+  // #region example
+  // Organization-level group.
+  await client.groups.create({ groupType: "org", groupId: "acme-corp", name: "Acme Corp" });
+
+  // Department-level groups.
+  await client.groups.create({ groupType: "dept", groupId: "engineering", name: "Engineering" });
+  await client.groups.create({ groupType: "dept", groupId: "marketing", name: "Marketing" });
+
+  // Team-level group.
+  await client.groups.create({ groupType: "team", groupId: "backend", name: "Backend Team" });
+
+  // A user can be in multiple groups at different levels.
+  await client.groups.addMember("org", "acme-corp", { userId });
+  await client.groups.addMember("dept", "engineering", { userId });
+  await client.groups.addMember("team", "backend", { userId });
+  // #endregion example
+}

--- a/examples/users-and-groups/relationship-groups.swift
+++ b/examples/users-and-groups/relationship-groups.swift
@@ -1,0 +1,31 @@
+import JsBaoClient
+
+// Relationship modeling with groups: a "parent-of" group per student, with the
+// parent added as a member. A per-parameter access expression on the operation
+// ("value in memberGroups('parent-of')") ensures a parent can only query their
+// own child's data — the server enforces it.
+func setUpParentOfRelationship(
+  client: JsBaoClient,
+  dbId: String,
+  parentUserId: String
+) async throws {
+  // #region example
+  // A "parent-of" group per student.
+  _ = try await client.groups.create(params: CreateGroupParams(
+    groupType: "parent-of",
+    groupId: "student-123",
+    name: "Parents of Student 123"
+  ))
+  _ = try await client.groups.addMember(
+    groupType: "parent-of", groupId: "student-123",
+    params: .userId(parentUserId)
+  )
+
+  // Parent queries their child's grades — server enforces access.
+  let grades = try await client.databases.executeOperation(
+    databaseId: dbId, name: "viewGrades",
+    options: ExecuteOperationOptions(params: ["studentId": "student-123"])
+  )
+  _ = grades
+  // #endregion example
+}

--- a/examples/users-and-groups/relationship-groups.ts
+++ b/examples/users-and-groups/relationship-groups.ts
@@ -1,0 +1,27 @@
+import type { JsBaoClient } from "js-bao-wss-client";
+
+// Relationship modeling with groups: a "parent-of" group per student, with the
+// parent added as a member. A per-parameter access expression on the operation
+// ("value in memberGroups('parent-of')") ensures a parent can only query their
+// own child's data — the server enforces it.
+export async function setUpParentOfRelationship(
+  client: JsBaoClient,
+  dbId: string,
+  parentUserId: string,
+) {
+  // #region example
+  // A "parent-of" group per student.
+  await client.groups.create({
+    groupType: "parent-of",
+    groupId: "student-123",
+    name: "Parents of Student 123",
+  });
+  await client.groups.addMember("parent-of", "student-123", { userId: parentUserId });
+
+  // Parent queries their child's grades — server enforces access.
+  const grades = await client.databases.executeOperation(dbId, "viewGrades", {
+    params: { studentId: "student-123" },
+  });
+  // #endregion example
+  return grades;
+}

--- a/examples/users-and-groups/role-groups.swift
+++ b/examples/users-and-groups/role-groups.swift
@@ -1,0 +1,25 @@
+import JsBaoClient
+
+// Role-based access using group types as roles within a context: an "editor"
+// and a "viewer" group per project, each granted a different document
+// permission. CEL operations then check isMemberOf('editor', params.projectId)
+// to gate writes and the editor-or-viewer union to gate reads.
+func setUpRoleGroups(client: JsBaoClient, docId: String) async throws {
+  // #region example
+  // Create role groups for a project.
+  _ = try await client.groups.create(params: CreateGroupParams(
+    groupType: "editor", groupId: "project-1", name: "Project 1 Editors"))
+  _ = try await client.groups.create(params: CreateGroupParams(
+    groupType: "viewer", groupId: "project-1", name: "Project 1 Viewers"))
+
+  // Grant different document permissions per role.
+  _ = try await client.documents.grantGroupPermission(
+    documentId: docId,
+    params: GrantGroupPermissionParams(
+      groupType: "editor", groupId: "project-1", permission: "read-write"))
+  _ = try await client.documents.grantGroupPermission(
+    documentId: docId,
+    params: GrantGroupPermissionParams(
+      groupType: "viewer", groupId: "project-1", permission: "reader"))
+  // #endregion example
+}

--- a/examples/users-and-groups/role-groups.ts
+++ b/examples/users-and-groups/role-groups.ts
@@ -1,0 +1,25 @@
+import type { JsBaoClient } from "js-bao-wss-client";
+
+// Role-based access using group types as roles within a context: an "editor"
+// and a "viewer" group per project, each granted a different document
+// permission. CEL operations then check isMemberOf('editor', params.projectId)
+// to gate writes and the editor-or-viewer union to gate reads.
+export async function setUpRoleGroups(client: JsBaoClient, docId: string) {
+  // #region example
+  // Create role groups for a project.
+  await client.groups.create({ groupType: "editor", groupId: "project-1", name: "Project 1 Editors" });
+  await client.groups.create({ groupType: "viewer", groupId: "project-1", name: "Project 1 Viewers" });
+
+  // Grant different document permissions per role.
+  await client.documents.grantGroupPermission(docId, {
+    groupType: "editor",
+    groupId: "project-1",
+    permission: "read-write",
+  });
+  await client.documents.grantGroupPermission(docId, {
+    groupType: "viewer",
+    groupId: "project-1",
+    permission: "reader",
+  });
+  // #endregion example
+}

--- a/examples/users-and-groups/supplement-user-data.swift
+++ b/examples/users-and-groups/supplement-user-data.swift
@@ -1,0 +1,28 @@
+import JsBaoClient
+
+// Supplement — don't replace — the platform user. Store app-specific user data
+// keyed by the platform userId, either in a document or via a database
+// operation that resolves the caller server-side as $user.userId.
+func supplementUserData(
+  client: JsBaoClient,
+  platformUserId: String,
+  userDocumentId: String,
+  dbId: String
+) async throws {
+  // #region example
+  // Store additional user data in a document, keyed by the platform userId.
+  let profile = AppUser(
+    id: platformUserId, // reference the platform user
+    email: "alice@example.com",
+    name: "Software engineer"
+  )
+  try profile.save(in: userDocumentId)
+
+  // Or in a database via a registered operation. The operation uses
+  // $user.userId server-side — no need to pass the userId yourself.
+  _ = try await client.databases.executeOperation(
+    databaseId: dbId, name: "updateProfile",
+    options: ExecuteOperationOptions(params: ["bio": "Software engineer", "theme": "dark"])
+  )
+  // #endregion example
+}

--- a/examples/users-and-groups/supplement-user-data.ts
+++ b/examples/users-and-groups/supplement-user-data.ts
@@ -1,0 +1,28 @@
+import type { JsBaoClient } from "js-bao-wss-client";
+import { AppUser } from "../_harness/generated/ts/AppUser.generated";
+
+// Supplement — don't replace — the platform user. Store app-specific user data
+// keyed by the platform userId, either in a document or via a database
+// operation that resolves the caller server-side as $user.userId.
+export async function supplementUserData(
+  client: JsBaoClient,
+  platformUserId: string,
+  userDocumentId: string,
+  dbId: string,
+) {
+  // #region example
+  // Store additional user data in a document, keyed by the platform userId.
+  const profile = new AppUser({
+    id: platformUserId, // reference the platform user
+    email: "alice@example.com",
+    name: "Software engineer",
+  });
+  await profile.save({ targetDocument: userDocumentId });
+
+  // Or in a database via a registered operation. The operation uses
+  // $user.userId server-side — no need to pass the userId yourself.
+  await client.databases.executeOperation(dbId, "updateProfile", {
+    params: { bio: "Software engineer", theme: "dark" },
+  });
+  // #endregion example
+}

--- a/examples/users-and-groups/team-workspace.swift
+++ b/examples/users-and-groups/team-workspace.swift
@@ -1,0 +1,25 @@
+import JsBaoClient
+
+// Team-based workspace access: a user creates a team, then a document is shared
+// with the whole team. Database operations gate on team membership in CEL —
+// e.g. access: "isMemberOf('team', database.metadata.teamId)".
+func setUpTeamWorkspace(client: JsBaoClient, docId: String) async throws {
+  // #region example
+  // User creates a team.
+  _ = try await client.groups.create(params: CreateGroupParams(
+    groupType: "team",
+    groupId: "alpha-team",
+    name: "Alpha Team"
+  ))
+
+  // Share a document with the team — every member inherits read-write.
+  _ = try await client.documents.grantGroupPermission(
+    documentId: docId,
+    params: GrantGroupPermissionParams(
+      groupType: "team",
+      groupId: "alpha-team",
+      permission: "read-write"
+    )
+  )
+  // #endregion example
+}

--- a/examples/users-and-groups/team-workspace.ts
+++ b/examples/users-and-groups/team-workspace.ts
@@ -1,0 +1,22 @@
+import type { JsBaoClient } from "js-bao-wss-client";
+
+// Team-based workspace access: a user creates a team, then a document is shared
+// with the whole team. Database operations gate on team membership in CEL —
+// e.g. access: "isMemberOf('team', database.metadata.teamId)".
+export async function setUpTeamWorkspace(client: JsBaoClient, docId: string) {
+  // #region example
+  // User creates a team.
+  await client.groups.create({
+    groupType: "team",
+    groupId: "alpha-team",
+    name: "Alpha Team",
+  });
+
+  // Share a document with the team — every member inherits read-write.
+  await client.documents.grantGroupPermission(docId, {
+    groupType: "team",
+    groupId: "alpha-team",
+    permission: "read-write",
+  });
+  // #endregion example
+}

--- a/examples/workflows/workflow-apply.swift
+++ b/examples/workflows/workflow-apply.swift
@@ -1,0 +1,17 @@
+import JsBaoClient
+
+// Register an apply handler so a client deterministically runs follow-up logic
+// exactly once for a workflow with requiresClientApply = true. Register
+// define() before start() so the apply can't arrive before the handler exists.
+func defineApplyHandler(client: JsBaoClient) {
+  // #region example
+  client.workflows.define("my-workflow-key") { ctx in
+    // Runs on exactly one connected client: the client claims the lease,
+    // fetches the run output, calls this handler, then confirms the apply.
+    // A thrown error releases the claim so another client (or a retry)
+    // can pick it up.
+    // ctx: workflowKey, runKey, runId, contextDocId?, output, startedByUserId?, meta?
+    _ = ctx.output
+  }
+  // #endregion example
+}

--- a/examples/workflows/workflow-apply.ts
+++ b/examples/workflows/workflow-apply.ts
@@ -1,0 +1,17 @@
+import type { JsBaoClient } from "js-bao-wss-client";
+
+// Register an apply handler so a client deterministically runs follow-up logic
+// exactly once for a workflow with requiresClientApply = true. Register
+// define() before start() so the apply can't arrive before the handler exists.
+export function defineApplyHandler(client: JsBaoClient) {
+  // #region example
+  client.workflows.define("my-workflow-key", {
+    onApply: async ({ output, workflowKey, runKey, runId, contextDocId, startedByUserId, meta }) => {
+      // Runs on exactly one connected client.
+      if (!contextDocId) return;
+      const { doc } = await client.documents.open(contextDocId);
+      doc?.getMap("data").set("result", output);
+    },
+  });
+  // #endregion example
+}

--- a/examples/workflows/workflow-events.swift
+++ b/examples/workflows/workflow-events.swift
@@ -1,0 +1,20 @@
+import JsBaoClient
+
+// React to workflow lifecycle events over the WebSocket, delivered as typed
+// event structs. Hold the returned EventSubscription for as long as you want
+// the handler live. Requires an active WebSocket (e.g. from
+// client.documents.open(docId)).
+func wireWorkflowEvents(client: JsBaoClient) -> [EventSubscription] {
+  // #region example
+  let started = client.events.on(.workflowStarted) { (e: WorkflowStartedEvent) in
+    // e.workflowKey, e.runId, e.runKey?, e.instanceId?, e.contextDocId?, e.meta?
+  }
+
+  let status = client.events.on(.workflowStatus) { (e: WorkflowStatusEvent) in
+    // e.status: "completed" | "failed" | "terminated"
+    // e.needsApply == true if requiresClientApply and not yet applied
+    // also: e.runKey, e.runId, e.output, e.error, e.contextDocId, e.meta
+  }
+  // #endregion example
+  return [started, status]
+}

--- a/examples/workflows/workflow-events.ts
+++ b/examples/workflows/workflow-events.ts
@@ -1,0 +1,17 @@
+import type { JsBaoClient } from "js-bao-wss-client";
+
+// React to workflow lifecycle events over the WebSocket. Requires an active
+// WebSocket (e.g. from client.documents.open(docId)).
+export function wireWorkflowEvents(client: JsBaoClient) {
+  // #region example
+  client.on("workflowStarted", (e) => {
+    // { workflowKey, runId, runKey, instanceId, contextDocId?, meta? }
+  });
+
+  client.on("workflowStatus", (e) => {
+    // e.status: "completed" | "failed" | "terminated"
+    //   (NOTE: "completed" here, with the "d" — getStatus returns "complete")
+    // e.needsApply: true if requiresClientApply and not yet applied
+  });
+  // #endregion example
+}

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_ANALYTICS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_ANALYTICS.swift.md
@@ -135,11 +135,11 @@ Events with no authenticated user are dropped. To log on pre-auth screens (landi
 
 Events are buffered and flushed automatically — including when the WebSocket reconnects — so you rarely need to flush manually. Call `flush` to force a send (e.g. before an explicit teardown).
 
-The queue auto-flushes every **100ms** (or earlier when batched). `client.destroy()` cancels the flush timer and triggers a final flush before storage closes, so you don't need a manual flush on teardown.
-
 ```swift
-client.analytics.flush()
+  client.analytics.flush()
 ```
+
+The queue auto-flushes every **100ms** (or earlier when batched). `client.destroy()` cancels the flush timer and triggers a final flush before storage closes, so you don't need a manual flush on teardown.
 
 ---
 
@@ -302,3 +302,53 @@ These fields are absent (or zero) when the event type doesn't produce them.
 4. **Don't log high-frequency events** — rate limiter caps at 300/min with burst 60. Design around meaningful actions, not continuous telemetry.
 5. **Use the override setters** instead of passing `plan` / `app_version` on every event.
 
+
+---
+
+## Complete Example: Feature Usage Tracking
+
+Configure auto events on the client, set the app-version override once, then log a per-feature action and a pre-auth landing event.
+
+```swift
+  let client = JsBaoClient(options: JsBaoClientOptions(
+    apiUrl: "https://primitiveapi.com",
+    wsUrl: "wss://primitiveapi.com",
+    appId: "YOUR_APP_ID",
+    analyticsAutoEvents: AnalyticsAutoEventsConfig(
+      blobUploadsStart: false,
+      blobUploadsSuccess: true,
+      blobUploadsFailure: true,
+      sessionEnd: true
+    )
+  ))
+
+  // Set version once after init (or after a deploy notification)
+  client.analytics.setAppVersionOverride("2.1.4")
+
+  func trackFeatureUsed(
+    _ userUlid: String,
+    feature: String,
+    action: String,
+    context: JSONValue? = nil
+  ) {
+    client.analytics.logEvent(AnalyticsEventInput(
+      action: action,
+      feature: feature,
+      user_ulid: userUlid,
+      context_json: context
+    ))
+  }
+
+  // Authenticated event
+  trackFeatureUsed(currentUserUlid, feature: "reports", action: "report_generated", context: [
+    "reportType": "quarterly",
+    "format": "pdf",
+  ])
+
+  // Pre-auth event (landing page)
+  client.analytics.logEvent(AnalyticsEventInput(
+    action: "landing_page_view",
+    feature: "onboarding",
+    user_ulid: AnalyticsEventInput.unauthenticatedUser
+  ))
+```

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_ANALYTICS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_ANALYTICS.template.md
@@ -190,12 +190,10 @@ Events with no authenticated user are dropped. To log on pre-auth screens (landi
 
 Events are buffered and flushed automatically — including when the WebSocket reconnects — so you rarely need to flush manually. Call `flush` to force a send (e.g. before an explicit teardown).
 
+{{ example: analytics/manual-flush }}
+
 {{#lang ts}}
 The queue auto-flushes every **100ms** or when the buffer reaches **25 KiB**, and the client also flushes on `beforeunload`, on tab visibility hidden, and on reconnect.
-
-```typescript
-client.analytics.flush();
-```
 
 Pre-existing browser hooks (added by the client itself):
 - `beforeunload` → fires `session_end`, then flushes
@@ -207,10 +205,6 @@ So **don't** add your own `beforeunload → flush` listener — it's redundant a
 {{/lang}}
 {{#lang swift}}
 The queue auto-flushes every **100ms** (or earlier when batched). `client.destroy()` cancels the flush timer and triggers a final flush before storage closes, so you don't need a manual flush on teardown.
-
-```swift
-client.analytics.flush()
-```
 {{/lang}}
 
 ---
@@ -363,55 +357,12 @@ These fields are absent (or zero) when the event type doesn't produce them.
 
 {{#lang ts}}
 6. **Don't add your own `beforeunload` flush** — the client already does this.
+{{/lang}}
 
 ---
 
 ## Complete Example: Feature Usage Tracking
 
-```typescript
-import { JsBaoClient, ANALYTICS_UNAUTHENTICATED_USER } from "js-bao-wss-client";
+Configure auto events on the client, set the app-version override once, then log a per-feature action and a pre-auth landing event.
 
-const client = new JsBaoClient({
-  appId: "app-123",
-  apiUrl: "https://api.example.com",
-  wsUrl: "wss://ws.example.com",
-  analyticsAutoEvents: {
-    sessionEnd: true,
-    blobUploads: { start: false, success: true, failure: true },
-    llm: { start: false, success: true, failure: true },
-  },
-});
-
-// Set version once after init (or after deploy notification)
-client.analytics.setAppVersionOverride("2.1.4");
-
-function trackFeatureUsed(
-  userUlid: string,
-  feature: string,
-  action: string,
-  context?: Record<string, unknown>
-) {
-  client.analytics.logEvent({
-    action,
-    feature,
-    user_ulid: userUlid,
-    context_json: context,
-  });
-}
-
-// Authenticated event
-trackFeatureUsed(currentUserUlid, "reports", "report_generated", {
-  reportType: "quarterly",
-  format: "pdf",
-});
-
-// Pre-auth event (landing page)
-client.analytics.logEvent({
-  action: "landing_page_view",
-  feature: "onboarding",
-  user_ulid: ANALYTICS_UNAUTHENTICATED_USER,
-});
-
-// No need for a beforeunload flush — the client adds one automatically.
-```
-{{/lang}}
+{{ example: analytics/feature-usage-tracking }}

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_ANALYTICS.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_ANALYTICS.ts.md
@@ -193,11 +193,11 @@ Events with no authenticated user are dropped. To log on pre-auth screens (landi
 
 Events are buffered and flushed automatically — including when the WebSocket reconnects — so you rarely need to flush manually. Call `flush` to force a send (e.g. before an explicit teardown).
 
-The queue auto-flushes every **100ms** or when the buffer reaches **25 KiB**, and the client also flushes on `beforeunload`, on tab visibility hidden, and on reconnect.
-
 ```typescript
-client.analytics.flush();
+  client.analytics.flush();
 ```
+
+The queue auto-flushes every **100ms** or when the buffer reaches **25 KiB**, and the client also flushes on `beforeunload`, on tab visibility hidden, and on reconnect.
 
 Pre-existing browser hooks (added by the client itself):
 - `beforeunload` → fires `session_end`, then flushes
@@ -378,49 +378,47 @@ These fields are absent (or zero) when the event type doesn't produce them.
 
 ## Complete Example: Feature Usage Tracking
 
+Configure auto events on the client, set the app-version override once, then log a per-feature action and a pre-auth landing event.
+
 ```typescript
-import { JsBaoClient, ANALYTICS_UNAUTHENTICATED_USER } from "js-bao-wss-client";
-
-const client = new JsBaoClient({
-  appId: "app-123",
-  apiUrl: "https://api.example.com",
-  wsUrl: "wss://ws.example.com",
-  analyticsAutoEvents: {
-    sessionEnd: true,
-    blobUploads: { start: false, success: true, failure: true },
-    llm: { start: false, success: true, failure: true },
-  },
-});
-
-// Set version once after init (or after deploy notification)
-client.analytics.setAppVersionOverride("2.1.4");
-
-function trackFeatureUsed(
-  userUlid: string,
-  feature: string,
-  action: string,
-  context?: Record<string, unknown>
-) {
-  client.analytics.logEvent({
-    action,
-    feature,
-    user_ulid: userUlid,
-    context_json: context,
+  const client = await initializeClient({
+    apiUrl: "https://primitiveapi.com",
+    wsUrl: "wss://primitiveapi.com",
+    appId: "YOUR_APP_ID",
+    analyticsAutoEvents: {
+      sessionEnd: true,
+      blobUploads: { start: false, success: true, failure: true },
+      llm: { start: false, success: true, failure: true },
+    },
   });
-}
 
-// Authenticated event
-trackFeatureUsed(currentUserUlid, "reports", "report_generated", {
-  reportType: "quarterly",
-  format: "pdf",
-});
+  // Set version once after init (or after a deploy notification)
+  client.analytics.setAppVersionOverride("2.1.4");
 
-// Pre-auth event (landing page)
-client.analytics.logEvent({
-  action: "landing_page_view",
-  feature: "onboarding",
-  user_ulid: ANALYTICS_UNAUTHENTICATED_USER,
-});
+  function trackFeatureUsed(
+    userUlid: string,
+    feature: string,
+    action: string,
+    context?: Record<string, unknown>,
+  ) {
+    client.analytics.logEvent({
+      action,
+      feature,
+      user_ulid: userUlid,
+      context_json: context,
+    });
+  }
 
-// No need for a beforeunload flush — the client adds one automatically.
+  // Authenticated event
+  trackFeatureUsed(currentUserUlid, "reports", "report_generated", {
+    reportType: "quarterly",
+    format: "pdf",
+  });
+
+  // Pre-auth event (landing page)
+  client.analytics.logEvent({
+    action: "landing_page_view",
+    feature: "onboarding",
+    user_ulid: ANALYTICS_UNAUTHENTICATED_USER,
+  });
 ```

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_AUTHENTICATION.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_AUTHENTICATION.swift.md
@@ -162,7 +162,12 @@ The callback delivers the token as a `magic_token` value — **not** `token`, `m
 To accept an invitation server-side at verify time (so the deferred grant resolves to the signing-in user even when emails differ), pass `inviteToken`:
 
 ```swift
-let result = try await client.auth.magicLinkVerify(token: magicToken, inviteToken: inviteTokenFromUrl)
+  let result = try await client.auth.magicLinkVerify(
+    token: magicToken,
+    inviteToken: inviteTokenFromUrl
+  )
+  let user = result.user
+  let isNewUser = result.isNewUser ?? false
 ```
 
 ---

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_AUTHENTICATION.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_AUTHENTICATION.template.md
@@ -157,16 +157,7 @@ The callback URL may also carry `?purpose=login-add-passkey`. The server appends
 
 To accept an invitation server-side at verify time (so the deferred grant resolves to the signing-in user even when emails differ), pass `inviteToken`:
 
-{{#lang ts}}
-```typescript
-await client.magicLinkVerify(magicToken, { inviteToken: inviteTokenFromUrl });
-```
-{{/lang}}
-{{#lang swift}}
-```swift
-let result = try await client.auth.magicLinkVerify(token: magicToken, inviteToken: inviteTokenFromUrl)
-```
-{{/lang}}
+{{ example: auth/magic-link-invite }}
 
 ---
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_AUTHENTICATION.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_AUTHENTICATION.ts.md
@@ -195,7 +195,9 @@ The callback URL may also carry `?purpose=login-add-passkey`. The server appends
 To accept an invitation server-side at verify time (so the deferred grant resolves to the signing-in user even when emails differ), pass `inviteToken`:
 
 ```typescript
-await client.magicLinkVerify(magicToken, { inviteToken: inviteTokenFromUrl });
+  const { user, isNewUser } = await client.magicLinkVerify(magicToken, {
+    inviteToken: inviteTokenFromUrl,
+  });
 ```
 
 ---

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_BLOBS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_BLOBS.swift.md
@@ -90,10 +90,20 @@ Uploading the same `blobId` twice with **identical** `sha256` and `size` returns
 
 ## Listing
 
-See **List / metadata / delete** above for the basic call.
+See **List / metadata / delete** above for the basic call. Each item carries `blobId`, `filename`, `contentType`, `numBytes`, `sha256`, and `createdAt`. `cursor` is an opaque pagination token; only present when more results exist — follow it to page through results.
 
+```swift
+  let page1 = try await blobs.list(limit: 50)
+  for b in page1.items {
+    print(b.blobId, b.filename, b.contentType, b.numBytes, b.sha256, b.createdAt)
+  }
 
-`list(limit:)` returns the items array directly. Each item carries `blobId`, `filename`, `contentType`, `numBytes`, `sha256`, and `createdAt`.
+  // `cursor` is an opaque token; only present when more results remain.
+  if let cursor = page1.cursor {
+    let page2 = try await blobs.list(cursor: cursor)
+    _ = page2.items
+  }
+```
 
 ---
 
@@ -113,21 +123,28 @@ let meta = try await blobs.get(blobId: blobId)
 
 ### Download URL (authenticated)
 
-The basic call is shown in **List / URL / read** above. The URL is authenticated via the user's session against the API origin.
-
+The basic call is shown in **List / URL / read** above. `downloadUrl` is synchronous and returns a string, authenticated via the user's session against the API origin — it works in an `<a href download>` or `window.location`.
 
 ```swift
-let url = blobs.downloadUrl(blobId: blobId, disposition: .attachment) // or .inline
+  let url = blobs.downloadUrl(
+    blobId: blobId,
+    disposition: .attachment,            // or .inline
+    attachmentFilename: "report.pdf"     // optional override (RFC 5987-encoded)
+  )
 ```
 
 ### Read content into memory
 
-`read` is shown in **List / URL / read** above.
-
+`read` is shown in **List / URL / read** above. It checks the cache first; on a miss it fetches from the server and writes the response into the cache.
 
 ```swift
-let data = try await blobs.read(blobId: blobId) // Data
+  let bytes = try await blobs.read(blobId: blobId)                 // Data
+  let text = try await blobs.read(blobId: blobId, as: String.self) // UTF-8 String
+
+  // Bypass the local cache and re-fetch from the server.
+  let fresh = try await blobs.read(blobId: blobId, as: String.self, force: true)
 ```
+
 
 ### Range requests and conditional GETs
 
@@ -151,41 +168,82 @@ let result = try await blobs.delete(blobId: blobId) // BlobDeleteResult: .delete
 
 Deleting also cancels any in-flight upload for the same `blobId` and clears local bytes.
 
+---
+
+## Offline & the upload queue
+
+The upload queue is keyed by user identity, retries with exponential backoff (2s base, 60s max), and persists across reloads. While offline, bytes are written to the local cache immediately and queued; `upload()` resolves without waiting for the network (`bytesTransferred: 0`). Reads are served from the cache for blobs previously uploaded or downloaded on this device/user, and `prefetch` warms the cache — its per-blob errors are logged and swallowed, so it resolves once all attempts complete regardless of individual failures. Coming back online resumes queue processing automatically, draining the queue in the background.
+
+```swift
+  client.setNetworkMode(.offline)
+
+  // Bytes are written to the local cache immediately and queued. upload()
+  // resolves without waiting for the network (bytesTransferred is 0).
+  let result = try await blobs.upload(
+    data: data,
+    options: BlobUploadSourceOptions(filename: "draft.txt", contentType: "text/plain")
+  )
+
+  // Reads served from cache for blobs uploaded or downloaded on this device.
+  let text = try await blobs.read(blobId: result.blobId, as: String.self)
+
+  // Warm the cache; per-blob errors are logged and swallowed.
+  await blobs.prefetch(blobIds: blobIds, concurrency: 4)
+
+  // Queue processing resumes automatically; listen for .blobsQueueDrained.
+  client.setNetworkMode(.online)
+```
 
 ---
 
-## Upload queue, prefetch, and events
+## Queue management
 
-Failed uploads retry with exponential backoff (2s base, 60s max). Inspect and control the queue through the document blob context, and read/prefetch cached bytes with the typed `read` overloads:
+Inspect and control the per-document upload queue, and set the client-wide upload concurrency (applies to all documents). The `queueId` is the `blobId` for document uploads.
 
 ```swift
-let blobs = client.documents.blobs(documentId: documentId)
+  // Inspect what's queued for this document. Each BlobUploadStatus carries
+  // queueId, blobId, filename, contentType, numBytes, status, attempts,
+  // nextAttemptAt, lastError.
+  let tasks = blobs.uploads()
 
-// Inspect what's queued — each BlobUploadStatus carries queueId, blobId,
-// filename, contentType, numBytes, status, attempts, nextAttemptAt, lastError
-let tasks = blobs.uploads()
+  // Pause/resume by blobId (the queueId is the blobId for document uploads).
+  _ = blobs.pauseUpload(blobId: blobId)
+  _ = blobs.resumeUpload(blobId: blobId)
 
-// Pause/resume by blobId (the queueId is the blobId for document uploads)
-_ = blobs.pauseUpload(blobId: blobId)
-_ = blobs.resumeUpload(blobId: blobId)
+  blobs.pauseAll()
+  blobs.resumeAll()
 
-blobs.pauseAll()
-blobs.resumeAll()
+  // Concurrency is set on the client (global, all documents).
+  client.setBlobUploadConcurrency(5) // min 1; default 2
+  let concurrency = client.getBlobUploadConcurrency()
+```
 
-// Concurrency is set on the client (global, all documents)
-client.setBlobUploadConcurrency(5) // min 1; default 2
-_ = client.getBlobUploadConcurrency()
+---
 
-// Warm the local cache; per-blob errors are logged and swallowed
-await blobs.prefetch(blobIds: [blobId1, blobId2], concurrency: 4)
+## Events
 
-// Cached-first reads; pass force: true to bypass the cache
-let bytes = try await blobs.read(blobId: blobId)              // Data
-let text = try await blobs.read(blobId: blobId, as: String.self)
+The upload queue emits lifecycle events. `upload-progress` is *not* a byte-level progress event — it fires on status transitions. There is no per-byte progress callback. `delete` issued mid-upload cancels the in-flight transfer and evicts the cached bytes.
+
+```swift
+  let progress = client.events.on(.blobsUploadProgress) { (e: BlobUploadProgressEvent) in
+    print(e.queueId, e.blobId, e.status, e.numBytes, e.attempts)
+  }
+
+  let completed = client.events.on(.blobsUploadCompleted) { (e: BlobUploadCompletedEvent) in
+    print("done", e.blobId, e.queueId)
+  }
+
+  let failed = client.events.on(.blobsUploadFailed) { (e: BlobUploadFailedEvent) in
+    print("failed", e.blobId, e.lastError ?? "", "retry?", e.willRetry)
+  }
+```
+
+A typed `read(blobId:as:)` overload also JSON-decodes a blob into any `Decodable` type:
+
+```swift
 let payload = try await blobs.read(blobId: blobId, as: MyCodable.self)
 ```
 
-Queue lifecycle events arrive on `client.events`: `.blobsUploadQueued`, `.blobsUploadProgress` (status transitions, not per-byte progress), `.blobsUploadCompleted`, `.blobsUploadFailed`, `.blobsUploadPaused`, `.blobsUploadResumed`, and `.blobsQueueDrained` once the queue empties. `delete(blobId:)` issued mid-upload cancels the in-flight transfer, evicts the cached bytes, and fires `.blobsQueueDrained` when the queue empties.
 
 ---
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_BLOBS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_BLOBS.template.md
@@ -105,27 +105,9 @@ Uploading the same `blobId` twice with **identical** `sha256` and `size` returns
 
 ## Listing
 
-See **List / metadata / delete** above for the basic call.
+See **List / metadata / delete** above for the basic call. Each item carries `blobId`, `filename`, `contentType`, `numBytes`, `sha256`, and `createdAt`. `cursor` is an opaque pagination token; only present when more results exist — follow it to page through results.
 
-{{#lang ts}}
-To page through results, follow the cursor:
-
-```typescript
-const page1 = await blobs.list({ limit: 50 });
-for (const b of page1.items) {
-  console.log(b.blobId, b.filename, b.contentType, b.numBytes, b.sha256, b.createdAt);
-}
-if (page1.cursor) {
-  const page2 = await blobs.list({ cursor: page1.cursor });
-}
-```
-
-`cursor` is an opaque pagination token; only present when more results exist.
-{{/lang}}
-
-{{#lang swift}}
-`list(limit:)` returns the items array directly. Each item carries `blobId`, `filename`, `contentType`, `numBytes`, `sha256`, and `createdAt`.
-{{/lang}}
+{{ example: blobs/doc-blob-list-paginate }}
 
 ---
 
@@ -153,49 +135,18 @@ let meta = try await blobs.get(blobId: blobId)
 
 ### Download URL (authenticated)
 
-The basic call is shown in **List / URL / read** above. The URL is authenticated via the user's session against the API origin.
+The basic call is shown in **List / URL / read** above. `downloadUrl` is synchronous and returns a string, authenticated via the user's session against the API origin — it works in an `<a href download>` or `window.location`.
 
-{{#lang ts}}
-```typescript
-const url = blobs.downloadUrl(blobId, {
-  disposition: "attachment",        // or "inline"
-  attachmentFilename: "report.pdf", // optional override (RFC 5987-encoded)
-});
-// Synchronous; returns a string. Authenticated via the user's session/cookie
-// against the API origin. Works in <a href={url} download> or window.location.
-```
-{{/lang}}
-
-{{#lang swift}}
-```swift
-let url = blobs.downloadUrl(blobId: blobId, disposition: .attachment) // or .inline
-```
-{{/lang}}
+{{ example: blobs/doc-blob-download-url }}
 
 ### Read content into memory
 
-`read` is shown in **List / URL / read** above.
+`read` is shown in **List / URL / read** above. It checks the cache first; on a miss it fetches from the server and writes the response into the cache.
+
+{{ example: blobs/doc-blob-read-formats }}
 
 {{#lang ts}}
-The return format is selectable via `{ as }`:
-
-```typescript
-const text  = await blobs.read(blobId, { as: "text" });
-const buf   = await blobs.read(blobId, { as: "arrayBuffer" });
-const blob  = await blobs.read(blobId, { as: "blob" });
-const bytes = await blobs.read(blobId, { as: "uint8array" }); // default
-
-// Bypass the local Cache API + IndexedDB cache and re-fetch from the server.
-const fresh = await blobs.read(blobId, { as: "text", forceRedownload: true });
-```
-
-`read` checks the cache first; on a miss it fetches from the server and writes the response into the cache. When offline (`networkMode === "offline"`) and the cache is empty, it throws `"Blob cache unavailable while offline"`.
-{{/lang}}
-
-{{#lang swift}}
-```swift
-let data = try await blobs.read(blobId: blobId) // Data
-```
+`{ as: "blob" }` is also available and returns a `Blob`. When offline (`networkMode === "offline"`) and the cache is empty, `read` throws `"Blob cache unavailable while offline"`.
 {{/lang}}
 
 ### Range requests and conditional GETs
@@ -227,102 +178,39 @@ let result = try await blobs.delete(blobId: blobId) // BlobDeleteResult: .delete
 
 Deleting also cancels any in-flight upload for the same `blobId` and clears local bytes.
 
-{{#lang ts}}
 ---
 
 ## Offline & the upload queue
 
-The upload queue is keyed by user identity. It hydrates from IndexedDB on sign-in, retries with exponential backoff (2s base, 60s max), and persists across page reloads.
+The upload queue is keyed by user identity, retries with exponential backoff (2s base, 60s max), and persists across reloads. While offline, bytes are written to the local cache immediately and queued; `upload()` resolves without waiting for the network (`bytesTransferred: 0`). Reads are served from the cache for blobs previously uploaded or downloaded on this device/user, and `prefetch` warms the cache — its per-blob errors are logged and swallowed, so it resolves once all attempts complete regardless of individual failures. Coming back online resumes queue processing automatically, draining the queue in the background.
 
-### Upload while offline
-
-```typescript
-await client.setNetworkMode("offline");
-
-// Bytes are written to the local Cache API immediately and queued.
-// upload() resolves without waiting for the network (the result includes
-// bytesTransferred: 0 to indicate nothing was transferred yet).
-const { blobId } = await blobs.upload(data, {
-  filename: "draft.txt",
-  contentType: "text/plain",
-});
-```
-
-### Read cached blobs offline
-
-```typescript
-// Works for blobs that were previously uploaded or downloaded on this device/user.
-const text = await blobs.read(blobId, { as: "text" });
-```
-
-### Prefetch into the cache
-
-```typescript
-await blobs.prefetch([blobId1, blobId2, blobId3], {
-  concurrency: 4,        // default 2, capped at blobIds.length
-  forceRedownload: false,
-});
-```
-
-Errors per blob are logged and swallowed — `prefetch` resolves once all attempts complete, regardless of individual failures. Don't rely on it to surface errors.
-
-### Coming back online
-
-```typescript
-await client.setNetworkMode("online");
-// Queue processing resumes automatically. Listen for "blobs:queue-drained" to know when done.
-```
+{{ example: blobs/doc-blob-offline }}
 
 ---
 
 ## Queue management
 
-```typescript
-// Inspect what's queued for this document
-const tasks = blobs.uploads();
-// Each task: { queueId, blobId, filename, contentType, numBytes,
-//              status: "pending" | "uploading" | "uploaded" | "paused",
-//              attempts, nextAttemptAt, retainLocal?, lastError?, updatedAt }
+Inspect and control the per-document upload queue, and set the client-wide upload concurrency (applies to all documents). The `queueId` is the `blobId` for document uploads.
 
-// Pause/resume by blobId (the queueId is the blobId for document uploads)
-blobs.pauseUpload(blobId);
-blobs.resumeUpload(blobId);
-
-blobs.pauseAll();
-blobs.resumeAll();
-
-// Concurrency is set on the client (global, all documents)
-client.setBlobUploadConcurrency(5); // min 1; default 2
-client.getBlobUploadConcurrency();
-```
+{{ example: blobs/doc-blob-queue }}
 
 ---
 
 ## Events
 
-```typescript
-// status here is one of: "queued" | "uploading" | "pending" | "paused"
-client.on("blobs:upload-progress", (e) => {
-  console.log(e.queueId, e.blobId, e.status, e.numBytes, e.attempts);
-});
+The upload queue emits lifecycle events. `upload-progress` is *not* a byte-level progress event — it fires on status transitions. There is no per-byte progress callback. `delete` issued mid-upload cancels the in-flight transfer and evicts the cached bytes.
 
-client.on("blobs:upload-completed", (e) => {
-  console.log("done", e.blobId, e.queueId);
-});
+{{ example: blobs/doc-blob-events }}
 
-client.on("blobs:upload-failed", (e) => {
-  console.log("failed", e.blobId, e.lastError, "retry?", e.willRetry);
-});
+{{#lang swift}}
+A typed `read(blobId:as:)` overload also JSON-decodes a blob into any `Decodable` type:
 
-client.on("blobs:queue-drained", () => {
-  console.log("all uploads finished");
-});
-
-// Also available: "blobs:upload-paused", "blobs:upload-resumed"
+```swift
+let payload = try await blobs.read(blobId: blobId, as: MyCodable.self)
 ```
+{{/lang}}
 
-`upload-progress` is *not* a byte-level progress event — it fires on status transitions. There is no per-byte progress callback.
-
+{{#lang ts}}
 ---
 
 ## Service worker proxy (for `<img>` / `<video>`)
@@ -344,43 +232,6 @@ if (blobs.hasServiceWorkerControl()) {
 ```
 
 `proxyUrl` returns the same URL as `downloadUrl`; it just signals intent to be intercepted by the service worker. See the js-bao-wss-client README for a service-worker implementation.
-{{/lang}}
-
-{{#lang swift}}
----
-
-## Upload queue, prefetch, and events
-
-Failed uploads retry with exponential backoff (2s base, 60s max). Inspect and control the queue through the document blob context, and read/prefetch cached bytes with the typed `read` overloads:
-
-```swift
-let blobs = client.documents.blobs(documentId: documentId)
-
-// Inspect what's queued — each BlobUploadStatus carries queueId, blobId,
-// filename, contentType, numBytes, status, attempts, nextAttemptAt, lastError
-let tasks = blobs.uploads()
-
-// Pause/resume by blobId (the queueId is the blobId for document uploads)
-_ = blobs.pauseUpload(blobId: blobId)
-_ = blobs.resumeUpload(blobId: blobId)
-
-blobs.pauseAll()
-blobs.resumeAll()
-
-// Concurrency is set on the client (global, all documents)
-client.setBlobUploadConcurrency(5) // min 1; default 2
-_ = client.getBlobUploadConcurrency()
-
-// Warm the local cache; per-blob errors are logged and swallowed
-await blobs.prefetch(blobIds: [blobId1, blobId2], concurrency: 4)
-
-// Cached-first reads; pass force: true to bypass the cache
-let bytes = try await blobs.read(blobId: blobId)              // Data
-let text = try await blobs.read(blobId: blobId, as: String.self)
-let payload = try await blobs.read(blobId: blobId, as: MyCodable.self)
-```
-
-Queue lifecycle events arrive on `client.events`: `.blobsUploadQueued`, `.blobsUploadProgress` (status transitions, not per-byte progress), `.blobsUploadCompleted`, `.blobsUploadFailed`, `.blobsUploadPaused`, `.blobsUploadResumed`, and `.blobsQueueDrained` once the queue empties. `delete(blobId:)` issued mid-upload cancels the in-flight transfer, evicts the cached bytes, and fires `.blobsQueueDrained` when the queue empties.
 {{/lang}}
 
 ---

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_BLOBS.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_BLOBS.ts.md
@@ -111,22 +111,20 @@ Uploading the same `blobId` twice with **identical** `sha256` and `size` returns
 
 ## Listing
 
-See **List / metadata / delete** above for the basic call.
-
-To page through results, follow the cursor:
+See **List / metadata / delete** above for the basic call. Each item carries `blobId`, `filename`, `contentType`, `numBytes`, `sha256`, and `createdAt`. `cursor` is an opaque pagination token; only present when more results exist — follow it to page through results.
 
 ```typescript
-const page1 = await blobs.list({ limit: 50 });
-for (const b of page1.items) {
-  console.log(b.blobId, b.filename, b.contentType, b.numBytes, b.sha256, b.createdAt);
-}
-if (page1.cursor) {
-  const page2 = await blobs.list({ cursor: page1.cursor });
-}
+  const page1 = await blobs.list({ limit: 50 });
+  for (const b of page1.items) {
+    console.log(b.blobId, b.filename, b.contentType, b.numBytes, b.sha256, b.createdAt);
+  }
+
+  // `cursor` is an opaque token; only present when more results remain.
+  if (page1.cursor) {
+    const page2 = await blobs.list({ cursor: page1.cursor });
+    return page2.items;
+  }
 ```
-
-`cursor` is an opaque pagination token; only present when more results exist.
-
 
 ---
 
@@ -146,36 +144,29 @@ const meta = await blobs.get(blobId);
 
 ### Download URL (authenticated)
 
-The basic call is shown in **List / URL / read** above. The URL is authenticated via the user's session against the API origin.
+The basic call is shown in **List / URL / read** above. `downloadUrl` is synchronous and returns a string, authenticated via the user's session against the API origin — it works in an `<a href download>` or `window.location`.
 
 ```typescript
-const url = blobs.downloadUrl(blobId, {
-  disposition: "attachment",        // or "inline"
-  attachmentFilename: "report.pdf", // optional override (RFC 5987-encoded)
-});
-// Synchronous; returns a string. Authenticated via the user's session/cookie
-// against the API origin. Works in <a href={url} download> or window.location.
+  const url = blobs.downloadUrl(blobId, {
+    disposition: "attachment",        // or "inline"
+    attachmentFilename: "report.pdf", // optional override (RFC 5987-encoded)
+  });
 ```
-
 
 ### Read content into memory
 
-`read` is shown in **List / URL / read** above.
-
-The return format is selectable via `{ as }`:
+`read` is shown in **List / URL / read** above. It checks the cache first; on a miss it fetches from the server and writes the response into the cache.
 
 ```typescript
-const text  = await blobs.read(blobId, { as: "text" });
-const buf   = await blobs.read(blobId, { as: "arrayBuffer" });
-const blob  = await blobs.read(blobId, { as: "blob" });
-const bytes = await blobs.read(blobId, { as: "uint8array" }); // default
+  const text = await blobs.read(blobId, { as: "text" });
+  const buf = await blobs.read(blobId, { as: "arrayBuffer" });
+  const bytes = await blobs.read(blobId, { as: "uint8array" }); // default
 
-// Bypass the local Cache API + IndexedDB cache and re-fetch from the server.
-const fresh = await blobs.read(blobId, { as: "text", forceRedownload: true });
+  // Bypass the local cache and re-fetch from the server.
+  const fresh = await blobs.read(blobId, { as: "text", forceRedownload: true });
 ```
 
-`read` checks the cache first; on a miss it fetches from the server and writes the response into the cache. When offline (`networkMode === "offline"`) and the cache is empty, it throws `"Blob cache unavailable while offline"`.
-
+`{ as: "blob" }` is also available and returns a `Blob`. When offline (`networkMode === "offline"`) and the cache is empty, `read` throws `"Blob cache unavailable while offline"`.
 
 ### Range requests and conditional GETs
 
@@ -203,96 +194,72 @@ Deleting also cancels any in-flight upload for the same `blobId` and clears loca
 
 ## Offline & the upload queue
 
-The upload queue is keyed by user identity. It hydrates from IndexedDB on sign-in, retries with exponential backoff (2s base, 60s max), and persists across page reloads.
-
-### Upload while offline
+The upload queue is keyed by user identity, retries with exponential backoff (2s base, 60s max), and persists across reloads. While offline, bytes are written to the local cache immediately and queued; `upload()` resolves without waiting for the network (`bytesTransferred: 0`). Reads are served from the cache for blobs previously uploaded or downloaded on this device/user, and `prefetch` warms the cache — its per-blob errors are logged and swallowed, so it resolves once all attempts complete regardless of individual failures. Coming back online resumes queue processing automatically, draining the queue in the background.
 
 ```typescript
-await client.setNetworkMode("offline");
+  await client.setNetworkMode("offline");
 
-// Bytes are written to the local Cache API immediately and queued.
-// upload() resolves without waiting for the network (the result includes
-// bytesTransferred: 0 to indicate nothing was transferred yet).
-const { blobId } = await blobs.upload(data, {
-  filename: "draft.txt",
-  contentType: "text/plain",
-});
-```
+  // Bytes are written to the local cache immediately and queued. upload()
+  // resolves without waiting for the network (bytesTransferred is 0).
+  const { blobId } = await blobs.upload(data, {
+    filename: "draft.txt",
+    contentType: "text/plain",
+  });
 
-### Read cached blobs offline
+  // Reads served from cache for blobs uploaded or downloaded on this device.
+  const text = await blobs.read(blobId, { as: "text" });
 
-```typescript
-// Works for blobs that were previously uploaded or downloaded on this device/user.
-const text = await blobs.read(blobId, { as: "text" });
-```
+  // Warm the cache; per-blob errors are logged and swallowed.
+  await blobs.prefetch(blobIds, { concurrency: 4 });
 
-### Prefetch into the cache
-
-```typescript
-await blobs.prefetch([blobId1, blobId2, blobId3], {
-  concurrency: 4,        // default 2, capped at blobIds.length
-  forceRedownload: false,
-});
-```
-
-Errors per blob are logged and swallowed — `prefetch` resolves once all attempts complete, regardless of individual failures. Don't rely on it to surface errors.
-
-### Coming back online
-
-```typescript
-await client.setNetworkMode("online");
-// Queue processing resumes automatically. Listen for "blobs:queue-drained" to know when done.
+  // Queued uploads resume automatically once back online.
+  await client.setNetworkMode("online");
 ```
 
 ---
 
 ## Queue management
 
+Inspect and control the per-document upload queue, and set the client-wide upload concurrency (applies to all documents). The `queueId` is the `blobId` for document uploads.
+
 ```typescript
-// Inspect what's queued for this document
-const tasks = blobs.uploads();
-// Each task: { queueId, blobId, filename, contentType, numBytes,
-//              status: "pending" | "uploading" | "uploaded" | "paused",
-//              attempts, nextAttemptAt, retainLocal?, lastError?, updatedAt }
+  // Inspect what's queued for this document. Each task carries queueId, blobId,
+  // filename, contentType, numBytes, status, attempts, nextAttemptAt, lastError.
+  const tasks = blobs.uploads();
 
-// Pause/resume by blobId (the queueId is the blobId for document uploads)
-blobs.pauseUpload(blobId);
-blobs.resumeUpload(blobId);
+  // Pause/resume by blobId (the queueId is the blobId for document uploads).
+  blobs.pauseUpload(blobId);
+  blobs.resumeUpload(blobId);
 
-blobs.pauseAll();
-blobs.resumeAll();
+  blobs.pauseAll();
+  blobs.resumeAll();
 
-// Concurrency is set on the client (global, all documents)
-client.setBlobUploadConcurrency(5); // min 1; default 2
-client.getBlobUploadConcurrency();
+  // Concurrency is set on the client (global, all documents).
+  client.setBlobUploadConcurrency(5); // min 1; default 2
+  const concurrency = client.getBlobUploadConcurrency();
 ```
 
 ---
 
 ## Events
 
+The upload queue emits lifecycle events. `upload-progress` is *not* a byte-level progress event — it fires on status transitions. There is no per-byte progress callback. `delete` issued mid-upload cancels the in-flight transfer and evicts the cached bytes.
+
 ```typescript
-// status here is one of: "queued" | "uploading" | "pending" | "paused"
-client.on("blobs:upload-progress", (e) => {
-  console.log(e.queueId, e.blobId, e.status, e.numBytes, e.attempts);
-});
+  // status is one of: "queued" | "uploading" | "pending" | "paused"
+  client.on("blobs:upload-progress", (e) => {
+    console.log(e.queueId, e.blobId, e.status, e.numBytes, e.attempts);
+  });
 
-client.on("blobs:upload-completed", (e) => {
-  console.log("done", e.blobId, e.queueId);
-});
+  client.on("blobs:upload-completed", (e) => {
+    console.log("done", e.blobId, e.queueId);
+  });
 
-client.on("blobs:upload-failed", (e) => {
-  console.log("failed", e.blobId, e.lastError, "retry?", e.willRetry);
-});
-
-client.on("blobs:queue-drained", () => {
-  console.log("all uploads finished");
-});
-
-// Also available: "blobs:upload-paused", "blobs:upload-resumed"
+  client.on("blobs:upload-failed", (e) => {
+    console.log("failed", e.blobId, e.lastError, "retry?", e.willRetry);
+  });
 ```
 
-`upload-progress` is *not* a byte-level progress event — it fires on status transitions. There is no per-byte progress callback.
 
 ---
 
@@ -315,7 +282,6 @@ if (blobs.hasServiceWorkerControl()) {
 ```
 
 `proxyUrl` returns the same URL as `downloadUrl`; it just signals intent to be intercepted by the service worker. See the js-bao-wss-client README for a service-worker implementation.
-
 
 ---
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_BLOB_BUCKETS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_BLOB_BUCKETS.swift.md
@@ -69,11 +69,14 @@ Admin/owner only. Deleting a bucket cascades to every blob inside it.
 
 **Blob buckets** — general-purpose storage outside any document context. Each bucket has its own access preset, TTL tier, and supports time-limited signed URLs. **Cap: 100 MB per blob.**
 
-
 ```swift
-// There is no bucket() context object. The bucket key/ID is a positional arg.
-try await client.blobBuckets.upload(bucketIdOrKey: "avatars", data: data, filename: filename, contentType: contentType)
-try await client.blobBuckets.getSignedUrl(bucketIdOrKey: "avatars", blobId: blobId, expiresInSeconds: 3600)
+  // The bucket key/ID is a positional arg — there is no bucket() context object.
+  try await client.blobBuckets.upload(
+    bucketIdOrKey: "avatars", data: data, filename: filename, contentType: contentType
+  )
+  try await client.blobBuckets.getSignedUrl(
+    bucketIdOrKey: "avatars", blobId: blobId, expiresInSeconds: 3600
+  )
 ```
 
 **Decision rule:** use document-scoped blobs when the file's lifetime and access naturally match a document's. Use a bucket for avatars, workflow outputs, public assets, anonymous reads via signed URLs, or anything that should live outside any specific document. Document-scoped blobs (10 MB cap, permission inheritance, offline caching) are covered in the [Blobs guide](AGENT_GUIDE_TO_PRIMITIVE_BLOBS.md).

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_BLOB_BUCKETS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_BLOB_BUCKETS.template.md
@@ -28,21 +28,7 @@ Admin/owner only. Deleting a bucket cascades to every blob inside it.
 
 **Blob buckets** — general-purpose storage outside any document context. Each bucket has its own access preset, TTL tier, and supports time-limited signed URLs. **Cap: 100 MB per blob.**
 
-{{#lang ts}}
-```typescript
-// There is NO bucket() context object. The bucket key/ID is a positional arg.
-await client.blobBuckets.upload("avatars", { filename, contentType, data });
-await client.blobBuckets.getSignedUrl("avatars", blobId, 3600);
-```
-{{/lang}}
-
-{{#lang swift}}
-```swift
-// There is no bucket() context object. The bucket key/ID is a positional arg.
-try await client.blobBuckets.upload(bucketIdOrKey: "avatars", data: data, filename: filename, contentType: contentType)
-try await client.blobBuckets.getSignedUrl(bucketIdOrKey: "avatars", blobId: blobId, expiresInSeconds: 3600)
-```
-{{/lang}}
+{{ example: blobs/bucket-positional-args }}
 
 **Decision rule:** use document-scoped blobs when the file's lifetime and access naturally match a document's. Use a bucket for avatars, workflow outputs, public assets, anonymous reads via signed URLs, or anything that should live outside any specific document. Document-scoped blobs (10 MB cap, permission inheritance, offline caching) are covered in the [Blobs guide](AGENT_GUIDE_TO_PRIMITIVE_BLOBS.md).
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_BLOB_BUCKETS.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_BLOB_BUCKETS.ts.md
@@ -63,11 +63,10 @@ Admin/owner only. Deleting a bucket cascades to every blob inside it.
 **Blob buckets** — general-purpose storage outside any document context. Each bucket has its own access preset, TTL tier, and supports time-limited signed URLs. **Cap: 100 MB per blob.**
 
 ```typescript
-// There is NO bucket() context object. The bucket key/ID is a positional arg.
-await client.blobBuckets.upload("avatars", { filename, contentType, data });
-await client.blobBuckets.getSignedUrl("avatars", blobId, 3600);
+  // The bucket key/ID is a positional arg — there is no bucket() context object.
+  await client.blobBuckets.upload("avatars", { filename, contentType, data });
+  await client.blobBuckets.getSignedUrl("avatars", blobId, 3600);
 ```
-
 
 **Decision rule:** use document-scoped blobs when the file's lifetime and access naturally match a document's. Use a bucket for avatars, workflow outputs, public assets, anonymous reads via signed URLs, or anything that should live outside any specific document. Document-scoped blobs (10 MB cap, permission inheritance, offline caching) are covered in the [Blobs guide](AGENT_GUIDE_TO_PRIMITIVE_BLOBS.md).
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.swift.md
@@ -855,6 +855,221 @@ primitive databases cel-context update <database-id> --data '{"teamId":"team-alp
 primitive databases cel-context get <database-id>
 ```
 
+## Direct Record Operations
+
+Direct record operations require owner or manager permission. For most apps, use registered operations instead.
+
+`connect()` returns a `DoDb` handle. Save (upsert), patch (partial update), find a single record, delete, and count all run against it. A `save` is an upsert; pass `ifNotExists` for insert-only, `condition` for a conditional write, and `stringSets` to seed StringSet fields:
+
+```swift
+  let db = client.databases.connect(databaseId: databaseId)
+
+  // Save (upsert) — data must carry an "id" (or use upsertOn).
+  _ = try await db.save(modelName: "tasks", data: ["id": "task-1", "title": "Ship v1"])
+
+  // Insert only — fails if the record already exists.
+  _ = try await db.save(
+    modelName: "tasks", data: ["id": "task-3", "title": "Draft"],
+    options: DoDbSaveOptions(ifNotExists: true)
+  )
+
+  // Conditional write — only proceeds if the existing record matches.
+  _ = try await db.save(
+    modelName: "tasks", data: ["id": "task-3", "title": "Draft"],
+    options: DoDbSaveOptions(condition: ["completed": false])
+  )
+
+  // Seed StringSet fields on the write.
+  _ = try await db.save(
+    modelName: "tasks", data: ["id": "task-4", "title": "Tagged"],
+    options: DoDbSaveOptions(stringSets: ["tags": ["featured", "sale"]])
+  )
+
+  // Patch (partial update) — only the provided fields change.
+  _ = try await db.patch(modelName: "tasks", id: "task-1", data: ["priority": 5])
+  _ = try await db.patch(
+    modelName: "tasks", id: "task-1", data: ["priority": 7],
+    options: DoDbPatchOptions(condition: ["completed": false])
+  )
+
+  // Find a single record by id (or nil).
+  let task = try await db.find(modelName: "tasks", id: "task-1")
+
+  // Delete — true if a record existed.
+  let deleted = try await db.delete(modelName: "tasks", id: "task-2")
+
+  // Count, optionally filtered.
+  let total = try await db.count(modelName: "tasks")
+  let open = try await db.count(modelName: "tasks", filter: ["completed": false])
+```
+
+### Query
+
+The handle queries with the full filter operator grammar, sort + cursor pagination, projection, and related-data `include`:
+
+```swift
+  // Filter operators: exact match, comparisons, set membership, text, $or/$and.
+  let result = try await db.query(modelName: "tasks", filter: [
+    "completed": false,
+    "priority": ["$gte": 5],
+    "category": ["$in": ["work", "urgent"]],
+    "title": ["$startsWith": "Ship"],
+    "tags": ["$contains": "featured"],
+    "$or": [["category": "work"], ["priority": ["$gte": 8]]],
+  ])
+
+  // Multiple fields on the same object are ANDed; use explicit $and to put
+  // two conditions on one field.
+  let priced = try await db.query(modelName: "tasks", filter: [
+    "$and": [["priority": ["$gte": 1]], ["priority": ["$lte": 5]]],
+  ])
+
+  // Sort, limit, and cursor pagination.
+  let page1 = try await db.query(
+    modelName: "tasks", filter: [:],
+    options: DoDbQueryOptions(sort: DoDbSort("priority", .descending), limit: 20)
+  )
+  var page2: DoDbQueryResult?
+  if page1.hasMore {
+    page2 = try await db.query(
+      modelName: "tasks", filter: [:],
+      options: DoDbQueryOptions(sort: DoDbSort("priority", .descending), limit: 20, uniqueStartKey: page1.nextCursor)
+    )
+  }
+
+  // Projection — return only the named fields.
+  let titles = try await db.query(
+    modelName: "tasks", filter: [:],
+    options: DoDbQueryOptions(projection: DoDbProjection([("title", .include), ("completed", .include)]))
+  )
+
+  // Include related records — they land under _related on each parent.
+  let withCategory = try await db.query(
+    modelName: "tasks", filter: [:],
+    options: DoDbQueryOptions(include: [
+      DoDbInclude(model: "categories", type: .refersTo, sourceField: "category", alias: "categoryInfo")
+    ])
+  )
+```
+
+### Filter operators
+
+| Operator | Description | Example |
+|----------|-------------|---------|
+| *(exact match)* | Equals a value (shorthand for `$eq`) | `{ status: "active" }` |
+| `$eq` | Explicit equality | `{ status: { $eq: "active" } }` |
+| `$ne` | Not equal | `{ status: { $ne: "archived" } }` |
+| `$gt` | Greater than | `{ price: { $gt: 10 } }` |
+| `$gte` | Greater than or equal | `{ price: { $gte: 10 } }` |
+| `$lt` | Less than | `{ price: { $lt: 50 } }` |
+| `$lte` | Less than or equal | `{ price: { $lte: 50 } }` |
+| `$in` | Matches any value in array | `{ category: { $in: ["books", "music"] } }` |
+| `$nin` | Matches none of the values in array | `{ status: { $nin: ["archived", "deleted"] } }` |
+| `$startsWith` | String prefix match | `{ name: { $startsWith: "Pro" } }` |
+| `$endsWith` | String suffix match | `{ filename: { $endsWith: ".pdf" } }` |
+| `$containsText` | Full-text search | `{ name: { $containsText: "deluxe" } }` |
+| `$exists` | Field exists (true) or is null/missing (false) | `{ avatar: { $exists: true } }` |
+| `$contains` | StringSet contains a value | `{ tags: { $contains: "featured" } }` |
+| `$all` | StringSet contains all values | `{ tags: { $all: ["featured", "sale"] } }` |
+| `$size` | StringSet element count (number or comparison) | `{ tags: { $size: 3 } }` or `{ tags: { $size: { $gte: 1 } } }` |
+| `$or` | Matches any of the conditions | `{ $or: [{ status: "active" }, { priority: { $gte: 5 } }] }` |
+| `$and` | Matches all conditions (useful when multiple conditions target the same field) | `{ $and: [{ price: { $gte: 10 } }, { price: { $lte: 50 } }] }` |
+
+`$startsWith`, `$endsWith`, and `$containsText` are mutually exclusive on the same field — only one substring operator per field per query.
+
+Multiple filters on different fields are implicitly combined with AND. Use an explicit `$and` only when you need two conditions on the *same* field (e.g. a range), and combine `$or` with other top-level fields freely.
+
+Include types: `refersTo` (FK to one record), `hasMany` (target FK to this record), `refersToMany` (StringSet to multiple records). The loaded records land under `_related` on each parent (e.g. `result.data[0]._related.customer`).
+
+## Atomic Operations
+
+Increment/decrement numeric fields (returns the post-increment values) and add/remove StringSet members atomically — no read-modify-write round trip:
+
+```swift
+  // Increment/decrement numeric fields; returns the post-increment values.
+  let newValues = try await db.increment(
+    modelName: "tasks", id: "task-1",
+    fields: ["priority": 1, "estimatedHours": -2]
+  )
+
+  // Atomically add/remove StringSet members.
+  try await db.addToSet(modelName: "tasks", id: "task-1", sets: ["tags": ["featured"]])
+  try await db.removeFromSet(modelName: "tasks", id: "task-1", sets: ["tags": ["sale"]])
+```
+
+## Batch Writes (direct)
+
+`db.batch` executes multiple writes atomically at the storage layer. It returns one `BatchOperationResult` per input op (`{success, id, error?, values?}` — `values` for increment ops); a per-item failure does NOT throw, so check `.success` on each result.
+
+```swift
+  let results = try await db.batch([
+    DoDbBatchOperation(op: .save, modelName: "tasks", id: "t-1", data: ["title": "A"]),
+    DoDbBatchOperation(op: .patch, modelName: "tasks", id: "t-2", data: ["completed": true]),
+    DoDbBatchOperation(op: .delete, modelName: "tasks", id: "t-3"),
+    DoDbBatchOperation(op: .increment, modelName: "tasks", id: "t-4", fields: ["priority": 1]),
+    DoDbBatchOperation(op: .addToSet, modelName: "tasks", id: "t-5", stringSets: ["tags": ["urgent"]]),
+  ])
+
+  for r in results where !r.success {
+    print("op failed:", r.id, r.error ?? "")
+  }
+```
+
+### Aggregation (direct)
+
+Group by one or more fields and compute `count`/`sum`/`avg`/`min`/`max`, with an optional filter, sort, and limit:
+
+```swift
+  let result = try await db.aggregate(modelName: "tasks", options: DoDbAggregationOptions(
+    groupBy: [.field("category")],
+    operations: [
+      DoDbAggregationOperation(type: .count),
+      DoDbAggregationOperation(type: .sum, field: "estimatedHours"),
+      DoDbAggregationOperation(type: .avg, field: "estimatedHours"),
+      DoDbAggregationOperation(type: .min, field: "priority"),
+      DoDbAggregationOperation(type: .max, field: "priority"),
+    ],
+    filter: ["completed": false],
+    limit: 10,
+    sort: DoDbAggregationSort(field: "count", direction: .descending)
+  ))
+```
+
+
+Database field types: `id` (primary key, use `auto_assign = true` for ULIDs), `string`, `number`, `boolean`, `date`, `stringset` (set-of-strings field — use with `addToSet`/`removeFromSet`). There is no object/JSON field type — store structured payloads as JSON strings and parse on read.
+
+### Indexes
+
+Add an index to every field you filter or sort on; without one the engine scans all records of that model. Register them manually, declare composite unique constraints, list and drop them, or sync a model's declared index state at once:
+
+```swift
+  // Sync the desired index state for one or more models (additive — the
+  // server registers only what's missing).
+  _ = try await db.syncIndexes(models: [
+    DoDbModelSyncState(
+      modelName: "tasks",
+      indexes: [
+        DoDbModelSyncState.Index(fieldName: "category"),
+        DoDbModelSyncState.Index(fieldName: "priority", fieldType: "number"),
+      ]
+    )
+  ])
+
+  // Or register indexes manually.
+  try await db.registerIndex(modelName: "tasks", fieldName: "category", fieldType: "string")
+  try await db.registerIndex(modelName: "tasks", fieldName: "priority", fieldType: "number")
+  try await db.registerIndex(modelName: "appUsers", fieldName: "email", fieldType: "string", unique: true)
+
+  // Composite unique constraint across multiple fields.
+  try await db.registerUniqueConstraint(modelName: "categories", constraintName: "name_parentId", fields: ["name", "parentId"])
+
+  // List and drop.
+  let indexes = try await db.listIndexes(modelName: "tasks")
+  try await db.dropIndex(modelName: "tasks", fieldName: "category")
+
+  let constraints = try await db.listUniqueConstraints(modelName: "categories")
+  try await db.dropUniqueConstraint(modelName: "categories", constraintName: "name_parentId")
+```
 
 ## Permissions
 
@@ -933,8 +1148,16 @@ For a unified "all DBs I can access" view, combine `databases.list()` with `grou
 
 Databases are schemaless — the system tracks fields and inferred types as records are written.
 
-List the models (collections) in a database via the raw records endpoint `GET /app/<appId>/api/databases/<databaseId>/records/models` (returns `{ models: ["contacts", "orders", "products"] }`).
+List the models (collections) in a database via the raw records endpoint `GET /app/<appId>/api/databases/<databaseId>/records/models` (returns `{ models: ["contacts", "orders", "products"] }`):
 
+```swift
+  let result = try await client.makeRequest(
+    "GET",
+    "/databases/\(databaseId)/records/models"
+  )
+  let models = (result as? [String: Any])?["models"] as? [String]
+  // models: ["contacts", "orders", "products"]
+```
 
 Describe a model's observed fields:
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.template.md
@@ -783,77 +783,19 @@ primitive databases cel-context update <database-id> --data '{"teamId":"team-alp
 primitive databases cel-context get <database-id>
 ```
 
-{{#lang ts}}
 ## Direct Record Operations
 
 Direct record operations require owner or manager permission. For most apps, use registered operations instead.
 
-Connect to a database to get a `DoDb` handle:
+`connect()` returns a `DoDb` handle. Save (upsert), patch (partial update), find a single record, delete, and count all run against it. A `save` is an upsert; pass `ifNotExists` for insert-only, `condition` for a conditional write, and `stringSets` to seed StringSet fields:
 
-```typescript
-const db = client.databases.connect(databaseId);
-```
-
-The handle supports string-based or model-class-based access:
-
-```typescript
-// String-based
-await db.save("tasks", { id: "task-1", title: "Ship v1" });
-
-// Model-class-based (with js-bao models)
-import { Task } from "./models";
-await db.save(Task, { id: "task-1", title: "Ship v1" });
-```
-
-### Save (upsert)
-
-```typescript
-await db.save("products", { id: "prod-1", name: "Widget", price: 9.99 });
-
-// Insert only — fails if record exists
-await db.save("products", data, { ifNotExists: true });
-
-// Conditional write
-await db.save("products", data, { condition: { status: "draft" } });
-
-// With StringSet fields
-await db.save("products", data, { stringSets: { tags: ["featured", "sale"] } });
-```
-
-### Patch (partial update)
-
-```typescript
-await db.patch("products", "prod-1", { price: 7.99 });
-
-// Conditional patch
-await db.patch("products", "prod-1", { price: 7.99 }, { condition: { status: "draft" } });
-```
-
-### Find
-
-```typescript
-const product = await db.find("products", "prod-1"); // or null
-```
-
-### Delete
-
-```typescript
-const deleted = await db.delete("products", "prod-1"); // true if existed
-```
-
-### Count
-
-```typescript
-const total = await db.count("products");
-const saleCount = await db.count("products", { onSale: true });
-```
+{{ example: databases/db-record-crud }}
 
 ### Query
 
-```typescript
-const result = await db.query("tasks", filter, options);
-// result: { data: T[], hasMore: boolean, nextCursor?: string, prevCursor?: string }
-```
+The handle queries with the full filter operator grammar, sort + cursor pagination, projection, and related-data `include`:
+
+{{ example: databases/db-record-query }}
 
 ### Filter operators
 
@@ -880,116 +822,29 @@ const result = await db.query("tasks", filter, options);
 
 `$startsWith`, `$endsWith`, and `$containsText` are mutually exclusive on the same field — only one substring operator per field per query.
 
-Multiple filters on different fields are implicitly combined with AND:
+Multiple filters on different fields are implicitly combined with AND. Use an explicit `$and` only when you need two conditions on the *same* field (e.g. a range), and combine `$or` with other top-level fields freely.
 
-```typescript
-// These two are equivalent:
-{ status: "active", priority: { $gte: 5 } }
-{ $and: [{ status: "active" }, { priority: { $gte: 5 } }] }
-
-// Use explicit $and when you need multiple conditions on the same field:
-{ $and: [{ price: { $gte: 10 } }, { price: { $lte: 50 } }] }
-
-// Combine $or with other filters:
-{ category: "electronics", $or: [{ onSale: true }, { price: { $lt: 20 } }] }
-```
-
-### Sort, limit, pagination
-
-```typescript
-const page1 = await db.query("tasks", {}, {
-  sort: { createdAt: -1 },
-  limit: 20,
-});
-
-if (page1.hasMore) {
-  const page2 = await db.query("tasks", {}, {
-    sort: { createdAt: -1 },
-    limit: 20,
-    uniqueStartKey: page1.nextCursor,
-  });
-}
-```
-
-### Projection
-
-```typescript
-const result = await db.query("tasks", {}, {
-  projection: { title: 1, status: 1 },
-});
-```
-
-### Includes (related data)
-
-```typescript
-const result = await db.query("orders", {}, {
-  include: [{
-    model: "customers",
-    type: "refersTo",
-    sourceField: "customerId",
-    as: "customer",
-  }],
-});
-// result.data[0]._related.customer = { id, name, ... }
-```
-
-Include types: `refersTo` (FK to one record), `hasMany` (target FK to this record), `refersToMany` (StringSet to multiple records).
+Include types: `refersTo` (FK to one record), `hasMany` (target FK to this record), `refersToMany` (StringSet to multiple records). The loaded records land under `_related` on each parent (e.g. `result.data[0]._related.customer`).
 
 ## Atomic Operations
 
-### Increment
+Increment/decrement numeric fields (returns the post-increment values) and add/remove StringSet members atomically — no read-modify-write round trip:
 
-```typescript
-const newValues = await db.increment("products", "prod-1", {
-  viewCount: 1,
-  stock: -1,
-});
-// { viewCount: 43, stock: 11 }
-```
-
-### StringSet add/remove
-
-```typescript
-await db.addToSet("products", "prod-1", { tags: ["featured"] });
-await db.removeFromSet("products", "prod-1", { tags: ["sale"] });
-```
+{{ example: databases/db-record-atomic }}
 
 ## Batch Writes (direct)
 
-`db.batch` executes multiple writes atomically at the storage layer. Returns one `BatchOperationResult` per input op (`{success, id, error?, values?}` — `values` for increment ops); a per-item failure does NOT throw, so check `.success` on each result.
+`db.batch` executes multiple writes atomically at the storage layer. It returns one `BatchOperationResult` per input op (`{success, id, error?, values?}` — `values` for increment ops); a per-item failure does NOT throw, so check `.success` on each result.
 
-```typescript
-const results = await db.batch([
-  { op: "save",      modelName: "tasks", id: "t-1", data: { title: "A" } },
-  { op: "patch",     modelName: "tasks", id: "t-2", data: { done: true } },
-  { op: "delete",    modelName: "tasks", id: "t-3" },
-  { op: "increment", modelName: "tasks", id: "t-4", fields: { priority: 1 } },
-  { op: "addToSet",  modelName: "tasks", id: "t-5", stringSets: { tags: ["urgent"] } },
-]);
-
-for (const r of results) {
-  if (!r.success) console.warn("op failed:", r.id, r.error);
-}
-```
+{{ example: databases/db-record-batch }}
 
 ### Aggregation (direct)
 
-```typescript
-const result = await db.aggregate("orders", {
-  groupBy: ["status"],
-  operations: [
-    { type: "count" },
-    { type: "sum", field: "total" },
-    { type: "avg", field: "total" },
-    { type: "min", field: "total" },
-    { type: "max", field: "total" },
-  ],
-  filter: { createdAt: { $gte: "2025-01-01" } },
-  sort: { field: "count", direction: -1 },
-  limit: 10,
-});
-```
+Group by one or more fields and compute `count`/`sum`/`avg`/`min`/`max`, with an optional filter, sort, and limit:
 
+{{ example: databases/db-record-aggregate }}
+
+{{#lang ts}}
 ## Client-Side Models (Direct Record Access Only)
 
 **Registered operations are the primary client interface for databases and need no client-side models** — the operation layer is typed by `primitive databases codegen` (see TypeScript codegen above). The models below apply only to the **direct record access** path (owner/manager `DoDb` handles): there, defining js-bao models gives you type safety, autoregistration, and automatic index syncing on connect. The database itself stays schemaless — `modelName` is a collection label and the server accepts any JSON for it.
@@ -1060,42 +915,15 @@ export { Task };
 ```
 
 This produces the same runtime artifact as codegen output, but you lose the auto-registered barrel and the boot-time TOML/code consistency check. Reach for it only if TOML+codegen genuinely doesn't fit your build setup; the migration path back to TOML is `npx js-bao-codegen-v2 migrate`.
+{{/lang}}
 
 Database field types: `id` (primary key, use `auto_assign = true` for ULIDs), `string`, `number`, `boolean`, `date`, `stringset` (set-of-strings field — use with `addToSet`/`removeFromSet`). There is no object/JSON field type — store structured payloads as JSON strings and parse on read.
 
 ### Indexes
 
-Add `indexed: true` to fields you filter or sort on. Sync indexes after connecting:
+Add an index to every field you filter or sort on; without one the engine scans all records of that model. Register them manually, declare composite unique constraints, list and drop them, or sync a model's declared index state at once:
 
-```typescript
-const db = client.databases.connect(databaseId);
-await db.syncIndexes(Task);
-```
-
-Or register indexes manually:
-
-```typescript
-await db.registerIndex("tasks", "status", "string");
-await db.registerIndex("tasks", "priority", "number");
-
-// Unique index
-await db.registerIndex("users", "email", "string", true);
-
-// Composite unique constraint
-await db.registerUniqueConstraint("tasks", "unique_title_per_project", ["projectId", "title"]);
-
-// List and drop indexes
-const indexes = await db.listIndexes("tasks"); // or listIndexes() for all models
-await db.dropIndex("tasks", "status");
-
-// List and drop unique constraints
-const constraints = await db.listUniqueConstraints("tasks");
-await db.dropUniqueConstraint("tasks", "unique_title_per_project");
-
-// Sync indexes for all models passed in the models array at init
-await db.syncAllIndexes();
-```
-{{/lang}}
+{{ example: databases/db-record-indexes }}
 
 ## Permissions
 
@@ -1324,35 +1152,7 @@ On WS reconnect the local connection id rotates, so a frame for the writer's own
 
 ### Canonical Pattern: Load + Subscribe
 
-```typescript
-async function liveTickets(databaseId: string) {
-  // 1. Initial load — full current state.
-  const { data: tickets } = await client.databases.executeOperation(
-    databaseId,
-    "list-my-open-tickets",
-  );
-  const byId = new Map(tickets.map(t => [t.id, t]));
-  render(Array.from(byId.values()));
-
-  // 2. Subscribe for delta updates.
-  const unsub = client.databases.subscribe(databaseId, "my-open-tickets", {
-    onChange: (event) => {
-      for (const change of event.changes) {
-        if (change.op === "delete") {
-          byId.delete(change.id);
-        } else {
-          // save / patch / increment / addToSet / removeFromSet
-          byId.set(change.id, change.data);
-        }
-      }
-      render(Array.from(byId.values()));
-    },
-  });
-
-  // 3. Return teardown — call this on unmount.
-  return unsub;
-}
-```
+{{ example: databases/db-load-subscribe }}
 
 Make the initial-load operation's filter and the subscription's `filter` semantically equivalent. If they diverge, the UI will flicker (records the operation returned but the subscription never updates, or vice versa).
 
@@ -1398,18 +1198,9 @@ For driving subscriptions from a scheduled write (a cron-triggered workflow muta
 
 Databases are schemaless — the system tracks fields and inferred types as records are written.
 
-List the models (collections) in a database via the raw records endpoint `GET /app/<appId>/api/databases/<databaseId>/records/models` (returns `{ models: ["contacts", "orders", "products"] }`).
+List the models (collections) in a database via the raw records endpoint `GET /app/<appId>/api/databases/<databaseId>/records/models` (returns `{ models: ["contacts", "orders", "products"] }`):
 
-{{#lang ts}}
-```typescript
-const response = await fetch(
-  `${apiUrl}/app/${appId}/api/databases/${databaseId}/records/models`,
-  { headers: { Authorization: `Bearer ${token}` } }
-);
-const { models } = await response.json();
-// ["contacts", "orders", "products"]
-```
-{{/lang}}
+{{ example: databases/db-list-models }}
 
 Describe a model's observed fields:
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.ts.md
@@ -853,71 +853,76 @@ primitive databases cel-context get <database-id>
 
 Direct record operations require owner or manager permission. For most apps, use registered operations instead.
 
-Connect to a database to get a `DoDb` handle:
+`connect()` returns a `DoDb` handle. Save (upsert), patch (partial update), find a single record, delete, and count all run against it. A `save` is an upsert; pass `ifNotExists` for insert-only, `condition` for a conditional write, and `stringSets` to seed StringSet fields:
 
 ```typescript
-const db = client.databases.connect(databaseId);
-```
+  const db = client.databases.connect(databaseId);
 
-The handle supports string-based or model-class-based access:
+  // Save (upsert).
+  await db.save("tasks", { id: "task-1", title: "Ship v1" });
 
-```typescript
-// String-based
-await db.save("tasks", { id: "task-1", title: "Ship v1" });
+  // Insert only — fails if the record already exists.
+  await db.save("tasks", { id: "task-3", title: "Draft" }, { ifNotExists: true });
 
-// Model-class-based (with js-bao models)
-import { Task } from "./models";
-await db.save(Task, { id: "task-1", title: "Ship v1" });
-```
+  // Conditional write — only proceeds if the existing record matches.
+  await db.save("tasks", { id: "task-3", title: "Draft" }, { condition: { completed: false } });
 
-### Save (upsert)
+  // Seed StringSet fields on the write.
+  await db.save("tasks", { id: "task-4", title: "Tagged" }, { stringSets: { tags: ["featured", "sale"] } });
 
-```typescript
-await db.save("products", { id: "prod-1", name: "Widget", price: 9.99 });
+  // Patch (partial update) — only the provided fields change.
+  await db.patch("tasks", "task-1", { priority: 5 });
+  await db.patch("tasks", "task-1", { priority: 7 }, { condition: { completed: false } });
 
-// Insert only — fails if record exists
-await db.save("products", data, { ifNotExists: true });
+  // Find a single record by id (or null).
+  const task = await db.find("tasks", "task-1");
 
-// Conditional write
-await db.save("products", data, { condition: { status: "draft" } });
+  // Delete — true if a record existed.
+  const deleted = await db.delete("tasks", "task-2");
 
-// With StringSet fields
-await db.save("products", data, { stringSets: { tags: ["featured", "sale"] } });
-```
-
-### Patch (partial update)
-
-```typescript
-await db.patch("products", "prod-1", { price: 7.99 });
-
-// Conditional patch
-await db.patch("products", "prod-1", { price: 7.99 }, { condition: { status: "draft" } });
-```
-
-### Find
-
-```typescript
-const product = await db.find("products", "prod-1"); // or null
-```
-
-### Delete
-
-```typescript
-const deleted = await db.delete("products", "prod-1"); // true if existed
-```
-
-### Count
-
-```typescript
-const total = await db.count("products");
-const saleCount = await db.count("products", { onSale: true });
+  // Count, optionally filtered.
+  const total = await db.count("tasks");
+  const open = await db.count("tasks", { completed: false });
 ```
 
 ### Query
 
+The handle queries with the full filter operator grammar, sort + cursor pagination, projection, and related-data `include`:
+
 ```typescript
-const result = await db.query("tasks", filter, options);
-// result: { data: T[], hasMore: boolean, nextCursor?: string, prevCursor?: string }
+  // Filter operators: exact match, comparisons, set membership, text, $or/$and.
+  const result = await db.query("tasks", {
+    completed: false,
+    priority: { $gte: 5 },
+    category: { $in: ["work", "urgent"] },
+    title: { $startsWith: "Ship" },
+    tags: { $contains: "featured" },
+    $or: [{ category: "work" }, { priority: { $gte: 8 } }],
+  });
+
+  // Multiple fields on the same object are ANDed; use explicit $and to put
+  // two conditions on one field.
+  const priced = await db.query("tasks", {
+    $and: [{ priority: { $gte: 1 } }, { priority: { $lte: 5 } }],
+  });
+
+  // Sort, limit, and cursor pagination.
+  const page1 = await db.query("tasks", {}, { sort: { priority: -1 }, limit: 20 });
+  const page2 = page1.hasMore
+    ? await db.query("tasks", {}, {
+        sort: { priority: -1 },
+        limit: 20,
+        uniqueStartKey: page1.nextCursor,
+      })
+    : undefined;
+
+  // Projection — return only the named fields.
+  const titles = await db.query("tasks", {}, { projection: { title: 1, completed: 1 } });
+
+  // Include related records — they land under _related on each parent.
+  const withCategory = await db.query("tasks", {}, {
+    include: [{ model: "categories", type: "refersTo", sourceField: "category", as: "categoryInfo" }],
+  });
 ```
 
 ### Filter operators
@@ -945,114 +950,62 @@ const result = await db.query("tasks", filter, options);
 
 `$startsWith`, `$endsWith`, and `$containsText` are mutually exclusive on the same field — only one substring operator per field per query.
 
-Multiple filters on different fields are implicitly combined with AND:
+Multiple filters on different fields are implicitly combined with AND. Use an explicit `$and` only when you need two conditions on the *same* field (e.g. a range), and combine `$or` with other top-level fields freely.
 
-```typescript
-// These two are equivalent:
-{ status: "active", priority: { $gte: 5 } }
-{ $and: [{ status: "active" }, { priority: { $gte: 5 } }] }
-
-// Use explicit $and when you need multiple conditions on the same field:
-{ $and: [{ price: { $gte: 10 } }, { price: { $lte: 50 } }] }
-
-// Combine $or with other filters:
-{ category: "electronics", $or: [{ onSale: true }, { price: { $lt: 20 } }] }
-```
-
-### Sort, limit, pagination
-
-```typescript
-const page1 = await db.query("tasks", {}, {
-  sort: { createdAt: -1 },
-  limit: 20,
-});
-
-if (page1.hasMore) {
-  const page2 = await db.query("tasks", {}, {
-    sort: { createdAt: -1 },
-    limit: 20,
-    uniqueStartKey: page1.nextCursor,
-  });
-}
-```
-
-### Projection
-
-```typescript
-const result = await db.query("tasks", {}, {
-  projection: { title: 1, status: 1 },
-});
-```
-
-### Includes (related data)
-
-```typescript
-const result = await db.query("orders", {}, {
-  include: [{
-    model: "customers",
-    type: "refersTo",
-    sourceField: "customerId",
-    as: "customer",
-  }],
-});
-// result.data[0]._related.customer = { id, name, ... }
-```
-
-Include types: `refersTo` (FK to one record), `hasMany` (target FK to this record), `refersToMany` (StringSet to multiple records).
+Include types: `refersTo` (FK to one record), `hasMany` (target FK to this record), `refersToMany` (StringSet to multiple records). The loaded records land under `_related` on each parent (e.g. `result.data[0]._related.customer`).
 
 ## Atomic Operations
 
-### Increment
+Increment/decrement numeric fields (returns the post-increment values) and add/remove StringSet members atomically — no read-modify-write round trip:
 
 ```typescript
-const newValues = await db.increment("products", "prod-1", {
-  viewCount: 1,
-  stock: -1,
-});
-// { viewCount: 43, stock: 11 }
-```
+  // Increment/decrement numeric fields; returns the post-increment values.
+  const newValues = await db.increment("tasks", "task-1", {
+    priority: 1,
+    estimatedHours: -2,
+  });
 
-### StringSet add/remove
-
-```typescript
-await db.addToSet("products", "prod-1", { tags: ["featured"] });
-await db.removeFromSet("products", "prod-1", { tags: ["sale"] });
+  // Atomically add/remove StringSet members.
+  await db.addToSet("tasks", "task-1", { tags: ["featured"] });
+  await db.removeFromSet("tasks", "task-1", { tags: ["sale"] });
 ```
 
 ## Batch Writes (direct)
 
-`db.batch` executes multiple writes atomically at the storage layer. Returns one `BatchOperationResult` per input op (`{success, id, error?, values?}` — `values` for increment ops); a per-item failure does NOT throw, so check `.success` on each result.
+`db.batch` executes multiple writes atomically at the storage layer. It returns one `BatchOperationResult` per input op (`{success, id, error?, values?}` — `values` for increment ops); a per-item failure does NOT throw, so check `.success` on each result.
 
 ```typescript
-const results = await db.batch([
-  { op: "save",      modelName: "tasks", id: "t-1", data: { title: "A" } },
-  { op: "patch",     modelName: "tasks", id: "t-2", data: { done: true } },
-  { op: "delete",    modelName: "tasks", id: "t-3" },
-  { op: "increment", modelName: "tasks", id: "t-4", fields: { priority: 1 } },
-  { op: "addToSet",  modelName: "tasks", id: "t-5", stringSets: { tags: ["urgent"] } },
-]);
+  const results = await db.batch([
+    { op: "save", modelName: "tasks", id: "t-1", data: { title: "A" } },
+    { op: "patch", modelName: "tasks", id: "t-2", data: { completed: true } },
+    { op: "delete", modelName: "tasks", id: "t-3" },
+    { op: "increment", modelName: "tasks", id: "t-4", fields: { priority: 1 } },
+    { op: "addToSet", modelName: "tasks", id: "t-5", stringSets: { tags: ["urgent"] } },
+  ]);
 
-for (const r of results) {
-  if (!r.success) console.warn("op failed:", r.id, r.error);
-}
+  for (const r of results) {
+    if (!r.success) console.warn("op failed:", r.id, r.error);
+  }
 ```
 
 ### Aggregation (direct)
 
+Group by one or more fields and compute `count`/`sum`/`avg`/`min`/`max`, with an optional filter, sort, and limit:
+
 ```typescript
-const result = await db.aggregate("orders", {
-  groupBy: ["status"],
-  operations: [
-    { type: "count" },
-    { type: "sum", field: "total" },
-    { type: "avg", field: "total" },
-    { type: "min", field: "total" },
-    { type: "max", field: "total" },
-  ],
-  filter: { createdAt: { $gte: "2025-01-01" } },
-  sort: { field: "count", direction: -1 },
-  limit: 10,
-});
+  const result = await db.aggregate("tasks", {
+    groupBy: ["category"],
+    operations: [
+      { type: "count" },
+      { type: "sum", field: "estimatedHours" },
+      { type: "avg", field: "estimatedHours" },
+      { type: "min", field: "priority" },
+      { type: "max", field: "priority" },
+    ],
+    filter: { completed: false },
+    sort: { field: "count", direction: -1 },
+    limit: 10,
+  });
 ```
 
 ## Client-Side Models (Direct Record Access Only)
@@ -1130,35 +1083,26 @@ Database field types: `id` (primary key, use `auto_assign = true` for ULIDs), `s
 
 ### Indexes
 
-Add `indexed: true` to fields you filter or sort on. Sync indexes after connecting:
+Add an index to every field you filter or sort on; without one the engine scans all records of that model. Register them manually, declare composite unique constraints, list and drop them, or sync a model's declared index state at once:
 
 ```typescript
-const db = client.databases.connect(databaseId);
-await db.syncIndexes(Task);
-```
+  // Register indexes (additive — never drops).
+  await db.registerIndex("tasks", "category", "string");
+  await db.registerIndex("tasks", "priority", "number");
+  await db.registerIndex("appUsers", "email", "string", true); // unique
 
-Or register indexes manually:
+  // Composite unique constraint across multiple fields.
+  await db.registerUniqueConstraint("categories", "name_parentId", ["name", "parentId"]);
 
-```typescript
-await db.registerIndex("tasks", "status", "string");
-await db.registerIndex("tasks", "priority", "number");
+  // List and drop.
+  const indexes = await db.listIndexes("tasks");
+  await db.dropIndex("tasks", "category");
 
-// Unique index
-await db.registerIndex("users", "email", "string", true);
+  const constraints = await db.listUniqueConstraints("categories");
+  await db.dropUniqueConstraint("categories", "name_parentId");
 
-// Composite unique constraint
-await db.registerUniqueConstraint("tasks", "unique_title_per_project", ["projectId", "title"]);
-
-// List and drop indexes
-const indexes = await db.listIndexes("tasks"); // or listIndexes() for all models
-await db.dropIndex("tasks", "status");
-
-// List and drop unique constraints
-const constraints = await db.listUniqueConstraints("tasks");
-await db.dropUniqueConstraint("tasks", "unique_title_per_project");
-
-// Sync indexes for all models passed in the models array at init
-await db.syncAllIndexes();
+  // Sync every model passed in the models array at init.
+  await db.syncAllIndexes();
 ```
 
 ## Permissions
@@ -1451,25 +1395,20 @@ On WS reconnect the local connection id rotates, so a frame for the writer's own
 ### Canonical Pattern: Load + Subscribe
 
 ```typescript
-async function liveTickets(databaseId: string) {
   // 1. Initial load — full current state.
   const { data: tickets } = await client.databases.executeOperation(
     databaseId,
     "list-my-open-tickets",
   );
-  const byId = new Map(tickets.map(t => [t.id, t]));
+  const byId = new Map<string, unknown>(tickets.map((t: { id: string }) => [t.id, t]));
   render(Array.from(byId.values()));
 
   // 2. Subscribe for delta updates.
   const unsub = client.databases.subscribe(databaseId, "my-open-tickets", {
     onChange: (event) => {
       for (const change of event.changes) {
-        if (change.op === "delete") {
-          byId.delete(change.id);
-        } else {
-          // save / patch / increment / addToSet / removeFromSet
-          byId.set(change.id, change.data);
-        }
+        if (change.op === "delete") byId.delete(change.id);
+        else byId.set(change.id, change.data); // save / patch / increment / addToSet / removeFromSet
       }
       render(Array.from(byId.values()));
     },
@@ -1477,7 +1416,6 @@ async function liveTickets(databaseId: string) {
 
   // 3. Return teardown — call this on unmount.
   return unsub;
-}
 ```
 
 Make the initial-load operation's filter and the subscription's `filter` semantically equivalent. If they diverge, the UI will flicker (records the operation returned but the subscription never updates, or vice versa).
@@ -1523,15 +1461,14 @@ For driving subscriptions from a scheduled write (a cron-triggered workflow muta
 
 Databases are schemaless — the system tracks fields and inferred types as records are written.
 
-List the models (collections) in a database via the raw records endpoint `GET /app/<appId>/api/databases/<databaseId>/records/models` (returns `{ models: ["contacts", "orders", "products"] }`).
+List the models (collections) in a database via the raw records endpoint `GET /app/<appId>/api/databases/<databaseId>/records/models` (returns `{ models: ["contacts", "orders", "products"] }`):
 
 ```typescript
-const response = await fetch(
-  `${apiUrl}/app/${appId}/api/databases/${databaseId}/records/models`,
-  { headers: { Authorization: `Bearer ${token}` } }
-);
-const { models } = await response.json();
-// ["contacts", "orders", "products"]
+  const { models } = await client.makeRequest(
+    "GET",
+    `/databases/${databaseId}/records/models`,
+  );
+  // models: ["contacts", "orders", "products"]
 ```
 
 Describe a model's observed fields:

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATA_MODELING.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATA_MODELING.swift.md
@@ -153,6 +153,21 @@ filter = "record.assigneeId == user.userId && record.status == 'open'"
 select = ["id", "title", "priority", "updatedAt"]  # optional projection
 ```
 
+Subscribe from the client and pair it with an operation call for the initial state:
+
+```swift
+  let initial = try await client.databases.executeOperation(databaseId: dbId, name: "listMyTickets")
+  let unsub = try client.databases.subscribe(
+    databaseId: dbId,
+    subscriptionKey: "my-open-tickets",
+    options: DatabaseSubscribeOptions(onChange: { event in
+      if event.isOrigin { return } // this tab wrote it
+      applyChanges(event.changes)
+    })
+  )
+```
+
+Subscriptions deliver deltas only — always pair with an operation call for the initial state, and use semantically equivalent filters. See the Databases guide for the full frame shape (`originConnectionId`, `originUserId`, `isOrigin`, `isOriginUser`, `changeType`).
 
 ## Worked architectures
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATA_MODELING.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATA_MODELING.template.md
@@ -116,21 +116,11 @@ filter = "record.assigneeId == user.userId && record.status == 'open'"
 select = ["id", "title", "priority", "updatedAt"]  # optional projection
 ```
 
-{{#lang ts}}
 Subscribe from the client and pair it with an operation call for the initial state:
 
-```typescript
-const initial = await client.databases.executeOperation(dbId, "listMyTickets", {});
-const unsub = client.databases.subscribe(dbId, "my-open-tickets", {
-  onChange: (event) => {
-    if (event.isOrigin) return;        // this tab wrote it
-    applyChanges(event.changes);
-  },
-});
-```
+{{ example: data-modeling/subscription-with-initial-load }}
 
 Subscriptions deliver deltas only — always pair with an operation call for the initial state, and use semantically equivalent filters. See the Databases guide for the full frame shape (`originConnectionId`, `originUserId`, `isOrigin`, `isOriginUser`, `changeType`).
-{{/lang}}
 
 ## Worked architectures
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATA_MODELING.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATA_MODELING.ts.md
@@ -152,13 +152,13 @@ select = ["id", "title", "priority", "updatedAt"]  # optional projection
 Subscribe from the client and pair it with an operation call for the initial state:
 
 ```typescript
-const initial = await client.databases.executeOperation(dbId, "listMyTickets", {});
-const unsub = client.databases.subscribe(dbId, "my-open-tickets", {
-  onChange: (event) => {
-    if (event.isOrigin) return;        // this tab wrote it
-    applyChanges(event.changes);
-  },
-});
+  const initial = await client.databases.executeOperation(dbId, "listMyTickets", {});
+  const unsub = client.databases.subscribe(dbId, "my-open-tickets", {
+    onChange: (event) => {
+      if (event.isOrigin) return; // this tab wrote it
+      applyChanges(event.changes);
+    },
+  });
 ```
 
 Subscriptions deliver deltas only — always pair with an operation call for the initial state, and use semantically equivalent filters. See the Databases guide for the full frame shape (`originConnectionId`, `originUserId`, `isOrigin`, `isOriginUser`, `changeType`).

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.swift.md
@@ -343,6 +343,17 @@ List with `me.ownedDocuments()` and `open()` the selected document; create a new
 
 All documents that need live updates or cross-document queries must be open. Tag documents so you can fetch a set with `me.ownedDocuments({ tag })` (and `me.sharedDocuments({ tag })` if the user can also be a non-owner), open each, and track per-document readiness yourself. For collective sharing of multiple documents as a unit, prefer the server-side Collections API (`client.collections.*` — see [Collections](#collections) below) over local tracking.
 
+```swift
+  // Open every document with a given tag
+  let channels = try await client.me.ownedDocuments(tag: "channel")
+  for channel in channels {
+    _ = try await client.documents.open(channel.documentId)
+  }
+
+  // Query runs across all open documents by default
+  let messages = Message.query([:])
+```
+
 
 The most common multi-doc shape is one ambient library/index document plus N per-item documents (each shareable independently); see [Index doc + per-item docs](#index-doc--per-item-docs-keying-tombstones-reconcile) below for keying, tombstones, and the reconcile pass. Open auxiliary docs with `appState.openAuxiliaryDoc(_:)` and close them with `appState.closeAuxiliaryDoc(_:)`.
 
@@ -910,13 +921,13 @@ Repeated email-based calls are idempotent: a second `updatePermissions(documentI
 **There is no `permission: null` to remove.** Removal is a separate call (`removePermission` by userId or by email; `transferOwnership` to hand a document to a new owner):
 
 ```swift
-// Remove a current member by userId (a bare string literal also works):
-try await client.documents.removePermission(documentId: documentId, .userId("user-abc"))
+  // Remove a current member by userId (a bare string literal also works):
+  try await client.documents.removePermission(documentId: documentId, .userId("user-abc"))
 
-// Cancel a pending email-based invite, OR remove a current member matched by email:
-try await client.documents.removePermission(documentId: documentId, .email("alice@example.com"))
+  // Cancel a pending email-based invite, OR remove a current member matched by email:
+  try await client.documents.removePermission(documentId: documentId, .email("alice@example.com"))
 
-try await client.documents.transferOwnership(documentId: documentId, newOwnerId: newOwnerId)
+  try await client.documents.transferOwnership(documentId: documentId, newOwnerId: newOwnerId)
 ```
 
 There is no `setPermissions`, and `updatePermissions` with a lower permission does **not** lower a higher group-derived permission — the user keeps access via the group.
@@ -932,6 +943,16 @@ Lowering a user's direct permission while they still have a higher one via a gro
 
 The method is **`grantGroupPermission`** (no `setGroupPermission`). Member changes inside the group propagate automatically — no per-membership permission calls.
 
+```swift
+  _ = try await client.documents.grantGroupPermission(
+    documentId: documentId,
+    params: GrantGroupPermissionParams(groupType: "team", groupId: "engineering", permission: "read-write")
+  )
+
+  // Listing / revoking
+  _ = try await client.documents.listGroupPermissions(documentId: documentId)
+  _ = try await client.documents.revokeGroupPermission(documentId: documentId, groupType: "team", groupId: "engineering")
+```
 
 #### Looking up users
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.template.md
@@ -236,18 +236,9 @@ List with `me.ownedDocuments()` and `open()` the selected document; create a new
 
 All documents that need live updates or cross-document queries must be open. Tag documents so you can fetch a set with `me.ownedDocuments({ tag })` (and `me.sharedDocuments({ tag })` if the user can also be a non-owner), open each, and track per-document readiness yourself. For collective sharing of multiple documents as a unit, prefer the server-side Collections API (`client.collections.*` — see [Collections](#collections) below) over local tracking.
 
+{{ example: documents/open-tagged-docs }}
+
 {{#lang ts}}
-```typescript
-// Open every document with a given tag
-const channels = await jsBaoClient.me.ownedDocuments({ tag: "channel" });
-await Promise.all(
-  channels.map((ch) => jsBaoClient.documents.open(ch.documentId))
-);
-
-// Query runs across all open documents by default
-const messages = await Message.query({});
-```
-
 The template does not ship a built-in "multi-document" Pinia store. A minimal store for "all documents tagged `channel`":
 
 ```typescript
@@ -1425,18 +1416,9 @@ Repeated email-based calls are idempotent: a second `updatePermissions(documentI
 
 **There is no `permission: null` to remove.** Removal is a separate call (`removePermission` by userId or by email; `transferOwnership` to hand a document to a new owner):
 
+{{ example: documents/manage-permissions }}
+
 {{#lang ts}}
-```typescript
-// Remove a current member by userId:
-await client.documents.removePermission(documentId, "user-abc");
-await client.documents.removePermission(documentId, { userId: "user-abc" });
-
-// Cancel a pending email-based invite, OR remove a current member matched by email:
-await client.documents.removePermission(documentId, { email: "alice@example.com" });
-
-await client.documents.transferOwnership(documentId, newOwnerId);
-```
-
 **Don't do this** (silent no-op for someone with a higher group permission, and there is no `null` form):
 
 ```typescript
@@ -1454,16 +1436,6 @@ await client.documents.updatePermissions(documentId, {
 ```
 {{/lang}}
 {{#lang swift}}
-```swift
-// Remove a current member by userId (a bare string literal also works):
-try await client.documents.removePermission(documentId: documentId, .userId("user-abc"))
-
-// Cancel a pending email-based invite, OR remove a current member matched by email:
-try await client.documents.removePermission(documentId: documentId, .email("alice@example.com"))
-
-try await client.documents.transferOwnership(documentId: documentId, newOwnerId: newOwnerId)
-```
-
 There is no `setPermissions`, and `updatePermissions` with a lower permission does **not** lower a higher group-derived permission — the user keeps access via the group.
 {{/lang}}
 
@@ -1498,19 +1470,7 @@ Lowering a user's direct permission while they still have a higher one via a gro
 
 The method is **`grantGroupPermission`** (no `setGroupPermission`). Member changes inside the group propagate automatically — no per-membership permission calls.
 
-{{#lang ts}}
-```typescript
-await client.documents.grantGroupPermission(documentId, {
-  groupType: "team",
-  groupId: "engineering",
-  permission: "read-write",       // owner | read-write | reader
-});
-
-// Listing / revoking
-await client.documents.listGroupPermissions(documentId);
-await client.documents.revokeGroupPermission(documentId, "team", "engineering");
-```
-{{/lang}}
+{{ example: documents/group-permission }}
 
 #### Looking up users
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.ts.md
@@ -376,14 +376,14 @@ List with `me.ownedDocuments()` and `open()` the selected document; create a new
 All documents that need live updates or cross-document queries must be open. Tag documents so you can fetch a set with `me.ownedDocuments({ tag })` (and `me.sharedDocuments({ tag })` if the user can also be a non-owner), open each, and track per-document readiness yourself. For collective sharing of multiple documents as a unit, prefer the server-side Collections API (`client.collections.*` — see [Collections](#collections) below) over local tracking.
 
 ```typescript
-// Open every document with a given tag
-const channels = await jsBaoClient.me.ownedDocuments({ tag: "channel" });
-await Promise.all(
-  channels.map((ch) => jsBaoClient.documents.open(ch.documentId))
-);
+  // Open every document with a given tag
+  const channels = await client.me.ownedDocuments({ tag: "channel" });
+  await Promise.all(
+    channels.map((ch) => client.documents.open(ch.documentId))
+  );
 
-// Query runs across all open documents by default
-const messages = await Message.query({});
+  // Query runs across all open documents by default
+  const messages = await Message.query({});
 ```
 
 The template does not ship a built-in "multi-document" Pinia store. A minimal store for "all documents tagged `channel`":
@@ -1374,14 +1374,14 @@ Repeated email-based calls are idempotent: a second `updatePermissions(documentI
 **There is no `permission: null` to remove.** Removal is a separate call (`removePermission` by userId or by email; `transferOwnership` to hand a document to a new owner):
 
 ```typescript
-// Remove a current member by userId:
-await client.documents.removePermission(documentId, "user-abc");
-await client.documents.removePermission(documentId, { userId: "user-abc" });
+  // Remove a current member by userId:
+  await client.documents.removePermission(documentId, "user-abc");
+  await client.documents.removePermission(documentId, { userId: "user-abc" });
 
-// Cancel a pending email-based invite, OR remove a current member matched by email:
-await client.documents.removePermission(documentId, { email: "alice@example.com" });
+  // Cancel a pending email-based invite, OR remove a current member matched by email:
+  await client.documents.removePermission(documentId, { email: "alice@example.com" });
 
-await client.documents.transferOwnership(documentId, newOwnerId);
+  await client.documents.transferOwnership(documentId, newOwnerId);
 ```
 
 **Don't do this** (silent no-op for someone with a higher group permission, and there is no `null` form):
@@ -1430,15 +1430,15 @@ Lowering a user's direct permission while they still have a higher one via a gro
 The method is **`grantGroupPermission`** (no `setGroupPermission`). Member changes inside the group propagate automatically — no per-membership permission calls.
 
 ```typescript
-await client.documents.grantGroupPermission(documentId, {
-  groupType: "team",
-  groupId: "engineering",
-  permission: "read-write",       // owner | read-write | reader
-});
+  await client.documents.grantGroupPermission(documentId, {
+    groupType: "team",
+    groupId: "engineering",
+    permission: "read-write", // owner | read-write | reader
+  });
 
-// Listing / revoking
-await client.documents.listGroupPermissions(documentId);
-await client.documents.revokeGroupPermission(documentId, "team", "engineering");
+  // Listing / revoking
+  await client.documents.listGroupPermissions(documentId);
+  await client.documents.revokeGroupPermission(documentId, "team", "engineering");
 ```
 
 #### Looking up users

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_INVITATIONS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_INVITATIONS.swift.md
@@ -125,30 +125,35 @@ The cascading delete is `client.invitations.delete(id)` — there is **no `clien
 Admins/owners can invite at any role; members can invite only at `role: "member"` and only when `memberInvitationsEnabled` is true (check `quota()` first). `sendEmail` defaults to `false` — when `true` the server delivers a default invitation email, otherwise you deliver the `inviteToken` yourself. `source` (≤64 chars) and `note` are optional audit/admin-UI metadata; `expiresAt` overrides the default expiry.
 
 ```swift
-// Admins/owners: any role
-_ = try await client.invitations.create(params: [
-  "email": "alice@example.com",
-  "role": "member",  // or "admin" / "owner" (admin/owner only)
-])
+  // Admins/owners: any role
+  _ = try await client.invitations.create(
+    params: CreateInvitationParams(
+      email: "alice@example.com",
+      role: "member" // or "admin" / "owner" (admin/owner only)
+    )
+  )
 
-// Full options
-_ = try await client.invitations.create(params: [
-  "email": "alice@example.com",
-  "role": "member",
-  "expiresAt": ISO8601DateFormatter().string(from: Date().addingTimeInterval(7 * 86400)),
-  "source": "team-onboarding-flow",
-  "note": "Backend hire — Q2 cohort",
-  "sendEmail": true,
-])
+  // Full options
+  let expiresAt = ISO8601DateFormatter().string(from: Date().addingTimeInterval(7 * 86400))
+  _ = try await client.invitations.create(
+    params: CreateInvitationParams(
+      email: "alice@example.com",
+      role: "member",
+      expiresAt: expiresAt, // optional override
+      source: "team-onboarding-flow",
+      note: "Backend hire — Q2 cohort",
+      sendEmail: true
+    )
+  )
 
-// Members: gate on quota first
-let quota = try await client.invitations.quota()
-let unlimited = quota["unlimited"] as? Bool ?? false
-let remaining = quota["remaining"] as? Int ?? 0
-if !unlimited && remaining <= 0 {
-  return showQuotaExhausted()
-}
-_ = try await client.invitations.create(params: ["email": email, "role": "member"])
+  // Members: gate on quota first
+  let quota = try await client.invitations.quota()
+  if !quota.unlimited && quota.remaining <= 0 {
+    return // quota exhausted — hide the invite UI
+  }
+  _ = try await client.invitations.create(
+    params: CreateInvitationParams(email: email, role: "member")
+  )
 ```
 
 ### Member invitations + quotas
@@ -196,11 +201,10 @@ Capture the `inviteToken` from the mint response if you need to build accept URL
 For resend / lookup after the initial response is gone, fetch the invitation by id and rebuild the accept URL from its `inviteToken`. The returned record carries `invitationId`, `email`, `role`, `invitedBy`, `invitedAt`, `expiresAt`, `accepted`, `acceptedAt`, `source`, `note`, `inviteToken`, and a computed `status` (`"pending" | "expired" | "accepted"`).
 
 ```swift
-let inv = try await client.invitations.get(invitationId: invitationId)
-let inviteToken = inv["inviteToken"] as? String ?? ""
-let email = inv["email"] as? String ?? ""
-let acceptUrl = "\(myApp.baseURL)/invite/accept?inviteToken=\(inviteToken)"
-try await myEmailService.send(to: email, link: acceptUrl)
+  let inv = try await client.invitations.get(invitationId: invitationId)
+  let inviteToken = inv.inviteToken ?? ""
+  let acceptUrl = "\(baseURL)/invite/accept?inviteToken=\(inviteToken)"
+  // Send `acceptUrl` to `inv.email` from your own email provider.
 ```
 
 Permissions for `invitations.get`: app admin/owner, OR the invitation's original inviter. Members who did not create the invitation receive 403 — `inviteToken` is a bearer credential, so read access is intentionally narrow.
@@ -250,9 +254,11 @@ Deferred grants are re-validated at resolution time. In a `domain`-restricted ap
 ### Inspecting pending state (debug only)
 
 ```swift
-let (grants, nextCursor) = try await client.invitations.listDeferredGrants(
-  email: "alice@example.com"
-)
+  let result = try await client.invitations.listDeferredGrants(
+    email: "alice@example.com"
+  )
+  let grants = result.grants
+  let nextCursor = result.nextCursor
 ```
 
 Reserve this for admin/debug UIs. For end-user "people with access + pending invitations" UI, use the per-resource `listPendingInvitations` endpoints on documents/groups/collections (see the [Documents guide](AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.md#building-a-members--pending-ui)).
@@ -266,25 +272,26 @@ Reserve this for admin/debug UIs. For end-user "people with access + pending inv
 Check quota, mint the app invitation, share the project document by email, and add the email to the team group. After signup all three resolve in one server-side transaction.
 
 ```swift
-func onboardTeammate(email: String, projectDocId: String) async throws {
-  let quota = try await client.invitations.quota()
-  let unlimited = quota["unlimited"] as? Bool ?? false
-  let remaining = quota["remaining"] as? Int ?? 0
-  if !unlimited && remaining <= 0 {
-    throw OnboardingError.quotaExhausted
-  }
+  // 1. Invite a teammate
+  _ = try await client.invitations.create(
+    params: CreateInvitationParams(email: "newhire@example.com", role: "member")
+  )
 
-  _ = try await client.invitations.create(params: ["email": email, "role": "member"])
-
+  // 2. Share a project document with them (pending until signup)
   _ = try await client.documents.updatePermissions(
     documentId: projectDocId,
-    params: ["permissions": [["email": email, "permission": "read-write"]]]
+    params: .email("newhire@example.com", permission: "read-write")
   )
 
+  // 3. Add them to the engineering group (pending until signup)
   _ = try await client.groups.addMember(
-    groupType: "team", groupId: "engineering", params: ["email": email]
+    groupType: "team",
+    groupId: "engineering",
+    params: .email("newhire@example.com")
   )
-}
+
+  // When they sign up, all three apply in one transaction. They land in the
+  // app with team-group access and the project already shared with them.
 ```
 
 ---
@@ -294,16 +301,16 @@ func onboardTeammate(email: String, projectDocId: String) async throws {
 The `invitation` event is the only typed app-membership event. The lifecycle action is on `event.action` (not `event.type`, which is always `"invitation"`). Branch on `action`: `created`/`updated`/`cancelled` go to the invitee only; `declined` to both; `accepted` to the inviter only (with `event.acceptedBy` carrying the userId). Treat unknown actions as a no-op.
 
 ```swift
-client.events.on(.invitation) { event in
-  switch event.action {
-  case "created":   break  // invitee only
-  case "updated":   break  // invitee only
-  case "cancelled": break  // invitee only
-  case "declined":  break  // both invitee and inviter
-  case "accepted":  break  // inviter only — event.acceptedBy carries the userId
-  default:          break  // future-proof: no-op, don't throw
+  let sub = client.events.on(.invitation) { (event: [String: Any]) in
+    switch event["action"] as? String {
+    case "created":   break  // invitee only
+    case "updated":   break  // invitee only
+    case "cancelled": break  // invitee only
+    case "declined":  break  // both invitee and inviter
+    case "accepted":  break  // inviter only — event["acceptedBy"] carries the userId
+    default:          break  // future-proof: no-op, don't throw
+    }
   }
-}
 ```
 
 **Targeting is asymmetric** — most actions go to one side only. `accepted` goes to the *inviter*; `created` goes to the *invitee*. Don't expect both sides to see the same events. Polling `invitations.list()` for acceptance is an anti-pattern — subscribe and switch on the `accepted` action instead.

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_INVITATIONS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_INVITATIONS.template.md
@@ -124,60 +124,7 @@ The cascading delete is `client.invitations.delete(id)` — there is **no `clien
 
 Admins/owners can invite at any role; members can invite only at `role: "member"` and only when `memberInvitationsEnabled` is true (check `quota()` first). `sendEmail` defaults to `false` — when `true` the server delivers a default invitation email, otherwise you deliver the `inviteToken` yourself. `source` (≤64 chars) and `note` are optional audit/admin-UI metadata; `expiresAt` overrides the default expiry.
 
-{{#lang ts}}
-```typescript
-// Admins/owners: any role
-await client.invitations.create({
-  email: "alice@example.com",
-  role: "member", // or "admin" / "owner" (admin/owner only)
-});
-
-// Full options
-await client.invitations.create({
-  email: "alice@example.com",
-  role: "member",
-  expiresAt: new Date(Date.now() + 7 * 86400_000).toISOString(), // optional override
-  source: "team-onboarding-flow",
-  note: "Backend hire — Q2 cohort",
-  sendEmail: true,
-});
-
-// Members: gate on quota first
-const quota = await client.invitations.quota();
-if (!quota.unlimited && quota.remaining <= 0) {
-  return showQuotaExhausted();
-}
-await client.invitations.create({ email, role: "member" });
-```
-{{/lang}}
-{{#lang swift}}
-```swift
-// Admins/owners: any role
-_ = try await client.invitations.create(params: [
-  "email": "alice@example.com",
-  "role": "member",  // or "admin" / "owner" (admin/owner only)
-])
-
-// Full options
-_ = try await client.invitations.create(params: [
-  "email": "alice@example.com",
-  "role": "member",
-  "expiresAt": ISO8601DateFormatter().string(from: Date().addingTimeInterval(7 * 86400)),
-  "source": "team-onboarding-flow",
-  "note": "Backend hire — Q2 cohort",
-  "sendEmail": true,
-])
-
-// Members: gate on quota first
-let quota = try await client.invitations.quota()
-let unlimited = quota["unlimited"] as? Bool ?? false
-let remaining = quota["remaining"] as? Int ?? 0
-if !unlimited && remaining <= 0 {
-  return showQuotaExhausted()
-}
-_ = try await client.invitations.create(params: ["email": email, "role": "member"])
-```
-{{/lang}}
+{{ example: sharing/invitation-create-options }}
 
 ### Member invitations + quotas
 
@@ -230,22 +177,7 @@ Capture the `inviteToken` from the mint response if you need to build accept URL
 
 For resend / lookup after the initial response is gone, fetch the invitation by id and rebuild the accept URL from its `inviteToken`. The returned record carries `invitationId`, `email`, `role`, `invitedBy`, `invitedAt`, `expiresAt`, `accepted`, `acceptedAt`, `source`, `note`, `inviteToken`, and a computed `status` (`"pending" | "expired" | "accepted"`).
 
-{{#lang ts}}
-```typescript
-const inv = await client.invitations.get(invitationId);
-const acceptUrl = `${myApp.baseUrl}/invite/accept?inviteToken=${inv.inviteToken}`;
-await myEmailService.send({ to: inv.email, link: acceptUrl });
-```
-{{/lang}}
-{{#lang swift}}
-```swift
-let inv = try await client.invitations.get(invitationId: invitationId)
-let inviteToken = inv["inviteToken"] as? String ?? ""
-let email = inv["email"] as? String ?? ""
-let acceptUrl = "\(myApp.baseURL)/invite/accept?inviteToken=\(inviteToken)"
-try await myEmailService.send(to: email, link: acceptUrl)
-```
-{{/lang}}
+{{ example: sharing/invitation-get-token }}
 
 Permissions for `invitations.get`: app admin/owner, OR the invitation's original inviter. Members who did not create the invitation receive 403 — `inviteToken` is a bearer credential, so read access is intentionally narrow.
 
@@ -298,20 +230,7 @@ Deferred grants are re-validated at resolution time. In a `domain`-restricted ap
 
 ### Inspecting pending state (debug only)
 
-{{#lang ts}}
-```typescript
-const { grants, nextCursor } = await client.invitations.listDeferredGrants({
-  email: "alice@example.com",
-});
-```
-{{/lang}}
-{{#lang swift}}
-```swift
-let (grants, nextCursor) = try await client.invitations.listDeferredGrants(
-  email: "alice@example.com"
-)
-```
-{{/lang}}
+{{ example: sharing/list-deferred-grants }}
 
 Reserve this for admin/debug UIs. For end-user "people with access + pending invitations" UI, use the per-resource `listPendingInvitations` endpoints on documents/groups/collections (see the [Documents guide](AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.md#building-a-members--pending-ui)).
 
@@ -323,47 +242,7 @@ Reserve this for admin/debug UIs. For end-user "people with access + pending inv
 
 Check quota, mint the app invitation, share the project document by email, and add the email to the team group. After signup all three resolve in one server-side transaction.
 
-{{#lang ts}}
-```typescript
-async function onboardTeammate(email: string, projectDocId: string) {
-  const quota = await client.invitations.quota();
-  if (!quota.unlimited && quota.remaining <= 0) {
-    throw new Error("Invitation quota exhausted");
-  }
-
-  await client.invitations.create({ email, role: "member" });
-
-  await client.documents.updatePermissions(projectDocId, {
-    permissions: [{ email, permission: "read-write" }],
-  });
-
-  await client.groups.addMember("team", "engineering", { email });
-}
-```
-{{/lang}}
-{{#lang swift}}
-```swift
-func onboardTeammate(email: String, projectDocId: String) async throws {
-  let quota = try await client.invitations.quota()
-  let unlimited = quota["unlimited"] as? Bool ?? false
-  let remaining = quota["remaining"] as? Int ?? 0
-  if !unlimited && remaining <= 0 {
-    throw OnboardingError.quotaExhausted
-  }
-
-  _ = try await client.invitations.create(params: ["email": email, "role": "member"])
-
-  _ = try await client.documents.updatePermissions(
-    documentId: projectDocId,
-    params: ["permissions": [["email": email, "permission": "read-write"]]]
-  )
-
-  _ = try await client.groups.addMember(
-    groupType: "team", groupId: "engineering", params: ["email": email]
-  )
-}
-```
-{{/lang}}
+{{ example: sharing/invite-onboarding }}
 
 ---
 
@@ -371,34 +250,7 @@ func onboardTeammate(email: String, projectDocId: String) async throws {
 
 The `invitation` event is the only typed app-membership event. The lifecycle action is on `event.action` (not `event.type`, which is always `"invitation"`). Branch on `action`: `created`/`updated`/`cancelled` go to the invitee only; `declined` to both; `accepted` to the inviter only (with `event.acceptedBy` carrying the userId). Treat unknown actions as a no-op.
 
-{{#lang ts}}
-```typescript
-client.on("invitation", (event) => {
-  switch (event.action) {
-    case "created":   /* invitee only */ break;
-    case "updated":   /* invitee only */ break;
-    case "cancelled": /* invitee only */ break;
-    case "declined":  /* both invitee and inviter */ break;
-    case "accepted":  /* inviter only — event.acceptedBy carries the userId */ break;
-    default: /* future-proof: no-op, don't throw */ break;
-  }
-});
-```
-{{/lang}}
-{{#lang swift}}
-```swift
-client.events.on(.invitation) { event in
-  switch event.action {
-  case "created":   break  // invitee only
-  case "updated":   break  // invitee only
-  case "cancelled": break  // invitee only
-  case "declined":  break  // both invitee and inviter
-  case "accepted":  break  // inviter only — event.acceptedBy carries the userId
-  default:          break  // future-proof: no-op, don't throw
-  }
-}
-```
-{{/lang}}
+{{ example: sharing/invitation-events }}
 
 **Targeting is asymmetric** — most actions go to one side only. `accepted` goes to the *inviter*; `created` goes to the *invitee*. Don't expect both sides to see the same events. Polling `invitations.list()` for acceptance is an anti-pattern — subscribe and switch on the `accepted` action instead.
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_INVITATIONS.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_INVITATIONS.ts.md
@@ -126,28 +126,28 @@ The cascading delete is `client.invitations.delete(id)` — there is **no `clien
 Admins/owners can invite at any role; members can invite only at `role: "member"` and only when `memberInvitationsEnabled` is true (check `quota()` first). `sendEmail` defaults to `false` — when `true` the server delivers a default invitation email, otherwise you deliver the `inviteToken` yourself. `source` (≤64 chars) and `note` are optional audit/admin-UI metadata; `expiresAt` overrides the default expiry.
 
 ```typescript
-// Admins/owners: any role
-await client.invitations.create({
-  email: "alice@example.com",
-  role: "member", // or "admin" / "owner" (admin/owner only)
-});
+  // Admins/owners: any role
+  await client.invitations.create({
+    email: "alice@example.com",
+    role: "member", // or "admin" / "owner" (admin/owner only)
+  });
 
-// Full options
-await client.invitations.create({
-  email: "alice@example.com",
-  role: "member",
-  expiresAt: new Date(Date.now() + 7 * 86400_000).toISOString(), // optional override
-  source: "team-onboarding-flow",
-  note: "Backend hire — Q2 cohort",
-  sendEmail: true,
-});
+  // Full options
+  await client.invitations.create({
+    email: "alice@example.com",
+    role: "member",
+    expiresAt: new Date(Date.now() + 7 * 86400_000).toISOString(), // optional override
+    source: "team-onboarding-flow",
+    note: "Backend hire — Q2 cohort",
+    sendEmail: true,
+  });
 
-// Members: gate on quota first
-const quota = await client.invitations.quota();
-if (!quota.unlimited && quota.remaining <= 0) {
-  return showQuotaExhausted();
-}
-await client.invitations.create({ email, role: "member" });
+  // Members: gate on quota first
+  const quota = await client.invitations.quota();
+  if (!quota.unlimited && quota.remaining <= 0) {
+    return; // quota exhausted — hide the invite UI
+  }
+  await client.invitations.create({ email, role: "member" });
 ```
 
 ### Member invitations + quotas
@@ -197,9 +197,9 @@ Capture the `inviteToken` from the mint response if you need to build accept URL
 For resend / lookup after the initial response is gone, fetch the invitation by id and rebuild the accept URL from its `inviteToken`. The returned record carries `invitationId`, `email`, `role`, `invitedBy`, `invitedAt`, `expiresAt`, `accepted`, `acceptedAt`, `source`, `note`, `inviteToken`, and a computed `status` (`"pending" | "expired" | "accepted"`).
 
 ```typescript
-const inv = await client.invitations.get(invitationId);
-const acceptUrl = `${myApp.baseUrl}/invite/accept?inviteToken=${inv.inviteToken}`;
-await myEmailService.send({ to: inv.email, link: acceptUrl });
+  const inv = await client.invitations.get(invitationId);
+  const acceptUrl = `${baseUrl}/invite/accept?inviteToken=${inv.inviteToken}`;
+  // Send `acceptUrl` to `inv.email` from your own email provider.
 ```
 
 Permissions for `invitations.get`: app admin/owner, OR the invitation's original inviter. Members who did not create the invitation receive 403 — `inviteToken` is a bearer credential, so read access is intentionally narrow.
@@ -249,9 +249,9 @@ Deferred grants are re-validated at resolution time. In a `domain`-restricted ap
 ### Inspecting pending state (debug only)
 
 ```typescript
-const { grants, nextCursor } = await client.invitations.listDeferredGrants({
-  email: "alice@example.com",
-});
+  const { grants, nextCursor } = await client.invitations.listDeferredGrants({
+    email: "alice@example.com",
+  });
 ```
 
 Reserve this for admin/debug UIs. For end-user "people with access + pending invitations" UI, use the per-resource `listPendingInvitations` endpoints on documents/groups/collections (see the [Documents guide](AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.md#building-a-members--pending-ui)).
@@ -265,20 +265,20 @@ Reserve this for admin/debug UIs. For end-user "people with access + pending inv
 Check quota, mint the app invitation, share the project document by email, and add the email to the team group. After signup all three resolve in one server-side transaction.
 
 ```typescript
-async function onboardTeammate(email: string, projectDocId: string) {
-  const quota = await client.invitations.quota();
-  if (!quota.unlimited && quota.remaining <= 0) {
-    throw new Error("Invitation quota exhausted");
-  }
+  // 1. Invite a teammate
+  await client.invitations.create({ email: "newhire@example.com", role: "member" });
 
-  await client.invitations.create({ email, role: "member" });
-
+  // 2. Share a project document with them (pending until signup)
   await client.documents.updatePermissions(projectDocId, {
-    permissions: [{ email, permission: "read-write" }],
+    email: "newhire@example.com",
+    permission: "read-write",
   });
 
-  await client.groups.addMember("team", "engineering", { email });
-}
+  // 3. Add them to the engineering group (pending until signup)
+  await client.groups.addMember("team", "engineering", { email: "newhire@example.com" });
+
+  // When they sign up, all three apply in one transaction. They land in the
+  // app with team-group access and the project already shared with them.
 ```
 
 ---
@@ -288,16 +288,16 @@ async function onboardTeammate(email: string, projectDocId: string) {
 The `invitation` event is the only typed app-membership event. The lifecycle action is on `event.action` (not `event.type`, which is always `"invitation"`). Branch on `action`: `created`/`updated`/`cancelled` go to the invitee only; `declined` to both; `accepted` to the inviter only (with `event.acceptedBy` carrying the userId). Treat unknown actions as a no-op.
 
 ```typescript
-client.on("invitation", (event) => {
-  switch (event.action) {
-    case "created":   /* invitee only */ break;
-    case "updated":   /* invitee only */ break;
-    case "cancelled": /* invitee only */ break;
-    case "declined":  /* both invitee and inviter */ break;
-    case "accepted":  /* inviter only — event.acceptedBy carries the userId */ break;
-    default: /* future-proof: no-op, don't throw */ break;
-  }
-});
+  client.on("invitation", (event) => {
+    switch (event.action) {
+      case "created":   /* invitee only */ break;
+      case "updated":   /* invitee only */ break;
+      case "cancelled": /* invitee only */ break;
+      case "declined":  /* both invitee and inviter */ break;
+      case "accepted":  /* inviter only — event.acceptedBy carries the userId */ break;
+      default: /* future-proof: no-op, don't throw */ break;
+    }
+  });
 ```
 
 **Targeting is asymmetric** — most actions go to one side only. `accepted` goes to the *inviter*; `created` goes to the *invitee*. Don't expect both sides to see the same events. Polling `invitations.list()` for acceptance is an anti-pattern — subscribe and switch on the `accepted` action instead.

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_PERFORMANCE.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_PERFORMANCE.swift.md
@@ -129,15 +129,12 @@ definition = '{"filter":{},"sort":{"groupId":1},"limit":1000}'
 Call it once, then group client-side:
 
 ```swift
-let all = try await db.executeOperation(name: "listAllTargets")
-var byGroup: [String: [Target]] = [:]
-for t in all.data {
-  byGroup[t.groupId, default: []].append(t)
-}
-for group in groups {
-  let targets = byGroup[group.id] ?? []
-  // ...
-}
+  let all = try await client.databases.executeOperation(databaseId: databaseId, name: "listAllTasks")
+  var byCategory: [String: [JSONValue]] = [:]
+  for task in all["data"]?.arrayValue ?? [] {
+    let key = task["category"]?.stringValue ?? "uncategorized"
+    byCategory[key, default: []].append(task)
+  }
 ```
 
 If you can fold the bulk op into a pipeline (Pattern 1), do that instead — same round-trip count, fewer named ops to maintain.
@@ -238,7 +235,7 @@ An init routine that eagerly awaits everything before signalling the app is read
 ```swift
 func initialize() async throws {
   // Always loaded, even on screens that never consult it
-  authConfig = try await client.getAuthConfig()
+  authConfig = try await client.auth.getAuthConfig()
   // Always loaded, even though only some screens care about memberships
   memberships = try await client.groups.listUserMemberships(userId: userId)
   // Always awaited before isAuthenticated flips true
@@ -269,7 +266,7 @@ func initialize() async throws {
 func loadAuthConfig() async {
   if authConfig != nil { return }
   if let task = authConfigTask { return await task.value }
-  let task = Task { normalize(try await client.getAuthConfig()) }
+  let task = Task { normalize(try await client.auth.getAuthConfig()) }
   authConfigTask = task
   authConfig = await task.value
 }
@@ -412,10 +409,14 @@ final class SourceStore: ObservableObject {
   // a server-registered subscription key, and an options object carrying the
   // `onChange` callback (plus any `params` forwarded to the subscription's
   // filter CEL).
-  func observe(dbId: String) {
-    client.databases.subscribe(databaseId: dbId, key: "source-changes") { [weak self] _ in
-      self?.invalidate()
-    }
+  func observe(dbId: String) throws {
+    _ = try client.databases.subscribe(
+      databaseId: dbId,
+      subscriptionKey: "source-changes",
+      options: DatabaseSubscribeOptions(onChange: { [weak self] _ in
+        self?.invalidate()
+      })
+    )
   }
 }
 ```
@@ -466,7 +467,7 @@ When auditing an existing Primitive app, these usually find real wins:
 | N+1 in a loop | `for .* in` followed by `try await .*executeOperation` |
 | Per-symbol third-party call | calls to `client.integrations.call` inside a loop |
 | Eager full-reload on every state change | a change observer whose body does `try await load…` |
-| Awaiting non-critical init | `try await client.getAuthConfig()`, `try await listUserMemberships`, `try await initializeUserPrefs()` inside `initialize()` / `completeAuthentication()` |
+| Awaiting non-critical init | `try await client.auth.getAuthConfig()`, `try await listUserMemberships`, `try await initializeUserPrefs()` inside `initialize()` / `completeAuthentication()` |
 | Cached value behind a re-block | `await ensurePrefsReady(); let cached = getPref(...)` (yes — really) |
 | Sequential awaits | three or more consecutive `try await db.executeOperation(...)` lines |
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_PERFORMANCE.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_PERFORMANCE.template.md
@@ -146,34 +146,7 @@ definition = '{"filter":{},"sort":{"groupId":1},"limit":1000}'
 
 Call it once, then group client-side:
 
-{{#lang ts}}
-```ts
-const all = await db.executeOperation("listAllTargets");
-const byGroup = new Map<string, Target[]>();
-for (const t of all.data) {
-  const list = byGroup.get(t.groupId) ?? [];
-  list.push(t);
-  byGroup.set(t.groupId, list);
-}
-for (const group of groups) {
-  const targets = byGroup.get(group.id) ?? [];
-  // ...
-}
-```
-{{/lang}}
-{{#lang swift}}
-```swift
-let all = try await db.executeOperation(name: "listAllTargets")
-var byGroup: [String: [Target]] = [:]
-for t in all.data {
-  byGroup[t.groupId, default: []].append(t)
-}
-for group in groups {
-  let targets = byGroup[group.id] ?? []
-  // ...
-}
-```
-{{/lang}}
+{{ example: performance/bulk-then-group }}
 
 If you can fold the bulk op into a pipeline (Pattern 1), do that instead — same round-trip count, fewer named ops to maintain.
 
@@ -297,7 +270,7 @@ async function initialize() {
 ```swift
 func initialize() async throws {
   // Always loaded, even on screens that never consult it
-  authConfig = try await client.getAuthConfig()
+  authConfig = try await client.auth.getAuthConfig()
   // Always loaded, even though only some screens care about memberships
   memberships = try await client.groups.listUserMemberships(userId: userId)
   // Always awaited before isAuthenticated flips true
@@ -364,7 +337,7 @@ func initialize() async throws {
 func loadAuthConfig() async {
   if authConfig != nil { return }
   if let task = authConfigTask { return await task.value }
-  let task = Task { normalize(try await client.getAuthConfig()) }
+  let task = Task { normalize(try await client.auth.getAuthConfig()) }
   authConfigTask = task
   authConfig = await task.value
 }
@@ -598,10 +571,14 @@ final class SourceStore: ObservableObject {
   // a server-registered subscription key, and an options object carrying the
   // `onChange` callback (plus any `params` forwarded to the subscription's
   // filter CEL).
-  func observe(dbId: String) {
-    client.databases.subscribe(databaseId: dbId, key: "source-changes") { [weak self] _ in
-      self?.invalidate()
-    }
+  func observe(dbId: String) throws {
+    _ = try client.databases.subscribe(
+      databaseId: dbId,
+      subscriptionKey: "source-changes",
+      options: DatabaseSubscribeOptions(onChange: { [weak self] _ in
+        self?.invalidate()
+      })
+    )
   }
 }
 ```
@@ -664,7 +641,7 @@ When auditing an existing Primitive app, these usually find real wins:
 | N+1 in a loop | `for .* in` followed by `try await .*executeOperation` |
 | Per-symbol third-party call | calls to `client.integrations.call` inside a loop |
 | Eager full-reload on every state change | a change observer whose body does `try await load…` |
-| Awaiting non-critical init | `try await client.getAuthConfig()`, `try await listUserMemberships`, `try await initializeUserPrefs()` inside `initialize()` / `completeAuthentication()` |
+| Awaiting non-critical init | `try await client.auth.getAuthConfig()`, `try await listUserMemberships`, `try await initializeUserPrefs()` inside `initialize()` / `completeAuthentication()` |
 | Cached value behind a re-block | `await ensurePrefsReady(); let cached = getPref(...)` (yes — really) |
 | Sequential awaits | three or more consecutive `try await db.executeOperation(...)` lines |
 {{/lang}}

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_PERFORMANCE.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_PERFORMANCE.ts.md
@@ -126,18 +126,15 @@ definition = '{"filter":{},"sort":{"groupId":1},"limit":1000}'
 
 Call it once, then group client-side:
 
-```ts
-const all = await db.executeOperation("listAllTargets");
-const byGroup = new Map<string, Target[]>();
-for (const t of all.data) {
-  const list = byGroup.get(t.groupId) ?? [];
-  list.push(t);
-  byGroup.set(t.groupId, list);
-}
-for (const group of groups) {
-  const targets = byGroup.get(group.id) ?? [];
-  // ...
-}
+```typescript
+  const all = await client.databases.executeOperation(databaseId, "listAllTasks");
+  const byCategory = new Map<string, TaskAttrs[]>();
+  for (const task of all.data as TaskAttrs[]) {
+    const key = task.category ?? "uncategorized";
+    const list = byCategory.get(key) ?? [];
+    list.push(task);
+    byCategory.set(key, list);
+  }
 ```
 
 If you can fold the bulk op into a pipeline (Pattern 1), do that instead — same round-trip count, fewer named ops to maintain.

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.swift.md
@@ -86,18 +86,20 @@ For app-specific user data (preferences, settings, profile fields beyond name/em
 **Do this:**
 
 ```swift
-// Store additional user data in a document, keyed by the platform userId
-var userProfile = UserProfile()
-userProfile.userId = platformUserId  // reference the platform user
-userProfile.bio = "Software engineer"
-userProfile.theme = "dark"
-try await userProfile.save(targetDocument: userDocumentId)
+  // Store additional user data in a document, keyed by the platform userId.
+  let profile = AppUser(
+    id: platformUserId, // reference the platform user
+    email: "alice@example.com",
+    name: "Software engineer"
+  )
+  try profile.save(in: userDocumentId)
 
-// Or in a database via registered operation
-try await client.databases.executeOperation(dbId, "updateProfile", params: [
-  "bio": "Software engineer", "theme": "dark"
-  // The operation uses $user.userId server-side — no need to pass userId
-])
+  // Or in a database via a registered operation. The operation uses
+  // $user.userId server-side — no need to pass the userId yourself.
+  _ = try await client.databases.executeOperation(
+    databaseId: dbId, name: "updateProfile",
+    options: ExecuteOperationOptions(params: ["bio": "Software engineer", "theme": "dark"])
+  )
 ```
 
 **Don't do this:**
@@ -756,46 +758,49 @@ autoAddCreator = true
 **Runtime** (in app code):
 
 ```swift
-// User creates a team
-try await client.groups.create(
-  groupType: "team",
-  groupId: "alpha-team",
-  name: "Alpha Team"
-)
+  // User creates a team.
+  _ = try await client.groups.create(params: CreateGroupParams(
+    groupType: "team",
+    groupId: "alpha-team",
+    name: "Alpha Team"
+  ))
 
-// Share a document with the team
-try await client.documents.grantGroupPermission(
-  docId,
-  groupType: "team",
-  groupId: "alpha-team",
-  permission: "read-write"
-)
-
-// Database operations gated by team membership
-// access: "isMemberOf('team', database.metadata.teamId)"
+  // Share a document with the team — every member inherits read-write.
+  _ = try await client.documents.grantGroupPermission(
+    documentId: docId,
+    params: GrantGroupPermissionParams(
+      groupType: "team",
+      groupId: "alpha-team",
+      permission: "read-write"
+    )
+  )
 ```
+
+Gate the team's database operations on membership in CEL: `access: "isMemberOf('team', database.metadata.teamId)"`.
 
 ### Role-based access (reviewer, editor, viewer)
 
 Use group types as roles within a context.
 
 ```swift
-// Create role groups for a project
-try await client.groups.create(groupType: "editor", groupId: "project-1", name: "Project 1 Editors")
-try await client.groups.create(groupType: "viewer", groupId: "project-1", name: "Project 1 Viewers")
+  // Create role groups for a project.
+  _ = try await client.groups.create(params: CreateGroupParams(
+    groupType: "editor", groupId: "project-1", name: "Project 1 Editors"))
+  _ = try await client.groups.create(params: CreateGroupParams(
+    groupType: "viewer", groupId: "project-1", name: "Project 1 Viewers"))
 
-// Grant different document permissions
-try await client.documents.grantGroupPermission(
-  docId, groupType: "editor", groupId: "project-1", permission: "read-write")
-try await client.documents.grantGroupPermission(
-  docId, groupType: "viewer", groupId: "project-1", permission: "reader")
-
-// Database operations with role checks
-// Editors can modify:
-// access: "isMemberOf('editor', params.projectId)"
-// Viewers can read:
-// access: "isMemberOf('viewer', params.projectId) || isMemberOf('editor', params.projectId)"
+  // Grant different document permissions per role.
+  _ = try await client.documents.grantGroupPermission(
+    documentId: docId,
+    params: GrantGroupPermissionParams(
+      groupType: "editor", groupId: "project-1", permission: "read-write"))
+  _ = try await client.documents.grantGroupPermission(
+    documentId: docId,
+    params: GrantGroupPermissionParams(
+      groupType: "viewer", groupId: "project-1", permission: "reader"))
 ```
+
+Gate the operations on role membership in CEL — editors can modify (`access: "isMemberOf('editor', params.projectId)"`); viewers can read (`access: "isMemberOf('viewer', params.projectId) || isMemberOf('editor', params.projectId)"`).
 
 ### Relationship modeling (parent-child, mentor-mentee)
 
@@ -820,17 +825,23 @@ The per-parameter `access` expression ensures parents can only view their own ch
 **Runtime** (in app code):
 
 ```swift
-// A "parent-of" group per student
-try await client.groups.create(
-  groupType: "parent-of",
-  groupId: "student-123",
-  name: "Parents of Student 123"
-)
-try await client.groups.addMember("parent-of", "student-123", userId: parentUserId)
+  // A "parent-of" group per student.
+  _ = try await client.groups.create(params: CreateGroupParams(
+    groupType: "parent-of",
+    groupId: "student-123",
+    name: "Parents of Student 123"
+  ))
+  _ = try await client.groups.addMember(
+    groupType: "parent-of", groupId: "student-123",
+    params: .userId(parentUserId)
+  )
 
-// Parent queries their child's grades — server enforces access
-let grades = try await client.databases.executeOperation(
-  dbId, "viewGrades", params: ["studentId": "student-123"])
+  // Parent queries their child's grades — server enforces access.
+  let grades = try await client.databases.executeOperation(
+    databaseId: dbId, name: "viewGrades",
+    options: ExecuteOperationOptions(params: ["studentId": "student-123"])
+  )
+  _ = grades
 ```
 
 ### Organization hierarchy
@@ -838,26 +849,30 @@ let grades = try await client.databases.executeOperation(
 Model nested organizational structure with multiple group types.
 
 ```swift
-// Organization-level groups
-try await client.groups.create(groupType: "org", groupId: "acme-corp", name: "Acme Corp")
+  // Organization-level group.
+  _ = try await client.groups.create(params: CreateGroupParams(
+    groupType: "org", groupId: "acme-corp", name: "Acme Corp"))
 
-// Department-level groups
-try await client.groups.create(groupType: "dept", groupId: "engineering", name: "Engineering")
-try await client.groups.create(groupType: "dept", groupId: "marketing", name: "Marketing")
+  // Department-level groups.
+  _ = try await client.groups.create(params: CreateGroupParams(
+    groupType: "dept", groupId: "engineering", name: "Engineering"))
+  _ = try await client.groups.create(params: CreateGroupParams(
+    groupType: "dept", groupId: "marketing", name: "Marketing"))
 
-// Team-level groups
-try await client.groups.create(groupType: "team", groupId: "backend", name: "Backend Team")
+  // Team-level group.
+  _ = try await client.groups.create(params: CreateGroupParams(
+    groupType: "team", groupId: "backend", name: "Backend Team"))
 
-// A user can be in multiple groups at different levels
-try await client.groups.addMember("org", "acme-corp", userId: userId)
-try await client.groups.addMember("dept", "engineering", userId: userId)
-try await client.groups.addMember("team", "backend", userId: userId)
-
-// CEL can check any level:
-// "isMemberOf('org', database.metadata.orgId)"
-// "isMemberOf('dept', params.deptId)"
-// "isMemberOf('team', database.metadata.teamId)"
+  // A user can be in multiple groups at different levels.
+  _ = try await client.groups.addMember(
+    groupType: "org", groupId: "acme-corp", params: .userId(userId))
+  _ = try await client.groups.addMember(
+    groupType: "dept", groupId: "engineering", params: .userId(userId))
+  _ = try await client.groups.addMember(
+    groupType: "team", groupId: "backend", params: .userId(userId))
 ```
+
+CEL can check any level: `"isMemberOf('org', database.metadata.orgId)"`, `"isMemberOf('dept', params.deptId)"`, `"isMemberOf('team', database.metadata.teamId)"`.
 
 ## Best Practices
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.template.md
@@ -46,24 +46,11 @@ For app-specific user data (preferences, settings, profile fields beyond name/em
 
 **Do this:**
 
-{{#lang ts}}
-```typescript
-// Store additional user data in a document, keyed by the platform userId
-const userProfile = new UserProfile();
-userProfile.userId = platformUserId; // reference the platform user
-userProfile.bio = "Software engineer";
-userProfile.theme = "dark";
-await userProfile.save({ targetDocument: userDocumentId });
-
-// Or in a database via registered operation
-await client.databases.executeOperation(dbId, "updateProfile", {
-  params: { bio: "Software engineer", theme: "dark" },
-  // The operation uses $user.userId server-side — no need to pass userId
-});
-```
+{{ example: users-and-groups/supplement-user-data }}
 
 **Don't do this:**
 
+{{#lang ts}}
 ```typescript
 // DON'T create a separate user model that duplicates platform fields
 const user = new AppUser();
@@ -73,23 +60,6 @@ user.id = generateNewId();        // Use platform userId instead
 ```
 {{/lang}}
 {{#lang swift}}
-```swift
-// Store additional user data in a document, keyed by the platform userId
-var userProfile = UserProfile()
-userProfile.userId = platformUserId  // reference the platform user
-userProfile.bio = "Software engineer"
-userProfile.theme = "dark"
-try await userProfile.save(targetDocument: userDocumentId)
-
-// Or in a database via registered operation
-try await client.databases.executeOperation(dbId, "updateProfile", params: [
-  "bio": "Software engineer", "theme": "dark"
-  // The operation uses $user.userId server-side — no need to pass userId
-])
-```
-
-**Don't do this:**
-
 ```swift
 // DON'T create a separate user model that duplicates platform fields
 var user = AppUser()
@@ -592,92 +562,17 @@ autoAddCreator = true
 
 **Runtime** (in app code):
 
-{{#lang ts}}
-```typescript
-// User creates a team
-await client.groups.create({
-  groupType: "team",
-  groupId: "alpha-team",
-  name: "Alpha Team",
-});
+{{ example: users-and-groups/team-workspace }}
 
-// Share a document with the team
-await client.documents.grantGroupPermission(docId, {
-  groupType: "team",
-  groupId: "alpha-team",
-  permission: "read-write",
-});
-
-// Database operations gated by team membership
-// access: "isMemberOf('team', database.metadata.teamId)"
-```
-{{/lang}}
-{{#lang swift}}
-```swift
-// User creates a team
-try await client.groups.create(
-  groupType: "team",
-  groupId: "alpha-team",
-  name: "Alpha Team"
-)
-
-// Share a document with the team
-try await client.documents.grantGroupPermission(
-  docId,
-  groupType: "team",
-  groupId: "alpha-team",
-  permission: "read-write"
-)
-
-// Database operations gated by team membership
-// access: "isMemberOf('team', database.metadata.teamId)"
-```
-{{/lang}}
+Gate the team's database operations on membership in CEL: `access: "isMemberOf('team', database.metadata.teamId)"`.
 
 ### Role-based access (reviewer, editor, viewer)
 
 Use group types as roles within a context.
 
-{{#lang ts}}
-```typescript
-// Create role groups for a project
-await client.groups.create({ groupType: "editor", groupId: "project-1", name: "Project 1 Editors" });
-await client.groups.create({ groupType: "viewer", groupId: "project-1", name: "Project 1 Viewers" });
+{{ example: users-and-groups/role-groups }}
 
-// Grant different document permissions
-await client.documents.grantGroupPermission(docId, {
-  groupType: "editor", groupId: "project-1", permission: "read-write",
-});
-await client.documents.grantGroupPermission(docId, {
-  groupType: "viewer", groupId: "project-1", permission: "reader",
-});
-
-// Database operations with role checks
-// Editors can modify:
-// access: "isMemberOf('editor', params.projectId)"
-// Viewers can read:
-// access: "isMemberOf('viewer', params.projectId) || isMemberOf('editor', params.projectId)"
-```
-{{/lang}}
-{{#lang swift}}
-```swift
-// Create role groups for a project
-try await client.groups.create(groupType: "editor", groupId: "project-1", name: "Project 1 Editors")
-try await client.groups.create(groupType: "viewer", groupId: "project-1", name: "Project 1 Viewers")
-
-// Grant different document permissions
-try await client.documents.grantGroupPermission(
-  docId, groupType: "editor", groupId: "project-1", permission: "read-write")
-try await client.documents.grantGroupPermission(
-  docId, groupType: "viewer", groupId: "project-1", permission: "reader")
-
-// Database operations with role checks
-// Editors can modify:
-// access: "isMemberOf('editor', params.projectId)"
-// Viewers can read:
-// access: "isMemberOf('viewer', params.projectId) || isMemberOf('editor', params.projectId)"
-```
-{{/lang}}
+Gate the operations on role membership in CEL — editors can modify (`access: "isMemberOf('editor', params.projectId)"`); viewers can read (`access: "isMemberOf('viewer', params.projectId) || isMemberOf('editor', params.projectId)"`).
 
 ### Relationship modeling (parent-child, mentor-mentee)
 
@@ -701,88 +596,15 @@ The per-parameter `access` expression ensures parents can only view their own ch
 
 **Runtime** (in app code):
 
-{{#lang ts}}
-```typescript
-// A "parent-of" group per student
-await client.groups.create({
-  groupType: "parent-of",
-  groupId: "student-123",
-  name: "Parents of Student 123",
-});
-await client.groups.addMember("parent-of", "student-123", { userId: parentUserId });
-
-// Parent queries their child's grades — server enforces access
-const grades = await client.databases.executeOperation(dbId, "viewGrades", {
-  params: { studentId: "student-123" },
-});
-```
-{{/lang}}
-{{#lang swift}}
-```swift
-// A "parent-of" group per student
-try await client.groups.create(
-  groupType: "parent-of",
-  groupId: "student-123",
-  name: "Parents of Student 123"
-)
-try await client.groups.addMember("parent-of", "student-123", userId: parentUserId)
-
-// Parent queries their child's grades — server enforces access
-let grades = try await client.databases.executeOperation(
-  dbId, "viewGrades", params: ["studentId": "student-123"])
-```
-{{/lang}}
+{{ example: users-and-groups/relationship-groups }}
 
 ### Organization hierarchy
 
 Model nested organizational structure with multiple group types.
 
-{{#lang ts}}
-```typescript
-// Organization-level groups
-await client.groups.create({ groupType: "org", groupId: "acme-corp", name: "Acme Corp" });
+{{ example: users-and-groups/org-hierarchy }}
 
-// Department-level groups
-await client.groups.create({ groupType: "dept", groupId: "engineering", name: "Engineering" });
-await client.groups.create({ groupType: "dept", groupId: "marketing", name: "Marketing" });
-
-// Team-level groups
-await client.groups.create({ groupType: "team", groupId: "backend", name: "Backend Team" });
-
-// A user can be in multiple groups at different levels
-await client.groups.addMember("org", "acme-corp", { userId });
-await client.groups.addMember("dept", "engineering", { userId });
-await client.groups.addMember("team", "backend", { userId });
-
-// CEL can check any level:
-// "isMemberOf('org', database.metadata.orgId)"
-// "isMemberOf('dept', params.deptId)"
-// "isMemberOf('team', database.metadata.teamId)"
-```
-{{/lang}}
-{{#lang swift}}
-```swift
-// Organization-level groups
-try await client.groups.create(groupType: "org", groupId: "acme-corp", name: "Acme Corp")
-
-// Department-level groups
-try await client.groups.create(groupType: "dept", groupId: "engineering", name: "Engineering")
-try await client.groups.create(groupType: "dept", groupId: "marketing", name: "Marketing")
-
-// Team-level groups
-try await client.groups.create(groupType: "team", groupId: "backend", name: "Backend Team")
-
-// A user can be in multiple groups at different levels
-try await client.groups.addMember("org", "acme-corp", userId: userId)
-try await client.groups.addMember("dept", "engineering", userId: userId)
-try await client.groups.addMember("team", "backend", userId: userId)
-
-// CEL can check any level:
-// "isMemberOf('org', database.metadata.orgId)"
-// "isMemberOf('dept', params.deptId)"
-// "isMemberOf('team', database.metadata.teamId)"
-```
-{{/lang}}
+CEL can check any level: `"isMemberOf('org', database.metadata.orgId)"`, `"isMemberOf('dept', params.deptId)"`, `"isMemberOf('team', database.metadata.teamId)"`.
 
 ## Best Practices
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.ts.md
@@ -79,18 +79,19 @@ For app-specific user data (preferences, settings, profile fields beyond name/em
 **Do this:**
 
 ```typescript
-// Store additional user data in a document, keyed by the platform userId
-const userProfile = new UserProfile();
-userProfile.userId = platformUserId; // reference the platform user
-userProfile.bio = "Software engineer";
-userProfile.theme = "dark";
-await userProfile.save({ targetDocument: userDocumentId });
+  // Store additional user data in a document, keyed by the platform userId.
+  const profile = new AppUser({
+    id: platformUserId, // reference the platform user
+    email: "alice@example.com",
+    name: "Software engineer",
+  });
+  await profile.save({ targetDocument: userDocumentId });
 
-// Or in a database via registered operation
-await client.databases.executeOperation(dbId, "updateProfile", {
-  params: { bio: "Software engineer", theme: "dark" },
-  // The operation uses $user.userId server-side — no need to pass userId
-});
+  // Or in a database via a registered operation. The operation uses
+  // $user.userId server-side — no need to pass the userId yourself.
+  await client.databases.executeOperation(dbId, "updateProfile", {
+    params: { bio: "Software engineer", theme: "dark" },
+  });
 ```
 
 **Don't do this:**
@@ -738,47 +739,46 @@ autoAddCreator = true
 **Runtime** (in app code):
 
 ```typescript
-// User creates a team
-await client.groups.create({
-  groupType: "team",
-  groupId: "alpha-team",
-  name: "Alpha Team",
-});
+  // User creates a team.
+  await client.groups.create({
+    groupType: "team",
+    groupId: "alpha-team",
+    name: "Alpha Team",
+  });
 
-// Share a document with the team
-await client.documents.grantGroupPermission(docId, {
-  groupType: "team",
-  groupId: "alpha-team",
-  permission: "read-write",
-});
-
-// Database operations gated by team membership
-// access: "isMemberOf('team', database.metadata.teamId)"
+  // Share a document with the team — every member inherits read-write.
+  await client.documents.grantGroupPermission(docId, {
+    groupType: "team",
+    groupId: "alpha-team",
+    permission: "read-write",
+  });
 ```
+
+Gate the team's database operations on membership in CEL: `access: "isMemberOf('team', database.metadata.teamId)"`.
 
 ### Role-based access (reviewer, editor, viewer)
 
 Use group types as roles within a context.
 
 ```typescript
-// Create role groups for a project
-await client.groups.create({ groupType: "editor", groupId: "project-1", name: "Project 1 Editors" });
-await client.groups.create({ groupType: "viewer", groupId: "project-1", name: "Project 1 Viewers" });
+  // Create role groups for a project.
+  await client.groups.create({ groupType: "editor", groupId: "project-1", name: "Project 1 Editors" });
+  await client.groups.create({ groupType: "viewer", groupId: "project-1", name: "Project 1 Viewers" });
 
-// Grant different document permissions
-await client.documents.grantGroupPermission(docId, {
-  groupType: "editor", groupId: "project-1", permission: "read-write",
-});
-await client.documents.grantGroupPermission(docId, {
-  groupType: "viewer", groupId: "project-1", permission: "reader",
-});
-
-// Database operations with role checks
-// Editors can modify:
-// access: "isMemberOf('editor', params.projectId)"
-// Viewers can read:
-// access: "isMemberOf('viewer', params.projectId) || isMemberOf('editor', params.projectId)"
+  // Grant different document permissions per role.
+  await client.documents.grantGroupPermission(docId, {
+    groupType: "editor",
+    groupId: "project-1",
+    permission: "read-write",
+  });
+  await client.documents.grantGroupPermission(docId, {
+    groupType: "viewer",
+    groupId: "project-1",
+    permission: "reader",
+  });
 ```
+
+Gate the operations on role membership in CEL — editors can modify (`access: "isMemberOf('editor', params.projectId)"`); viewers can read (`access: "isMemberOf('viewer', params.projectId) || isMemberOf('editor', params.projectId)"`).
 
 ### Relationship modeling (parent-child, mentor-mentee)
 
@@ -803,18 +803,18 @@ The per-parameter `access` expression ensures parents can only view their own ch
 **Runtime** (in app code):
 
 ```typescript
-// A "parent-of" group per student
-await client.groups.create({
-  groupType: "parent-of",
-  groupId: "student-123",
-  name: "Parents of Student 123",
-});
-await client.groups.addMember("parent-of", "student-123", { userId: parentUserId });
+  // A "parent-of" group per student.
+  await client.groups.create({
+    groupType: "parent-of",
+    groupId: "student-123",
+    name: "Parents of Student 123",
+  });
+  await client.groups.addMember("parent-of", "student-123", { userId: parentUserId });
 
-// Parent queries their child's grades — server enforces access
-const grades = await client.databases.executeOperation(dbId, "viewGrades", {
-  params: { studentId: "student-123" },
-});
+  // Parent queries their child's grades — server enforces access.
+  const grades = await client.databases.executeOperation(dbId, "viewGrades", {
+    params: { studentId: "student-123" },
+  });
 ```
 
 ### Organization hierarchy
@@ -822,26 +822,23 @@ const grades = await client.databases.executeOperation(dbId, "viewGrades", {
 Model nested organizational structure with multiple group types.
 
 ```typescript
-// Organization-level groups
-await client.groups.create({ groupType: "org", groupId: "acme-corp", name: "Acme Corp" });
+  // Organization-level group.
+  await client.groups.create({ groupType: "org", groupId: "acme-corp", name: "Acme Corp" });
 
-// Department-level groups
-await client.groups.create({ groupType: "dept", groupId: "engineering", name: "Engineering" });
-await client.groups.create({ groupType: "dept", groupId: "marketing", name: "Marketing" });
+  // Department-level groups.
+  await client.groups.create({ groupType: "dept", groupId: "engineering", name: "Engineering" });
+  await client.groups.create({ groupType: "dept", groupId: "marketing", name: "Marketing" });
 
-// Team-level groups
-await client.groups.create({ groupType: "team", groupId: "backend", name: "Backend Team" });
+  // Team-level group.
+  await client.groups.create({ groupType: "team", groupId: "backend", name: "Backend Team" });
 
-// A user can be in multiple groups at different levels
-await client.groups.addMember("org", "acme-corp", { userId });
-await client.groups.addMember("dept", "engineering", { userId });
-await client.groups.addMember("team", "backend", { userId });
-
-// CEL can check any level:
-// "isMemberOf('org', database.metadata.orgId)"
-// "isMemberOf('dept', params.deptId)"
-// "isMemberOf('team', database.metadata.teamId)"
+  // A user can be in multiple groups at different levels.
+  await client.groups.addMember("org", "acme-corp", { userId });
+  await client.groups.addMember("dept", "engineering", { userId });
+  await client.groups.addMember("team", "backend", { userId });
 ```
+
+CEL can check any level: `"isMemberOf('org', database.metadata.orgId)"`, `"isMemberOf('dept', params.deptId)"`, `"isMemberOf('team', database.metadata.teamId)"`.
 
 ## Best Practices
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.swift.md
@@ -1338,39 +1338,40 @@ The step records carry `{ stepRunId, runId, stepKind, status, input, output, err
 
 Requires an active WebSocket (e.g., from `client.documents.open(docId)`).
 
-
-Subscribe through `client.events.on(_:)` with the typed event payload; hold the returned `EventSubscription` for as long as you want the handler live.
-
 ```swift
-let started = client.events.on(.workflowStarted) { (e: WorkflowStartedEvent) in
+  let started = client.events.on(.workflowStarted) { (e: WorkflowStartedEvent) in
     // e.workflowKey, e.runId, e.runKey?, e.instanceId?, e.contextDocId?, e.meta?
-}
+  }
 
-let sub = client.events.on(.workflowStatus) { (e: WorkflowStatusEvent) in
+  let status = client.events.on(.workflowStatus) { (e: WorkflowStatusEvent) in
     // e.status: "completed" | "failed" | "terminated"
     // e.needsApply == true if requiresClientApply and not yet applied
     // also: e.runKey, e.runId, e.output, e.error, e.contextDocId, e.meta
-}
+  }
 ```
 
-The `workflowStatus` event uses `"completed"`; `getStatus` returns `"complete"`. These differ in the SDK — handle both if your code shares logic.
+The `workflowStatus` event uses `"completed"`. The `getStatus` method returns `"complete"`. These differ in the SDK — handle both if your code shares logic.
+
+Subscribe through `client.events.on(_:)`; hold the returned `EventSubscription` for as long as you want the handler live.
 
 ## Apply pattern
 
 For workflows with `requiresClientApply = true`, register an apply handler so a client deterministically runs follow-up logic exactly once.
 
-
 ```swift
-client.workflows.define("my-workflow-key") { ctx in
+  client.workflows.define("my-workflow-key") { ctx in
     // Runs on exactly one connected client: the client claims the lease,
     // fetches the run output, calls this handler, then confirms the apply.
     // A thrown error releases the claim so another client (or a retry)
     // can pick it up.
     // ctx: workflowKey, runKey, runId, contextDocId?, output, startedByUserId?, meta?
-}
+    _ = ctx.output
+  }
 ```
 
-Register `define(...)` before `start(...)` so the apply can't arrive before the handler is in place. After an offline gap, `getPendingApplies(contextDocId:)` lists runs still awaiting apply.
+Register `define(...)` before `start(...)` so the apply can't arrive before the handler is in place.
+
+After an offline gap, `getPendingApplies(contextDocId:)` lists runs still awaiting apply.
 
 Manual flow if you need it: `claimApply` → run logic → `confirmApply` (success) or `releaseApply` (failure). 30s lease timeout for crashed clients.
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md
@@ -1248,70 +1248,27 @@ The step records carry `{ stepRunId, runId, stepKind, status, input, output, err
 
 Requires an active WebSocket (e.g., from `client.documents.open(docId)`).
 
-{{#lang ts}}
-```typescript
-client.on("workflowStarted", (e) => { /* { workflowKey, runId, runKey, instanceId, contextDocId?, meta? } */ });
-
-client.on("workflowStatus", (e) => {
-  // e.status: "completed" | "failed" | "terminated"  (NOTE: "completed" here, with the "d")
-  // e.needsApply: true if requiresClientApply and not yet applied
-});
-```
+{{ example: workflows/workflow-events }}
 
 The `workflowStatus` event uses `"completed"`. The `getStatus` method returns `"complete"`. These differ in the SDK — handle both if your code shares logic.
-{{/lang}}
 
 {{#lang swift}}
-Subscribe through `client.events.on(_:)` with the typed event payload; hold the returned `EventSubscription` for as long as you want the handler live.
-
-```swift
-let started = client.events.on(.workflowStarted) { (e: WorkflowStartedEvent) in
-    // e.workflowKey, e.runId, e.runKey?, e.instanceId?, e.contextDocId?, e.meta?
-}
-
-let sub = client.events.on(.workflowStatus) { (e: WorkflowStatusEvent) in
-    // e.status: "completed" | "failed" | "terminated"
-    // e.needsApply == true if requiresClientApply and not yet applied
-    // also: e.runKey, e.runId, e.output, e.error, e.contextDocId, e.meta
-}
-```
-
-The `workflowStatus` event uses `"completed"`; `getStatus` returns `"complete"`. These differ in the SDK — handle both if your code shares logic.
+Subscribe through `client.events.on(_:)`; hold the returned `EventSubscription` for as long as you want the handler live.
 {{/lang}}
 
 ## Apply pattern
 
 For workflows with `requiresClientApply = true`, register an apply handler so a client deterministically runs follow-up logic exactly once.
 
-{{#lang ts}}
-```typescript
-client.workflows.define("my-workflow-key", {
-  onApply: async ({ output, workflowKey, runKey, runId, contextDocId, startedByUserId, meta }) => {
-    // Runs on exactly one connected client.
-    const { doc } = await client.documents.open(contextDocId);
-    doc.getMap("data").set("result", output);
-  },
-});
-```
+{{ example: workflows/workflow-apply }}
 
-Manual flow if you need it: `claimApply` → run logic → `confirmApply` (success) or `releaseApply` (failure). 30s lease timeout for crashed clients.
-{{/lang}}
+Register `define(...)` before `start(...)` so the apply can't arrive before the handler is in place.
 
 {{#lang swift}}
-```swift
-client.workflows.define("my-workflow-key") { ctx in
-    // Runs on exactly one connected client: the client claims the lease,
-    // fetches the run output, calls this handler, then confirms the apply.
-    // A thrown error releases the claim so another client (or a retry)
-    // can pick it up.
-    // ctx: workflowKey, runKey, runId, contextDocId?, output, startedByUserId?, meta?
-}
-```
-
-Register `define(...)` before `start(...)` so the apply can't arrive before the handler is in place. After an offline gap, `getPendingApplies(contextDocId:)` lists runs still awaiting apply.
+After an offline gap, `getPendingApplies(contextDocId:)` lists runs still awaiting apply.
+{{/lang}}
 
 Manual flow if you need it: `claimApply` → run logic → `confirmApply` (success) or `releaseApply` (failure). 30s lease timeout for crashed clients.
-{{/lang}}
 
 ## Footguns and don't-do-this
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.ts.md
@@ -1339,12 +1339,15 @@ The step records carry `{ stepRunId, runId, stepKind, status, input, output, err
 Requires an active WebSocket (e.g., from `client.documents.open(docId)`).
 
 ```typescript
-client.on("workflowStarted", (e) => { /* { workflowKey, runId, runKey, instanceId, contextDocId?, meta? } */ });
+  client.on("workflowStarted", (e) => {
+    // { workflowKey, runId, runKey, instanceId, contextDocId?, meta? }
+  });
 
-client.on("workflowStatus", (e) => {
-  // e.status: "completed" | "failed" | "terminated"  (NOTE: "completed" here, with the "d")
-  // e.needsApply: true if requiresClientApply and not yet applied
-});
+  client.on("workflowStatus", (e) => {
+    // e.status: "completed" | "failed" | "terminated"
+    //   (NOTE: "completed" here, with the "d" — getStatus returns "complete")
+    // e.needsApply: true if requiresClientApply and not yet applied
+  });
 ```
 
 The `workflowStatus` event uses `"completed"`. The `getStatus` method returns `"complete"`. These differ in the SDK — handle both if your code shares logic.
@@ -1355,17 +1358,20 @@ The `workflowStatus` event uses `"completed"`. The `getStatus` method returns `"
 For workflows with `requiresClientApply = true`, register an apply handler so a client deterministically runs follow-up logic exactly once.
 
 ```typescript
-client.workflows.define("my-workflow-key", {
-  onApply: async ({ output, workflowKey, runKey, runId, contextDocId, startedByUserId, meta }) => {
-    // Runs on exactly one connected client.
-    const { doc } = await client.documents.open(contextDocId);
-    doc.getMap("data").set("result", output);
-  },
-});
+  client.workflows.define("my-workflow-key", {
+    onApply: async ({ output, workflowKey, runKey, runId, contextDocId, startedByUserId, meta }) => {
+      // Runs on exactly one connected client.
+      if (!contextDocId) return;
+      const { doc } = await client.documents.open(contextDocId);
+      doc?.getMap("data").set("result", output);
+    },
+  });
 ```
 
-Manual flow if you need it: `claimApply` → run logic → `confirmApply` (success) or `releaseApply` (failure). 30s lease timeout for crashed clients.
+Register `define(...)` before `start(...)` so the apply can't arrive before the handler is in place.
 
+
+Manual flow if you need it: `claimApply` → run logic → `confirmApply` (success) or `releaseApply` (failure). 30s lease timeout for crashed clients.
 
 ## Footguns and don't-do-this
 


### PR DESCRIPTION
Implements the backlog migration in #87: move compilable client code out of un-compile-checked, un-parity-checked inline fences (especially `{{#lang}}` blocks) and into the `examples/` corpus, where it gets the compile gate and JS/Swift parity enforcement.

## What changed
Worst-first sweep across **all 14 templates** that still had inline ts/swift fences (one agent per template). For each fence: promote genuinely-compilable standalone usages to `examples/<subject>/<op>.{ts,swift}` (`#region example`) and replace with `{{ example: … }}`; collapse `{{#lang ts}}`+`{{#lang swift}}` pairs into one placeholder; leave non-compilable fragments inline by design.

- **34 new corpus example pairs** (+ reuse of existing ops).
- Inline ts/swift fences across templates: **208 → 139** (the remainder are TOML/shell/output-shapes, deliberately-WRONG teaching fragments, true one-language capabilities, and the framework-glue sections that want a dedicated generic-first restructure).
- **Verified against source, not transcribed on faith** — corrected stale/incorrect APIs the old fences carried: Swift params-struct group/invitation/share forms, synchronous `model.save(in:)`, `client.auth.getAuthConfig()`, the `DatabasesAPI.subscribe` shape, `DoDbSort`/`GroupBy` enums, raw-HTTP `makeRequest`, `executeOperation` return types, the `initializeClient()` factory, and rewrites of examples that referenced fixtures not in the harness `schema.toml`.
- Dropped two things the compile gate exposed as wrong: fabricated JS blob events (`queue-drained`/`upload-paused`/`-resumed` — not in `JsBaoEvents`) and model-class `DoDb` addressing that doesn't type-check from a codegen model (corpus uses the verified string-name form).

## Gates
- `pnpm check:examples` — TS + Swift compile, example parity, TOML, 435 CLI invocations, source stamp: **pass**.
- `npx vitepress build docs` (dead links): **pass**.

## JS/Swift parity gaps filed
Inconsistencies surfaced during verification that lacked an open tracking issue were filed in js-bao-wss (Swift-client gaps labeled `ios`, assigned to `rhettcon`):
- Primitive-Labs/js-bao-wss#1145 — `importCsv` lacks the model-class option (column filtering + post-import `syncIndexes`).
- Primitive-Labs/js-bao-wss#1146 — invitation event delivered untyped (no `InvitationEvent` struct).
- Primitive-Labs/js-bao-wss#1147 — auth option-surface parity (startOAuthFlow/verify `inviteToken`, logout options) — follow-up to the closed #964.

Candidates that were checked and **not** filed: Swift relationship includes (the batch `Include` path is already at parity per #1115), passkeys (#929), and intrinsic platform differences (model-definition primitives, browser-only `proxyUrl`, DevTools surfaces).

## Notes / follow-ups
- Pre-existing `examples/performance/pipeline-bundle.swift` reads `executeOperation`'s `JSONValue` result via an `as? [String:Any]` cast that always yields nil — flagged by the migration but left untouched (out of scope); worth a separate fix.
- The framework-glue sections (Pinia / `PrimitiveAppState` / dataloader) and ts-only capability sections (relationship includes, `upsertByUnique`) remain inline — they want a dedicated generic-first restructuring chunk rather than mechanical promotion, per the steer on #87.

🤖 Generated with [Claude Code](https://claude.com/claude-code)