### PR TITLE
Document sync diff / sync push --dry-run faithful preview (#121)

### DIFF
--- a/docs/getting-started/configuring-primitive-services.md
+++ b/docs/getting-started/configuring-primitive-services.md
@@ -23,6 +23,8 @@ primitive sync push --dir ./config    # apply your changes to the server
 
 The files live in your repo, so configuration changes ride the same workflow as code: branches, diffs, reviews, rollbacks. `sync push` validates every file before applying anything — a validation error aborts the push with no changes applied — and reports the file and entity behind any failure.
 
+**Preview before you push.** `primitive sync diff` shows which entities would be created, changed, or removed; `primitive sync push --dry-run` walks the full push and reports the same outcome without writing anything. Both run the identical validation a real push runs, so a rejection — an operation whose database type has no schema, an unresolved reference, a schema change that would break an existing operation — surfaces in the preview exactly as it would on push. The preview is faithful: what it reports is what `sync push` will do. And a blocked entity records no sync state, so it stays visible as pending on the next `diff` instead of quietly reading as "in sync."
+
 Every `sync pull` snapshots the sync directory before writing, so a pull that overwrites local edits is recoverable:
 
 ```bash

--- a/docs/getting-started/primitive-cli.md
+++ b/docs/getting-started/primitive-cli.md
@@ -307,6 +307,23 @@ This creates a directory structure like:
 
 Two app settings are not part of `app.toml`: **OTP** is toggled with `primitive apps update --otp <bool>` only, and **redirect URIs** are set with `primitive apps update --redirect-uris "<uri1>,<uri2>"` or in the [Admin Console](https://admin.primitiveapi.com/login) (no TOML key). For everything else, edit `app.toml` and `primitive sync push`.
 
+### Previewing a push
+
+Two commands preview a push without touching the server:
+
+```bash
+primitive sync diff             # entities that would be created, changed, or removed
+primitive sync push --dry-run   # the full push, reported but not applied
+```
+
+Both run the **same** validate-first gate a real `sync push` runs — file validation followed by the server-side checks — so the preview is faithful: what it reports is what the push will do. Schema-validation rejections in particular surface identically, before any change is applied:
+
+- an operation whose database type has no schema set,
+- a `$params.X` or other reference that doesn't resolve,
+- a schema change that would break an existing registered operation.
+
+A previewed (or genuinely blocked) entity records no sync state, so it stays visible as pending on the next `sync diff` rather than being marked "in sync" — a rejected change can't quietly disappear from the diff. Pipe `primitive sync diff --json | jq` for machine-readable output.
+
 ### When `sync push` fails
 
 `sync push` validates every TOML file before applying anything — a validation error in any file aborts the whole push with no changes applied, so a typo in one workflow can't leave a half-pushed configuration behind:

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_CONFIGURATION.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_CONFIGURATION.md
@@ -61,6 +61,10 @@ Not in `app.toml` (see [What sync does NOT carry](#what-sync-does-not-carry)): `
 
 Every command resolves its target environment in order: `--env <name>` flag → `PRIMITIVE_ENV` env var → `defaultEnvironment` in `.primitive/config.json` → the only defined environment → error. Manage environments with `primitive env add|list|show|use|remove`. Tokens are stored per-environment in `.primitive/credentials.json` (gitignored); `.primitive/config.json` is committed.
 
+## Previewing a push
+
+`primitive sync diff` lists entities that would be created, changed, or removed; `primitive sync push --dry-run` reports the full push without applying it. Both run the **same** validate-first gate as a real push — local TOML validation followed by the server-side checks via the validate-first pass — so the preview is faithful: what it reports is what the push applies. Schema-gate rejections surface identically in the preview and in a real push: an operation whose database type has no schema set, an unresolved `$params.X`/reference, or a schema change that would break an existing registered operation. A previewed or blocked entity records no content hash in sync state, so it stays pending on the next `sync diff` rather than reading "in sync" — a server-rejected change cannot silently disappear from the diff. `primitive sync diff --json` emits machine-readable output on stdout.
+
 ## Push failures
 
 `sync push` validates every TOML file before applying anything — any validation error aborts the push with no changes applied (`Aborting push: N TOML validation error(s) — no changes were applied.`). For workflows it validates `$params.X` references against declared `[[operations.params]]` entries at push time, naming the file and line of a bad reference. When validation passes but the server rejects an entity, the error names the entity and file. A cron trigger that already exists on the server but is missing from local sync state is adopted by key and updated in place rather than failing on the 409 — re-running a failed push converges. Diagnostics go to stderr; `--json` data goes to stdout (pipes stay clean).

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_CONFIGURATION.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_CONFIGURATION.template.md
@@ -61,6 +61,10 @@ Not in `app.toml` (see [What sync does NOT carry](#what-sync-does-not-carry)): `
 
 Every command resolves its target environment in order: `--env <name>` flag → `PRIMITIVE_ENV` env var → `defaultEnvironment` in `.primitive/config.json` → the only defined environment → error. Manage environments with `primitive env add|list|show|use|remove`. Tokens are stored per-environment in `.primitive/credentials.json` (gitignored); `.primitive/config.json` is committed.
 
+## Previewing a push
+
+`primitive sync diff` lists entities that would be created, changed, or removed; `primitive sync push --dry-run` reports the full push without applying it. Both run the **same** validate-first gate as a real push — local TOML validation followed by the server-side checks via the validate-first pass — so the preview is faithful: what it reports is what the push applies. Schema-gate rejections surface identically in the preview and in a real push: an operation whose database type has no schema set, an unresolved `$params.X`/reference, or a schema change that would break an existing registered operation. A previewed or blocked entity records no content hash in sync state, so it stays pending on the next `sync diff` rather than reading "in sync" — a server-rejected change cannot silently disappear from the diff. `primitive sync diff --json` emits machine-readable output on stdout.
+
 ## Push failures
 
 `sync push` validates every TOML file before applying anything — any validation error aborts the push with no changes applied (`Aborting push: N TOML validation error(s) — no changes were applied.`). For workflows it validates `$params.X` references against declared `[[operations.params]]` entries at push time, naming the file and line of a bad reference. When validation passes but the server rejects an entity, the error names the entity and file. A cron trigger that already exists on the server but is missing from local sync state is adopted by key and updated in place rather than failing on the 409 — re-running a failed push converges. Diagnostics go to stderr; `--json` data goes to stdout (pipes stay clean).


### PR DESCRIPTION
## What the issue reported

#121: the CLI/sync docs document `primitive sync push` but give no real treatment to `primitive sync diff` or `sync push --dry-run` as a preview. The only `--dry-run` mentions in the docs were the bulk-load preview and a Cloudflare deploy flag — neither is the sync preview. Since js-bao-wss#915 (closed 2026-06-09 via PR Primitive-Labs/js-bao-wss#1084), the preview is faithful: the schema gate runs in `--dry-run`/`diff` so previews match real pushes, and content hashes are no longer recorded for server-rejected ops so post-block drift stays visible.

## Verified against source

Confirmed in the stamped submodule (`be98bb81`, `cli/src/commands/sync.ts`):
- `sync diff` — "Show differences between local and remote configuration" (subcommand at line 4684).
- `sync push --dry-run` — "Show what would be changed without applying" (line 1829).
- Dry-run runs the **same** validate-first server gates as a real push ("dry-run runs the same server gates via the validate-first pass, so the same failures surface", #813/#666 — line 1932).
- Content hash is recorded only on a real successful push (`if (!dryRun)`, lines 1109/1128/1155), so a blocked/previewed entity stays pending on the next `diff`.

## What changed

- `docs/getting-started/configuring-primitive-services.md` — "Preview before you push" paragraph in The Sync Loop.
- `docs/getting-started/primitive-cli.md` — new "Previewing a push" subsection (diff + `--dry-run`, faithful-preview guarantee, schema-rejection list, drift-stays-visible).
- `guides/latest/AGENT_GUIDE_TO_PRIMITIVE_CONFIGURATION.template.md` (+ rendered build) — reference-dense "Previewing a push" section. Kept in sync with the human docs.

## Validation

- `pnpm check:examples` — green (incl. CLI gate: the new `sync diff` / `sync push --dry-run` invocations validate against `primitive-admin` source).
- `npx vitepress build docs` — green (no dead links).
- `pnpm render:guides` — rebuilt; `guides.json` unchanged.

Fixes #121