### PR TITLE
docs-next-sync: integrate issue tracker + parity-gated fence promotion (cherry-pick to next)

### DIFF
--- a/.claude/skills/docs-next-sync/SKILL.md
+++ b/.claude/skills/docs-next-sync/SKILL.md
@@ -32,6 +32,14 @@ Moving the submodules intentionally breaks the stamp gate until Step 4 restamps.
 
 The scan IS the inventory: triage every listed commit through Step 2 (commit subjects carry the PR number — `gh pr view <num> --repo Primitive-Labs/<repo>` for the description, `gh pr diff <num> --name-only` for the surface it touched: `cli/` → CLI docs, `src/client/` → client API docs, `src/app-api/` → behavior/limits, `web-admin/` → admin console page, `models.yaml` → usually internal). If the scan shows zero commits in every library, report "docs already current as of <stampedAt>" and stop. For large batches, fan the per-item investigation out to parallel subagents and collect structured verdicts.
 
+**Also scan the open issue tracker** — many open `primitive-docs` issues are *upstream-keyed*: "re-true X when js-bao-wss#NNN merges", or the parity-promotion tracker (#126, which lists one-language doc fences awaiting JS/Swift parity). The library commits in this batch are exactly what unblocks them.
+
+```bash
+gh issue list --state open --limit 100 --json number,title,body
+```
+
+For each open issue that names a library issue/PR as its blocker, check whether that blocker is actually in the **new submodule tips you just fast-forwarded to** — not merely closed upstream. A blocker that is closed on library main but not yet in your stamped tips is still deferred this pass; one that is now in-tree flips its docs issue from blocked → actionable. Fold an actionable issue's notes into the change you make for its corresponding library commit (the issue often records exactly what to say and where), and line it up for closing in Step 4.
+
 On this channel there is **no published-vs-merged distinction**: merged to library main means documentable. The gates validate against the same source (`pnpm build:source-packages` builds it), so a doc for an unreleased CLI flag or client API passes here and is held back from `main` automatically until release time.
 
 ## Step 2 — Triage every item
@@ -43,6 +51,7 @@ Classify each item before touching any doc:
 | **Not developer-facing** | Infra, internal refactors, admin/pipeline tooling, skills, CI, deploy plumbing, model/GSI changes with no API impact | **No doc change.** Record the item + "internal" in your report — silence must be a decision, not an oversight. |
 | **Factual change to documented behavior** | The change alters something a doc page or agent guide already states (a flag, a shape, a limit, an enum, a default) | Update every place that states the old fact — both human docs and agent guides. Breaking client changes (e.g. a response-envelope change) get a repo-wide sweep for the stale shape, not just the obvious page. |
 | **New developer-facing capability** | A new step kind, CLI command, client API, config surface | Propose where it lands: an existing page/guide section first, by the "capabilities live on their concept's page" rule. If it's a genuinely new area with no natural home, **suggest a new page but get the user's sign-off before creating it.** |
+| **Upstream parity now landed** | A JS/Swift parity fix in this batch closes a gap that forced a doc fence to stay one-language and inline (cross-ref the #126 promote-on-parity checklist) | **Promote the fence to the corpus.** Write *both* languages into `examples/<subject>/<op>.{ts,swift}` — verify the newly-available side against `SwiftEmitter.swift` / the JS client source, don't transcribe on faith — then replace the `{{#lang}}` inline fence with `{{ example: <subject>/<op> }}` so it re-enters the compile + parity gate. This is the standing mechanism that drains the one-language backlog as parity ships. |
 
 ## Step 3 — Write to the present tense
 
@@ -55,6 +64,7 @@ Verify anything you write against source per STYLE.md's source-of-truth map — 
 1. Mirror every human-doc change into the matching agent guide template (and vice versa); `pnpm render:guides`.
 2. **Restamp**: `pnpm stamp:sources` (preserves the next channel; rewrites `docs-sources.json` and `guides.json` `builtAgainst`, resetting the baseline for the next `--changes` scan). Only restamp once the docs actually reflect the new submodule tips — the restamp removes those commits from the next scan. If the pass made no doc changes, skip the restamp and reset the worktrees instead (see Step 1).
 3. `pnpm check:examples` (the TS-compile and CLI gates read the built submodule source on this channel) and `npx vitepress build docs`.
-4. Report: a table of every scanned commit → disposition (`internal — no change` / `updated <pages>` / `proposed: <new section/page>` awaiting user input), plus anything the sources contradicted in the docs that you couldn't resolve.
+4. **Close the issues this pass resolved.** For every open `primitive-docs` issue whose blocker is now in the stamped tips and whose docs change you made this pass, close it with evidence — what landed upstream, the stamped SHA, and what changed — or, if the work went through a PR, let `Fixes #NN` close it when that PR merges to its base. Do **not** close an issue whose blocker is closed upstream but not yet in the stamped tips; record it as still-deferred with the gating ref. As one-language fences graduate to the corpus, tick them off the #126 promote-on-parity checklist (and close #126 when it empties).
+5. Report: a table of every scanned commit → disposition (`internal — no change` / `updated <pages>` / `promoted <fence> → corpus` / `proposed: <new section/page>` awaiting user input), plus the open issues touched (`closed #NN` / `still deferred — gated on <ref>`), plus anything the sources contradicted in the docs that you couldn't resolve.
 
 Known channel caveat (fine to leave): the generated reference section (`pnpm gen:reference`) and the site build are only published from `main`, so reference output on next is a preview, not a published surface.


### PR DESCRIPTION
Cherry-pick of #128 (merged to `main`) onto `next`, so the new behavior is active on the branch `docs-next-sync` actually runs on.

Adds two standing mechanisms to the skill:
- **Step 1** scans open `primitive-docs` issues alongside the library commit scan; upstream-keyed issues become actionable once their blocker reaches the stamped submodule tips.
- **Step 2** gains an "upstream parity now landed" triage class that promotes one-language inline fences into both-language corpus pairs (draining the #126 backlog as parity ships).
- **Step 4** closes resolved issues (with evidence / `Fixes #NN`), keeps still-gated ones open, and ticks the #126 checklist.

Cherry-picked from main commit 1ff0e581.