### PR TITLE
Make BLOBS framework-glue sections generic-first (#136)

### DIFF
--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_BLOBS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_BLOBS.template.md
@@ -67,11 +67,11 @@ SHA-256 is computed client-side and used for server-side dedup. See **Upload wit
 
 ### From a file input
 
-```typescript
-const file = (document.querySelector('input[type="file"]') as HTMLInputElement).files![0];
+The upload call is the compiled [Upload](#upload) example — `client.document(documentId).blobs().upload(file)`. The only web-specific glue is pulling the `File` off an `<input>` (`File` objects are accepted directly; `filename`/`contentType` default to `file.name`/`file.type`):
 
-// File objects are accepted directly. If filename/contentType are omitted,
-// they default to file.name and file.type.
+```typescript
+// web-DOM glue: get a File from an <input type="file">, then upload it.
+const file = (document.querySelector('input[type="file"]') as HTMLInputElement).files![0];
 const { blobId } = await client.document(documentId).blobs().upload(file);
 ```
 
@@ -215,9 +215,10 @@ let payload = try await blobs.read(blobId: blobId, as: MyCodable.self)
 
 ## Service worker proxy (for `<img>` / `<video>`)
 
-`downloadUrl` requires the request to carry the user's auth token, which `<img>` tags don't do. Use `proxyUrl` if you've registered a service worker that forwards Primitive auth headers.
+The neutral blob calls here are `blobs.proxyUrl(blobId)` / `downloadUrl` (see [Download URL](#download-url-authenticated)) and `blobs.read(blobId, { as: "blob" })` (see [Read content into memory](#read-content-into-memory)). The rest is **web-DOM glue**: `downloadUrl` requires the request to carry the user's auth token, which `<img>` tags don't do, so on the web you either route through a service worker (`proxyUrl`) or read into memory and hand the element a Blob URL.
 
 ```typescript
+// web-DOM glue around proxyUrl / read — wiring an <img> src.
 if (blobs.hasServiceWorkerControl()) {
   imageElement.src = blobs.proxyUrl(blobId, {
     disposition: "inline",
@@ -259,6 +260,8 @@ Both fields are optional and accept `null` to clear. Errors surface as `BLOB_NOT
 
 ## Complete example: image upload with progress + display
 
+A **web walkthrough** composing the neutral calls already shown — [Upload](#upload), the `blobs:upload-progress` event ([Events](#events)), and `proxyUrl`/`read` ([Service worker proxy](#service-worker-proxy-for-img--video)) — into one DOM flow. The `<img>`/`URL.createObjectURL` wiring is web-DOM glue:
+
 ```typescript
 async function uploadAndDisplay(
   client: JsBaoClient,
@@ -293,6 +296,8 @@ async function uploadAndDisplay(
 ```
 
 ## Complete example: offline-ready gallery
+
+A **web walkthrough** composing [List](#listing), `prefetch` ([Offline & the upload queue](#offline--the-upload-queue)), and `proxyUrl` into a gallery loader. Only the URL-wiring is web-specific:
 
 ```typescript
 async function loadGallery(client: JsBaoClient, documentId: string) {

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_BLOBS.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_BLOBS.ts.md
@@ -79,11 +79,11 @@ SHA-256 is computed client-side and used for server-side dedup. See **Upload wit
 
 ### From a file input
 
-```typescript
-const file = (document.querySelector('input[type="file"]') as HTMLInputElement).files![0];
+The upload call is the compiled [Upload](#upload) example — `client.document(documentId).blobs().upload(file)`. The only web-specific glue is pulling the `File` off an `<input>` (`File` objects are accepted directly; `filename`/`contentType` default to `file.name`/`file.type`):
 
-// File objects are accepted directly. If filename/contentType are omitted,
-// they default to file.name and file.type.
+```typescript
+// web-DOM glue: get a File from an <input type="file">, then upload it.
+const file = (document.querySelector('input[type="file"]') as HTMLInputElement).files![0];
 const { blobId } = await client.document(documentId).blobs().upload(file);
 ```
 
@@ -265,9 +265,10 @@ The upload queue emits lifecycle events. `upload-progress` is *not* a byte-level
 
 ## Service worker proxy (for `<img>` / `<video>`)
 
-`downloadUrl` requires the request to carry the user's auth token, which `<img>` tags don't do. Use `proxyUrl` if you've registered a service worker that forwards Primitive auth headers.
+The neutral blob calls here are `blobs.proxyUrl(blobId)` / `downloadUrl` (see [Download URL](#download-url-authenticated)) and `blobs.read(blobId, { as: "blob" })` (see [Read content into memory](#read-content-into-memory)). The rest is **web-DOM glue**: `downloadUrl` requires the request to carry the user's auth token, which `<img>` tags don't do, so on the web you either route through a service worker (`proxyUrl`) or read into memory and hand the element a Blob URL.
 
 ```typescript
+// web-DOM glue around proxyUrl / read — wiring an <img> src.
 if (blobs.hasServiceWorkerControl()) {
   imageElement.src = blobs.proxyUrl(blobId, {
     disposition: "inline",
@@ -307,6 +308,8 @@ Both fields are optional and accept `null` to clear. Errors surface as `BLOB_NOT
 
 ## Complete example: image upload with progress + display
 
+A **web walkthrough** composing the neutral calls already shown — [Upload](#upload), the `blobs:upload-progress` event ([Events](#events)), and `proxyUrl`/`read` ([Service worker proxy](#service-worker-proxy-for-img--video)) — into one DOM flow. The `<img>`/`URL.createObjectURL` wiring is web-DOM glue:
+
 ```typescript
 async function uploadAndDisplay(
   client: JsBaoClient,
@@ -341,6 +344,8 @@ async function uploadAndDisplay(
 ```
 
 ## Complete example: offline-ready gallery
+
+A **web walkthrough** composing [List](#listing), `prefetch` ([Offline & the upload queue](#offline--the-upload-queue)), and `proxyUrl` into a gallery loader. Only the URL-wiring is web-specific:
 
 ```typescript
 async function loadGallery(client: JsBaoClient, documentId: string) {


### PR DESCRIPTION
## What the issue reported
The four framework-glue sections of `AGENT_GUIDE_TO_PRIMITIVE_BLOBS.template.md` lead with web wrappers. Restructure each so the framework-neutral blob call is promoted to a compile-checked corpus reference and only the thin web wiring stays inline, clearly marked. Agent-guide template only.

## What was verified
Every neutral blob call in the in-scope sections is already a compiled, parity-checked corpus example, so no new corpus ops were needed — each section now leads with / cross-references it:
- `blobs().upload(file)` → `blobs/doc-blob-upload`
- `proxyUrl` / `downloadUrl` → `blobs/doc-blob-download-url`
- `read(..., { as: "blob" })` → `blobs/doc-blob-read-formats`
- `list(...)` → `blobs/doc-blob-list-paginate`
- `prefetch(...)` → `blobs/doc-blob-offline`
- `blobs:upload-progress` → `blobs/doc-blob-events`

The wiring (`<input type="file">`, `<img>.src`, `URL.createObjectURL`, service-worker control, the progress/gallery DOM flows) is browser-only and can't compile standalone, so per the editorial rule it correctly stays as inline fences — now explicitly marked web-DOM glue.

## What changed (template only)
- **From a file input** — leads with the compiled Upload call; the `<input>`/`File` pull marked web-DOM glue.
- **Service worker proxy** — leads with `proxyUrl`/`downloadUrl` + `read`; `<img>.src` / `URL.createObjectURL` marked web-DOM glue.
- **Complete example: image upload with progress + display** — framed as a web walkthrough composing Upload + `blobs:upload-progress` + `proxyUrl`/`read`.
- **Complete example: offline-ready gallery** — framed as a web walkthrough composing List + `prefetch` + `proxyUrl`.

## Validation
- `pnpm check:examples` — passes.
- `npx vitepress build docs` — passes.
- Swift build unaffected (sections are TS-scoped; no leakage).

Fixes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)