### PR TITLE
ci: roll nightly docs-next-sync; auto-publish releases + back-merge to next

### DIFF
--- a/.claude/skills/docs-publish-release/SKILL.md
+++ b/.claude/skills/docs-publish-release/SKILL.md
@@ -75,7 +75,11 @@ Skip mechanical noise entirely: source stamps, lockfiles, rendered guide builds,
 ## Step 7 — Land and backflow
 
 1. PR the publish branch into `main` with the release-coverage table (Step 5) **and** the docs-delta summary (Step 6); merging publishes the site (publish-docs.yml verifies the channel is `production`).
-2. Backflow so `next` contains everything `main` does. **`next` is never recreated from `main`** — it carries trued-but-unreleased work a reset would destroy; you *merge* `main` into it. This release-time back-merge is the primary mechanism that keeps `next ⊇ main` (an interactive `docs-next-sync` run can optionally drain sooner, but the unattended nightly never does — it only opens PRs):
+2. Backflow so `next` contains everything `main` does. **`next` is never recreated from `main`** — it carries trued-but-unreleased work a reset would destroy; you *merge* `main` into it. This release-time back-merge is the primary mechanism that keeps `next ⊇ main` (an interactive `docs-next-sync` run can optionally drain sooner, but the unattended nightly never does — it only opens PRs).
+
+   **CI normally does this for you.** `backmerge-main-to-next.yml` fires when the publish PR (head `publish/**`) merges into `main` — whether you opened it or the automated publisher did — and performs this back-merge channel-preservingly: it takes `main`'s new content but forces `next`'s channel/stamp/pins, runs the next gates, and pushes `next` directly. So after the publish PR merges, **check that workflow succeeded** rather than running anything by hand.
+
+   Only run the back-merge manually if that workflow **failed or aborted** (it aborts and goes red on a content conflict outside the channel/stamp/pin files — exactly the case a human must resolve):
 
    ```bash
    git checkout next && git merge main

--- a/.github/workflows/backmerge-main-to-next.yml
+++ b/.github/workflows/backmerge-main-to-next.yml
@@ -1,0 +1,143 @@
+# Back-merge main into next (post-publish)
+#
+# Completes the publish loop. When a publish PR (head `publish/**`) merges into
+# `main`, this re-establishes the `next ⊇ main` invariant by merging `main` back
+# into `next` — the skill's Step 7.2, automated. It is channel-preserving: it
+# takes `main`'s new doc CONTENT but keeps `next`'s channel, stamp, and submodule
+# pins, so the production restamp never leaks onto `next`.
+#
+# `next` is unprotected, so this pushes directly — the same direct push the
+# interactive skill does by hand (this is the one CI path that writes to `next`
+# without a PR; the nightly truing still only ever opens PRs).
+#
+# Safety: it auto-resolves ONLY the channel/stamp/pin files (docs-sources.json,
+# guides.json, library_repos/*) to next's side; a conflict in any other file is a
+# real content conflict it will not guess at — it aborts the merge and fails the
+# run for a human. It also runs the next-channel gates before pushing, so a bad
+# back-merge never lands on `next`.
+#
+# Triggers on publish PRs whether opened by receive-production-release.yml
+# (automated) or by a human running docs-publish-release — so the skill's manual
+# Step 7.2 is redundant once this is live.
+#
+# NOTE: a `pull_request` workflow runs the version of this file on the PR's base
+# branch (main), so it must live on main.
+
+name: Back-merge main into next
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+  # Manual re-run: point it at an already-merged publish (or just to drain main).
+  workflow_dispatch: {}
+
+concurrency:
+  group: backmerge-main-to-next
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  backmerge:
+    # Only when a publish PR actually merged (skip mere closes and other PRs).
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true &&
+       startsWith(github.event.pull_request.head.ref, 'publish/'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout next
+        uses: actions/checkout@v5
+        with:
+          ref: next
+          token: ${{ secrets.DOCS_REPO_PAT }}
+          fetch-depth: 0
+
+      - name: Configure git auth and identity
+        run: |
+          git config --global url."https://x-access-token:${{ secrets.DOCS_REPO_PAT }}@github.com/".insteadOf "https://github.com/"
+          git config --global user.email "docs-bot@primitivelabs.com"
+          git config --global user.name "primitive-docs-bot"
+
+      - name: Initialize submodules at next's pinned SHAs
+        run: git submodule update --init --recursive
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Back-merge main into next (channel-preserving)
+        id: merge
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_NUM: ${{ github.event.pull_request.number }}
+        run: |
+          git fetch -q origin main
+
+          # No-ff, no-commit so we can force next's channel/pins before committing.
+          set +e
+          git merge --no-ff --no-commit origin/main
+          set -e
+
+          if ! git rev-parse -q --verify MERGE_HEAD >/dev/null 2>&1; then
+            echo "noop=true" >> "$GITHUB_OUTPUT"
+            echo "\`next\` already contains \`main\` — nothing to back-merge." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          # Abort on any conflict outside the channel/stamp/pin surface — those are
+          # real content conflicts a human must resolve.
+          CONFLICTS="$(git diff --name-only --diff-filter=U || true)"
+          UNEXPECTED="$(printf '%s\n' "$CONFLICTS" \
+            | grep -vE '^(docs-sources\.json|guides/latest/guides\.json|library_repos/)' \
+            | grep -v '^$' || true)"
+          if [ -n "$UNEXPECTED" ]; then
+            echo "::error::Back-merge hit content conflicts it won't auto-resolve — resolve by hand (skill Step 7.2):"
+            printf '%s\n' "$UNEXPECTED"
+            git merge --abort
+            exit 1
+          fi
+
+          # Force next's channel + pins, whether they conflicted or were cleanly
+          # taken from main. HEAD is next's pre-merge tip during the merge, so this
+          # restores next's docs-sources.json/guides.json and submodule gitlinks —
+          # keeping next on the next channel at its own (release-or-newer) pins.
+          git checkout HEAD -- docs-sources.json guides/latest/guides.json library_repos
+          git submodule update --init --recursive
+
+          # The merge may have brought main's package.json/lock (e.g. release pin
+          # bumps or infra dep changes) — re-sync node_modules before building.
+          pnpm install
+
+          # Rebuild the next source surface and re-stamp so the stamp matches the
+          # restored pins + installed packages (check:examples asserts this).
+          pnpm build:source-packages
+          pnpm stamp:sources --channel next
+
+          git add -A
+          git commit -m "Back-merge main into next after publishing ${HEAD_REF:-main} (#${PR_NUM:-manual}) — channel preserved"
+          echo "noop=false" >> "$GITHUB_OUTPUT"
+
+      - name: Validate next after back-merge
+        if: steps.merge.outputs.noop == 'false'
+        run: |
+          pnpm check:examples
+          npx vitepress build docs
+
+      - name: Push next
+        if: steps.merge.outputs.noop == 'false'
+        run: |
+          git push origin HEAD:next
+          echo "Back-merged \`main\` into \`next\` and pushed." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/docs-next-sync.yml
+++ b/.github/workflows/docs-next-sync.yml
@@ -11,6 +11,22 @@
 # firing on every push. Production releases are a separate tier — they trigger
 # `docs-publish-release` via receive-production-release.yml, not this workflow.
 #
+# ROLLING PR, not one-per-night. The PR is opened on a FIXED branch
+# (`docs-next-sync/auto`), so when a prior pass hasn't merged yet the next run
+# force-pushes the same branch and updates that one PR in place rather than
+# opening a second, overlapping one. Each update is a complete, gate-green,
+# independently-mergeable superset of everything new since the last MERGE (the
+# branch is recreated from `next` every run — no accumulation, no chain). On
+# merge, `next`'s stamp advances and the next run starts fresh and small.
+#
+# The scan step (below) picks its baseline accordingly: if that rolling PR
+# branch already exists, it scans against the branch's docs-sources.json stamp
+# (the tips the LAST RUN trued to) rather than next's merged stamp — so an
+# un-merged PR doesn't make us re-derive the same window every night. We only
+# pay for a Claude run when the library tips have actually moved past the last
+# attempt. The agent itself still trues from next's merged baseline, keeping the
+# PR a complete superset; only the cheap has_work gate uses the branch stamp.
+#
 # NOTE: repository_dispatch only triggers workflows that live on the default
 # branch (main), so this file must stay on main even though the work it does
 # targets `next`.
@@ -123,9 +139,34 @@ jobs:
         # tips actually moved past what the docs were last trued against. Keeps
         # no-op dispatches (and manual re-tests) to seconds instead of minutes.
         id: scan
+        env:
+          PR_BRANCH: docs-next-sync/auto
         run: |
           git submodule foreach 'git fetch -q origin || true' || true
+
+          # Baseline selection. By default the scan reads next's docs-sources.json
+          # (the last MERGED stamp). But if the rolling PR branch already exists,
+          # an earlier pass is still un-merged — scan against THAT branch's stamp
+          # (the tips the last run trued to) so we don't re-derive the same window
+          # every night. We only re-run when the library tips moved past the last
+          # attempt. This overlays the branch's docs-sources.json just for the
+          # scan, then restores next's so the agent step trues from the merged
+          # baseline (keeping the PR a complete superset).
+          BASELINE="next (last merged stamp)"
+          if git fetch -q origin "$PR_BRANCH" 2>/dev/null \
+             && git show "FETCH_HEAD:docs-sources.json" > /tmp/pr-sources.json 2>/dev/null; then
+            cp docs-sources.json /tmp/next-sources.json
+            cp /tmp/pr-sources.json docs-sources.json
+            BASELINE="open PR branch $PR_BRANCH (last attempt)"
+          fi
+          echo "Scan baseline: $BASELINE" | tee -a "$GITHUB_STEP_SUMMARY"
+
           node scripts/stamp-sources.mjs --changes | tee /tmp/scan.txt || true
+
+          # Restore next's stamp if we overlaid the PR branch's, so every later
+          # step (including the agent) sees next's merged baseline.
+          [ -f /tmp/next-sources.json ] && cp /tmp/next-sources.json docs-sources.json || true
+
           if [ "${{ github.event.inputs.force }}" = "true" ]; then
             echo "Forced run — exercising the agent path regardless of the scan." | tee -a "$GITHUB_STEP_SUMMARY"
             echo "has_work=true" >> "$GITHUB_OUTPUT"
@@ -133,7 +174,7 @@ jobs:
             echo "has_work=true" >> "$GITHUB_OUTPUT"
           else
             echo "has_work=false" >> "$GITHUB_OUTPUT"
-            echo "No library commits since the last stamp — nothing to true." >> "$GITHUB_STEP_SUMMARY"
+            echo "No library commits since the last attempt — nothing new to true." >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Run docs-next-sync with Claude Code CLI
@@ -271,13 +312,21 @@ jobs:
         with:
           token: ${{ secrets.DOCS_REPO_PAT }}
           base: next
-          branch: docs-next-sync/auto-${{ github.run_number }}
-          delete-branch: true
+          # FIXED branch (no run number): rolling PR. If a prior pass is still
+          # un-merged this force-pushes the same branch and updates that one PR in
+          # place instead of opening a second, overlapping one. The branch is
+          # recreated from `next` each run, so every update is a complete superset
+          # — never a chain. delete-branch:false keeps the branch alive between
+          # runs so the scan step above can read its stamp as the baseline.
+          branch: docs-next-sync/auto
+          delete-branch: false
           commit-message: |
             docs-next-sync: true next against ${{ steps.ctx.outputs.submodule }} (automated)
           title: "docs-next-sync: ${{ steps.ctx.outputs.submodule }} changes (automated)"
           body: |
             Automated `docs-next-sync` pass against the library main tips, triggered by the nightly release ${{ steps.ctx.outputs.submodule }}#${{ steps.ctx.outputs.issue }}.
+
+            > **Rolling PR.** This PR is updated in place each night until it merges — every update is a complete, gate-green superset of everything new since the last merge (branched fresh from `next`, not stacked). Merge it to advance the baseline; the next nightly then starts fresh and small.
 
             ${{ steps.report.outputs.body }}
 

--- a/.github/workflows/receive-production-release.yml
+++ b/.github/workflows/receive-production-release.yml
@@ -1,17 +1,34 @@
 # Docs publish-release (production tier)
 #
 # Receives the `production-release` repository_dispatch that js-bao-wss fires on
-# push to a `deploy/production/**` branch, and files an issue prompting a
-# human-in-the-loop `docs-publish-release` run (merge `next` → `main` at the
-# release SHA). This workflow does NOT publish anything itself — publishing is a
-# deliberate human action; it only surfaces the release so the skill has the
-# summary it needs.
+# push to a `deploy/production/**` branch, and runs the project's
+# docs-publish-release skill UNATTENDED with the Claude Code CLI to build the
+# publish branch that merges `next` into `main` at the release SHA. The result is
+# a pull request into `main` that is ready for a human to merge — merging it
+# publishes the site (publish-docs.yml, which enforces the production channel).
+#
+# This workflow never merges and never publishes: it leaves a reviewed-then-merge
+# PR. If the unattended pass cannot produce a clean, mergeable branch (an
+# unresolvable conflict, a red gate with no mechanical fix, a coverage gap it
+# can't write), the run FAILS — a red Actions run is the signal to publish by
+# hand. A best-effort-but-flagged branch is still opened as a DRAFT PR.
 #
 # Pairs with the nightly tier (docs-next-sync.yml): nightlies true `next`,
 # production releases publish a slice of `next` to `main`.
 #
+# POST-MERGE FOLLOW-UP (not automated): after the publish PR merges, the skill's
+# Step 7.2 back-merge (`main` -> `next`, keeping the next channel) still has to
+# run so `next ⊇ main`. The PR body calls this out; it is a deliberate, separate
+# step (there is no main->next automation in this repo).
+#
 # NOTE: repository_dispatch only triggers workflows on the default branch (main),
 # so this file must stay on main.
+#
+# Secrets used (already configured in this repo):
+#   ANTHROPIC_API_KEY — Claude Code CLI auth
+#   DOCS_REPO_PAT     — checkout + private submodule auth + `gh` (skill triage,
+#                       filing parity issues, pushing the publish branch, opening
+#                       the PR)
 #
 # Payload (client_payload) from js-bao-wss notify-docs-release.yml:
 #   sha           — full deployed js-bao-wss commit
@@ -19,8 +36,9 @@
 #   release_file  — releases/YYYY-MM-DD-<sha8>.md (path in js-bao-wss)
 #   release_notes — the full contents of that release summary (starts with
 #                   "# Production release YYYY-MM-DD (sha8)")
+#   source_url    — link to the source release issue/commit, if any
 
-name: Docs Publish-Release (notify)
+name: Docs Publish-Release (agent)
 
 on:
   repository_dispatch:
@@ -34,18 +52,58 @@ on:
         required: true
         type: string
       release_notes:
-        description: 'Release summary markdown (optional; a stub is filed if omitted)'
+        description: 'Release summary markdown (optional; coverage hint only)'
         required: false
         type: string
 
+# One publish pass at a time: the skill builds a branch, repins packages and
+# restamps. Queue rather than cancel.
+concurrency:
+  group: docs-publish-release
+  cancel-in-progress: false
+
 permissions:
-  issues: write
+  contents: write
+  pull-requests: write
 
 jobs:
-  file-publish-issue:
+  publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
-      - name: Build issue fields from payload
+      - name: Checkout primitive-docs (next)
+        # Check out `next` with full history: the skill walks `next` to pick the
+        # merge point (Step 2) and builds the publish branch off `main` (fetched
+        # below). The submodules are needed at their pinned SHAs to start.
+        uses: actions/checkout@v5
+        with:
+          ref: next
+          token: ${{ secrets.DOCS_REPO_PAT }}
+          fetch-depth: 0
+
+      - name: Fetch main and configure git
+        run: |
+          git fetch -q origin main
+          git config --global url."https://x-access-token:${{ secrets.DOCS_REPO_PAT }}@github.com/".insteadOf "https://github.com/"
+          git config --global user.email "docs-bot@primitivelabs.com"
+          git config --global user.name "primitive-docs-bot"
+
+      - name: Initialize submodules at their pinned SHAs
+        run: git submodule update --init --recursive
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build context from payload
         id: ctx
         env:
           EVENT_NAME: ${{ github.event_name }}
@@ -64,43 +122,229 @@ jobs:
           fi
 
           SHA8="${SHA:0:8}"
-          # Fall back to deriving the date from the release filename, then to "unknown".
+          # Fall back to deriving the date from the release filename, then "unknown".
           if [ -z "$DATE" ] && [ -n "$FILE" ]; then
             DATE="$(basename "$FILE" | sed -E 's/^([0-9]{4}-[0-9]{2}-[0-9]{2})-.*/\1/')"
           fi
           [ -z "$DATE" ] && DATE="unknown"
 
-          echo "sha8=$SHA8" >> "$GITHUB_OUTPUT"
-          echo "src_url=$SRC_URL" >> "$GITHUB_OUTPUT"
-          echo "title=Production release $DATE ($SHA8) — publish docs" >> "$GITHUB_OUTPUT"
+          if [ -n "$SHA" ]; then HAVE_SHA=true; else HAVE_SHA=false; fi
+
           {
+            echo "have_sha=$HAVE_SHA"
+            echo "sha=$SHA"
+            echo "sha8=$SHA8"
+            echo "date=$DATE"
+            echo "src_url=$SRC_URL"
+            echo "publish_branch=publish/$DATE-$SHA8"
+            echo "title=Publish docs: production release $DATE ($SHA8)"
             echo "notes<<NOTES_EOF"
             if [ -n "$NOTES" ]; then echo "$NOTES"; else echo "_(no release summary in the payload — pull it from js-bao-wss \`$FILE\`.)_"; fi
             echo "NOTES_EOF"
           } >> "$GITHUB_OUTPUT"
 
-      - name: File or skip the publish issue
-        env:
-          GH_TOKEN: ${{ secrets.DOCS_REPO_PAT }}
-          GH_REPO: ${{ github.repository }}
-          TITLE: ${{ steps.ctx.outputs.title }}
-          SHA8: ${{ steps.ctx.outputs.sha8 }}
-          NOTES: ${{ steps.ctx.outputs.notes }}
-          SRC_URL: ${{ steps.ctx.outputs.src_url }}
-        run: |
-          # Idempotent: a re-dispatch for the same release must not file a duplicate.
-          existing="$(gh issue list --state open --search "Production release ($SHA8) in:title" --json number --jq '.[0].number' || true)"
-          if [ -n "$existing" ]; then
-            echo "Open publish issue already exists (#$existing) for $SHA8 — skipping." >> "$GITHUB_STEP_SUMMARY"
-            exit 0
+          if [ "$HAVE_SHA" != "true" ]; then
+            echo "::error::No release SHA in the event — cannot resolve the release to publish."
           fi
 
-          {
-            printf '%s\n\n' "A production release has been deployed. Publish the docs by running the **docs-publish-release** skill (\`/docs-publish-release\`) against the summary below — it merges \`next\` into \`main\` at the release SHA, never past it. This is a human-in-the-loop step; the receiver only files this issue."
-            [ -n "$SRC_URL" ] && printf 'Source release issue: %s\n\n' "$SRC_URL"
-            printf '%s\n\n' "---"
-            printf '%s\n' "$NOTES"
-          } > /tmp/publish-issue-body.md
+      - name: Run docs-publish-release with Claude Code CLI
+        if: steps.ctx.outputs.have_sha == 'true'
+        id: claude
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ secrets.DOCS_REPO_PAT }}
+          SHA: ${{ steps.ctx.outputs.sha }}
+          DATE: ${{ steps.ctx.outputs.date }}
+          SRC_URL: ${{ steps.ctx.outputs.src_url }}
+          PUBLISH_BRANCH: ${{ steps.ctx.outputs.publish_branch }}
+          NOTES: ${{ steps.ctx.outputs.notes }}
+        run: |
+          npm install -g @anthropic-ai/claude-code
 
-          url="$(gh issue create --title "$TITLE" --body-file /tmp/publish-issue-body.md)"
-          echo "Filed publish issue: $url" >> "$GITHUB_STEP_SUMMARY"
+          # Static instructions (quoted heredoc → no shell interpolation).
+          cat > /tmp/prompt.txt <<'PROMPT'
+          You are running UNATTENDED in CI to PUBLISH the documentation for a
+          production release of the Primitive platform.
+
+          Your job: use the project's docs-publish-release skill to build the
+          publish branch that merges `next` into `main` AT THE RELEASE SHA, drive
+          it to green gates, and leave it ready for a human to merge. Begin now by
+          invoking the docs-publish-release skill (the `/docs-publish-release`
+          command) for the release described at the end of this prompt, and carry
+          it through Step 6 under the rules below.
+
+          CRITICAL unattended-run rules:
+          - The release to publish is the SHA + summary appended below. Treat the
+            summary as a coverage hint only; verify every fact against the
+            submodule source at the release SHA (never trust the summary).
+          - Build the publish branch named EXACTLY the branch printed below as
+            "Publish branch". Create it off `main` (Step 3), merging the correct
+            merge point from `next` (Step 2 selects it from next's stamp vs the
+            release SHA), pin js-bao-wss to the release SHA, repin packages and
+            restamp onto the PRODUCTION channel (Step 4), verify the summary is
+            covered (Step 5), and write the docs-delta summary (Step 6).
+          - You MAY create the branch and run `git commit` / `git merge` LOCALLY —
+            that is how the publish branch is built. You must NOT run `git push`,
+            `gh pr create`, `gh pr merge`, or anything that publishes. The workflow
+            pushes the branch and opens the PR into `main`.
+          - Do NOT perform Step 7 (opening the PR, and the `main`->`next`
+            backflow). The workflow opens the PR; the backflow is a separate
+            post-merge step. Stop after Step 6 with the publish branch checked out
+            and ALL changes committed on it.
+          - Drive the gates to GREEN against the production surface: repin the
+            published packages (Step 4), then run `pnpm check:examples` and
+            `npx vitepress build docs`. A slice that relies on a merged-but-
+            unpublished package API is NOT publishable this release — revert those
+            doc changes on the publish branch (they stay on `next`) and record the
+            held items in the report. The gates are the arbiter of what `main` can
+            state.
+          - Non-interactive: NEVER ask a question or wait for input. For a
+            genuinely ambiguous editorial call, pick the most conservative option
+            and note it. FILE parity/platform-gap issues per
+            `.claude/ISSUE_FILING.md` (the `ios` label for Swift-client gaps, no
+            assignee) and record the numbers in the report.
+          - Finish by writing your complete report to
+            `.docs-publish-release-report.md` at the repo root. Its FIRST line MUST
+            be a status line:
+              * `PUBLISH_STATUS: ready`   — the publish branch is built, committed,
+                and all gates are green: a human can merge it as-is.
+              * `PUBLISH_STATUS: blocked` — followed by the blocker, if you could
+                NOT produce a clean mergeable branch. Even when blocked, leave the
+                best-effort branch committed so a human can take it over.
+            After the status line, include: the Step 5 release-coverage table, the
+            Step 6 docs-delta summary (developer audience — NO branches/channels/
+            stamps/truing mechanics), any held/unpublishable items, and the parity
+            issues you filed.
+          PROMPT
+
+          # Append the (untrusted) payload context as plain data.
+          {
+            echo
+            echo "Release to publish:"
+            echo "- js-bao-wss release SHA: ${SHA}"
+            echo "- Release date: ${DATE}"
+            echo "- Publish branch (use EXACTLY this name): ${PUBLISH_BRANCH}"
+            echo "- Source release issue/commit: ${SRC_URL:-(none)}"
+            echo "- Release summary (\"# Production release …\"; a hint — verify against source):"
+            echo "${NOTES:-(none)}"
+          } >> /tmp/prompt.txt
+
+          # Opus, not Sonnet: source-verification + coverage judgement.
+          set +e
+          timeout 50m claude -p "$(cat /tmp/prompt.txt)" \
+            --model opus \
+            --permission-mode bypassPermissions \
+            --output-format json \
+            > /tmp/claude_out.json 2> /tmp/claude_err.log
+          code=$?
+          set -e
+
+          echo "claude exit code: $code"
+          echo "----- stderr (tail) -----"; tail -40 /tmp/claude_err.log || true
+          if jq -e . /tmp/claude_out.json >/dev/null 2>&1; then
+            echo "----- run stats -----"
+            jq -r '"is_error=\(.is_error)  num_turns=\(.num_turns)  cost_usd=\(.total_cost_usd)  duration_ms=\(.duration_ms)"' /tmp/claude_out.json || true
+            echo "::group::Agent final message (.result)"
+            jq -r '.result // "(no result field)"' /tmp/claude_out.json || true
+            echo "::endgroup::"
+          else
+            echo "----- raw stdout (tail) -----"; tail -40 /tmp/claude_out.json || true
+          fi
+
+          if [ "$code" -ne 0 ]; then
+            echo "::error::Claude Code CLI exited $code"; exit "$code"
+          fi
+          if jq -e '.is_error == true' /tmp/claude_out.json >/dev/null 2>&1; then
+            echo "::error::Claude reported is_error=true"; exit 1
+          fi
+
+      - name: Read agent report
+        if: steps.ctx.outputs.have_sha == 'true'
+        id: report
+        run: |
+          if [ -f .docs-publish-release-report.md ]; then
+            echo "::group::Disposition report (.docs-publish-release-report.md)"
+            cat .docs-publish-release-report.md
+            echo "::endgroup::"
+            { echo "body<<REPORT_EOF"; cat .docs-publish-release-report.md; echo "REPORT_EOF"; } >> "$GITHUB_OUTPUT"
+          else
+            echo "No .docs-publish-release-report.md was written — see the agent final message above."
+            echo "body=The agent produced no report file. Review the run logs (agent final message)." >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Detect publish branch
+        if: steps.ctx.outputs.have_sha == 'true'
+        id: pub
+        env:
+          PUBLISH_BRANCH: ${{ steps.ctx.outputs.publish_branch }}
+        run: |
+          git fetch -q origin main || true
+          CUR="$(git rev-parse --abbrev-ref HEAD || true)"
+          STATUS="$(grep -m1 '^PUBLISH_STATUS:' .docs-publish-release-report.md 2>/dev/null | awk '{print $2}' || true)"
+          AHEAD="$(git rev-list --count origin/main..HEAD 2>/dev/null || echo 0)"
+          echo "current branch: '$CUR'  commits ahead of main: $AHEAD  reported status: '${STATUS:-none}'"
+          if [ "$CUR" = "$PUBLISH_BRANCH" ] && [ "${AHEAD:-0}" -gt 0 ]; then
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+            echo "status=${STATUS:-unknown}" >> "$GITHUB_OUTPUT"
+          else
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "The agent did not leave a committed publish branch — the run will fail (publish by hand)." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Push publish branch and open PR into main
+        if: steps.ctx.outputs.have_sha == 'true' && steps.pub.outputs.ready == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.DOCS_REPO_PAT }}
+          PUBLISH_BRANCH: ${{ steps.ctx.outputs.publish_branch }}
+          TITLE: ${{ steps.ctx.outputs.title }}
+          SRC_URL: ${{ steps.ctx.outputs.src_url }}
+          STATUS: ${{ steps.pub.outputs.status }}
+          # Passed as an env var (not interpolated into the script): the report is
+          # agent-authored markdown with backticks/quotes/$ — `${{ }}` inlining
+          # would break quoting or run as shell.
+          REPORT: ${{ steps.report.outputs.body }}
+        run: |
+          # Force-push: the branch is rebuilt from main on every run, so a
+          # re-dispatch for the same release updates the same PR in place.
+          git push --force origin "HEAD:refs/heads/$PUBLISH_BRANCH"
+
+          {
+            if [ "$STATUS" = "ready" ]; then
+              echo "Automated \`docs-publish-release\` pass. Merging this PR publishes the documentation site for this production release (publish-docs.yml enforces the production channel)."
+            else
+              echo "> ⚠️ **Blocked / best-effort.** The automated pass could not certify a clean, mergeable branch — see the status line in the report below. Resolve the blocker before merging."
+            fi
+            echo
+            [ -n "$SRC_URL" ] && printf 'Source release issue: %s\n\n' "$SRC_URL"
+            printf '%s\n' "$REPORT"
+            echo
+            echo "---"
+            echo "**After merging**, run the skill's Step 7.2 back-merge so \`next ⊇ main\` (\`git checkout next && git merge main\`, then \`pnpm stamp:sources --channel next\` and re-init submodules). This is not automated."
+            echo
+            echo "> Generated unattended by the Claude Code CLI. Verify facts against source before merging."
+          } > /tmp/pr-body.md
+
+          DRAFT=""
+          [ "$STATUS" != "ready" ] && DRAFT="--draft"
+
+          if gh pr view "$PUBLISH_BRANCH" --json number >/dev/null 2>&1; then
+            gh pr edit "$PUBLISH_BRANCH" --title "$TITLE" --body-file /tmp/pr-body.md
+            url="$(gh pr view "$PUBLISH_BRANCH" --json url --jq .url)"
+            echo "Updated existing publish PR: $url" >> "$GITHUB_STEP_SUMMARY"
+          else
+            url="$(gh pr create --base main --head "$PUBLISH_BRANCH" --title "$TITLE" --body-file /tmp/pr-body.md $DRAFT)"
+            echo "Opened publish PR: $url" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Fail the run if no publish PR was produced
+        # No silent skips: a missing release SHA or an agent that didn't leave a
+        # committed publish branch fails the run so the release is surfaced
+        # (publish by hand). A hard agent failure already fails the run above.
+        if: steps.pub.outputs.ready != 'true'
+        run: |
+          if [ "${{ steps.ctx.outputs.have_sha }}" != "true" ]; then
+            echo "::error::No release SHA in the event — cannot resolve the release to publish."
+          else
+            echo "::error::docs-publish-release did not produce a ready-to-merge PR — publish this release by hand."
+          fi
+          exit 1


### PR DESCRIPTION
Three changes to the docs CI automation, all targeting `main` (these workflows must live on the default branch — `repository_dispatch` / `pull_request` base only fire there).

## 1. Nightly `docs-next-sync`: one rolling PR + skip re-derivation
`docs-next-sync.yml`
- **Fixed branch** `docs-next-sync/auto` → the nightly updates the *same* PR in place instead of opening a new overlapping one each night. The branch is recreated from `next` each run, so every update is a complete, gate-green, independently-mergeable superset (no chain). `delete-branch: false` keeps it alive between runs.
- **Baseline guard** in the scan step: if that PR branch exists, scan against *its* `docs-sources.json` stamp (the last attempt's tips) instead of `next`'s merged stamp — so a Claude run only fires when the library tips actually moved past the last attempt. The agent still trues from `next`'s merged baseline, keeping the PR a complete superset.

Net: at most one open next-sync PR; re-runs only when upstream moved.

## 2. Production release: auto-publish into a ready-to-merge PR
`receive-production-release.yml`
- On a `production-release` dispatch, runs `docs-publish-release` unattended via the Claude CLI (same pattern as the nightly) — builds the `publish/<date>-<sha8>` branch that merges `next`→`main` at the release SHA, repins/restamps onto the production channel, drives the gates green, and opens a PR into `main` **ready to merge** (was: just filed an issue).
- The agent builds/commits the branch locally but never pushes/PRs/merges; the workflow force-pushes the deterministic branch (a re-dispatch updates the same PR) and opens it. A flagged best-effort branch opens as a **draft**; if no committed branch is produced, the run **fails red** (no fallback issue).

## 3. Post-publish back-merge `main`→`next` (NEW)
`backmerge-main-to-next.yml`
- Completes the loop: when a `publish/*` PR merges into `main`, merges `main` back into `next` so `next ⊇ main` — the skill's manual **Step 7.2, automated**.
- **Channel-preserving:** takes `main`'s new doc content but forces `next`'s channel/stamp/pins (`docs-sources.json`, `guides.json`, `library_repos/*`) to next's side, then re-installs, rebuilds source packages, and restamps `--channel next`. The production restamp never leaks onto `next`.
- **Safe:** auto-resolves *only* those channel files; any other (content) conflict aborts the merge and **fails red** for a human. Runs the next-channel gates (`check:examples`, vitepress build) before pushing.
- `next` is unprotected, so it pushes directly — the same push the interactive skill does by hand. Triggers for both automated and human-opened publish PRs, so the skill's manual Step 7.2 becomes redundant once this is live.

## Validation
- All three files parse as YAML; every `run:` script passes `bash -n`.
- Confirmed `stamp-sources.mjs --changes` derives its baseline solely from `docs-sources.json` (HEAD-vs-stamp check is `--check`-only), so the next-sync overlay guard is correct.
- Confirmed `next` has no branch protection (direct push is viable) and `check:examples` ends with `stamp-sources --check` (so the back-merge restamps to stay green).

## Follow-ups (not in this PR)
- These are dispatch/PR-driven; worth a manual `workflow_dispatch` smoke test of the publish + back-merge flow against a recent release SHA after merge.
- `docs-publish-release` SKILL.md Step 7.2 is now automated for publish PRs — worth a note in the skill that the back-merge runs in CI. Happy to do that as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
