### PR TITLE
Default sync/db examples to the auto-resolved sync dir (#146)

### DIFF
--- a/docs/getting-started/api-integrations.md
+++ b/docs/getting-started/api-integrations.md
@@ -47,10 +47,10 @@ The value resolves server-side when the request is proxied and is never exposed 
 
 ```bash
 # Initialize config directory
-primitive sync init --dir ./config
+primitive sync init
 
 # Push integration config to server
-primitive sync push --dir ./config
+primitive sync push
 
 # Test the integration
 primitive integrations test weather-api

--- a/docs/getting-started/blobs-and-files.md
+++ b/docs/getting-started/blobs-and-files.md
@@ -29,7 +29,7 @@ ttlTier = "permanent"
 Push it:
 
 ```bash
-primitive sync push --dir ./config
+primitive sync push
 ```
 
 Or via the CLI:

--- a/docs/getting-started/configuring-primitive-services.md
+++ b/docs/getting-started/configuring-primitive-services.md
@@ -14,12 +14,14 @@ Both edit the same underlying configuration. Most teams explore in the console a
 `primitive sync` round-trips your app's configuration between the server and a directory of TOML files:
 
 ```bash
-primitive sync init --dir ./config     # create the directory structure
-primitive sync pull --dir ./config    # download current server config as TOML
+primitive sync init     # create the directory structure
+primitive sync pull     # download current server config as TOML
 # ... edit files locally ...
-primitive sync diff --dir ./config    # see what would change
-primitive sync push --dir ./config    # apply your changes to the server
+primitive sync diff     # see what would change
+primitive sync push     # apply your changes to the server
 ```
+
+The sync directory auto-resolves to `.primitive/sync/<env>/<appId>/` — one isolated slot per environment. Pass `--dir <path>` to override it with a fixed directory.
 
 The files live in your repo, so configuration changes ride the same workflow as code: branches, diffs, reviews, rollbacks. `sync push` validates every file before applying anything — a validation error aborts the push with no changes applied — and reports the file and entity behind any failure.
 

--- a/docs/getting-started/primitive-cli.md
+++ b/docs/getting-started/primitive-cli.md
@@ -434,10 +434,10 @@ See [Invoking Workflows: On a Schedule](./workflows.md#on-a-schedule-cron-trigge
 Generate TypeScript types from your database-type TOML schemas:
 
 ```bash
-primitive databases codegen --sync-dir ./config --output ./src/generated/db
+primitive databases codegen -o ./src/generated/db
 ```
 
-Reads `[models.*]` schema blocks and `[[operations]]` from your database-type TOML and emits typed record interfaces, operation param types, and result types. Keeps client-side types aligned with the server-authoritative schema.
+Reads from the database-type TOML in the auto-resolved sync directory; pass `--sync-dir <path>` to override it. Reads `[models.*]` schema blocks and `[[operations]]` from your database-type TOML and emits typed record interfaces, operation param types, and result types. Keeps client-side types aligned with the server-authoritative schema.
 
 ### Blob Buckets
 

--- a/docs/getting-started/prompts.md
+++ b/docs/getting-started/prompts.md
@@ -26,7 +26,7 @@ Summarize the following text in a {{ input.style || 'brief' }} style:
 ```
 
 ```bash
-primitive sync push --dir ./config
+primitive sync push
 ```
 
 ## Template Variables

--- a/docs/getting-started/workflows.md
+++ b/docs/getting-started/workflows.md
@@ -37,7 +37,7 @@ htmlBody = "{{ steps.generate-message.content }}"
 Push it to the server:
 
 ```bash
-primitive sync push --dir ./config
+primitive sync push
 ```
 
 `sync push` creates and updates the workflow's active configuration in place. Once `status = "active"`, the workflow can be invoked.
@@ -344,19 +344,19 @@ primitive workflows runs steps <workflow-id> <run-id>
 ## Syncing Workflow Config
 
 ```bash
-# Initialize config
-primitive sync init --dir ./config
+# Initialize config (sync dir auto-resolves to .primitive/sync/<env>/<appId>/)
+primitive sync init
 
 # Pull current server config
-primitive sync pull --dir ./config
+primitive sync pull
 
 # Edit TOML files locally...
 
 # See what changed
-primitive sync diff --dir ./config
+primitive sync diff
 
 # Push changes
-primitive sync push --dir ./config
+primitive sync push
 ```
 
 When a workflow needs flags `sync push` doesn't carry (`requiresClientApply`, `syncCallable`, queue caps), set them with `primitive workflows update`.

--- a/docs/getting-started/working-with-databases.md
+++ b/docs/getting-started/working-with-databases.md
@@ -30,12 +30,14 @@ primitive databases create "Product Catalog" --type products
 
 ### 2. Define Operations
 
-Pull your config directory, then define operations in `config/database-types/products.toml`:
+Pull your config directory, then define operations in the synced `database-types/products.toml`:
 
 ```bash
-primitive sync init --dir ./config
-primitive sync pull --dir ./config
+primitive sync init
+primitive sync pull
 ```
+
+The sync directory auto-resolves to `.primitive/sync/<env>/<appId>/`; pass `--dir <path>` to override it.
 
 ```toml
 [type]
@@ -69,7 +71,7 @@ params = '{"name":{"type":"string","required":true},"price":{"type":"number","re
 ### 3. Push to Server
 
 ```bash
-primitive sync push --dir ./config
+primitive sync push
 ```
 
 ### 4. Use in Your App
@@ -307,10 +309,10 @@ primitive databases schema generate inventory
 Generate record interfaces and operation param/result types from your database-type TOML:
 
 ```bash
-primitive databases codegen --sync-dir ./config --output ./src/generated/db
+primitive databases codegen -o ./src/generated/db
 ```
 
-This reads the `[models.*]` blocks and `[[operations]]` definitions and emits typed interfaces — one per model, plus typed params and results per operation. Fields and params restricted to a fixed set of string values become TypeScript string-literal unions, so invalid values are caught at compile time (enum params are also validated server-side).
+Codegen reads the database-type TOML from the auto-resolved sync directory; pass `--sync-dir <path>` to override it. This reads the `[models.*]` blocks and `[[operations]]` definitions and emits typed interfaces — one per model, plus typed params and results per operation. Fields and params restricted to a fixed set of string values become TypeScript string-literal unions, so invalid values are caught at compile time (enum params are also validated server-side).
 
 ## Bulk CSV Import
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_CONFIGURATION.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_CONFIGURATION.md
@@ -5,13 +5,13 @@ Guidelines for AI agents configuring Primitive services. Everything Primitive do
 ## The sync loop
 
 ```bash
-primitive sync init --dir ./config     # create directory structure
-primitive sync pull --dir ./config    # download server config as TOML
-primitive sync diff --dir ./config    # preview changes
-primitive sync push --dir ./config    # apply local TOML to the server
+primitive sync init     # create directory structure
+primitive sync pull     # download server config as TOML
+primitive sync diff     # preview changes
+primitive sync push     # apply local TOML to the server
 ```
 
-With project-scoped environments (`.primitive/config.json`), omit `--dir` and the sync directory auto-resolves to `.primitive/sync/<env>/<appId>/` — one isolated slot per environment, so a `pull --env staging` never touches production state.
+With project-scoped environments (`.primitive/config.json`), the sync directory auto-resolves to `.primitive/sync/<env>/<appId>/` — one isolated slot per environment, so a `pull --env staging` never touches production state. Pass `--dir <path>` only to override that location with a fixed directory shared across environments.
 
 ## Pull snapshots and revert
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_CONFIGURATION.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_CONFIGURATION.template.md
@@ -5,13 +5,13 @@ Guidelines for AI agents configuring Primitive services. Everything Primitive do
 ## The sync loop
 
 ```bash
-primitive sync init --dir ./config     # create directory structure
-primitive sync pull --dir ./config    # download server config as TOML
-primitive sync diff --dir ./config    # preview changes
-primitive sync push --dir ./config    # apply local TOML to the server
+primitive sync init     # create directory structure
+primitive sync pull     # download server config as TOML
+primitive sync diff     # preview changes
+primitive sync push     # apply local TOML to the server
 ```
 
-With project-scoped environments (`.primitive/config.json`), omit `--dir` and the sync directory auto-resolves to `.primitive/sync/<env>/<appId>/` — one isolated slot per environment, so a `pull --env staging` never touches production state.
+With project-scoped environments (`.primitive/config.json`), the sync directory auto-resolves to `.primitive/sync/<env>/<appId>/` — one isolated slot per environment, so a `pull --env staging` never touches production state. Pass `--dir <path>` only to override that location with a fixed directory shared across environments.
 
 ## Pull snapshots and revert
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.swift.md
@@ -69,7 +69,7 @@ Database setup has two phases: **configuration** (via CLI and TOML config files)
 Initialize a sync directory and create config files:
 
 ```bash
-primitive sync init --dir ./config
+primitive sync init
 ```
 
 Create a database type config with operations in `config/database-types/project.toml`:
@@ -106,7 +106,7 @@ params = '{"title":{"type":"string","required":true},"projectId":{"type":"string
 Push configuration to the server:
 
 ```bash
-primitive sync push --dir ./config
+primitive sync push
 ```
 
 ### 2. Use databases in app code

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.template.md
@@ -49,7 +49,7 @@ Database setup has two phases: **configuration** (via CLI and TOML config files)
 Initialize a sync directory and create config files:
 
 ```bash
-primitive sync init --dir ./config
+primitive sync init
 ```
 
 Create a database type config with operations in `config/database-types/project.toml`:
@@ -86,7 +86,7 @@ params = '{"title":{"type":"string","required":true},"projectId":{"type":"string
 Push configuration to the server:
 
 ```bash
-primitive sync push --dir ./config
+primitive sync push
 ```
 
 ### 2. Use databases in app code
@@ -264,8 +264,10 @@ primitive databases import-csv <database-id> <file.csv> --model <name> \
 Generate TypeScript record interfaces and op param/result types from the database-type TOML:
 
 ```bash
-primitive databases codegen --sync-dir ./config --output ./src/generated/db
+primitive databases codegen -o ./src/generated/db
 ```
+
+Codegen reads the database-type TOML from the auto-resolved sync directory (`.primitive/sync/<env>/<appId>/`); pass `--sync-dir <path>` only when overriding it. With no `-o`, generated files land in `<sync-dir>/database-types/generated/`.
 
 **Codegen enum / union / required typing.** When a field or an operation param restricts a string to a fixed set of values, codegen emits a TypeScript string-literal union (e.g. `status: "open" | "in-progress" | "closed"`) instead of `string`, and enum params are validated server-side as well. Fields that operation params mark `required` are emitted as non-optional on the generated record interface. This keeps generated types aligned with the server's validation instead of widening everything to `string`.
 {{/lang}}

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.ts.md
@@ -66,7 +66,7 @@ Database setup has two phases: **configuration** (via CLI and TOML config files)
 Initialize a sync directory and create config files:
 
 ```bash
-primitive sync init --dir ./config
+primitive sync init
 ```
 
 Create a database type config with operations in `config/database-types/project.toml`:
@@ -103,7 +103,7 @@ params = '{"title":{"type":"string","required":true},"projectId":{"type":"string
 Push configuration to the server:
 
 ```bash
-primitive sync push --dir ./config
+primitive sync push
 ```
 
 ### 2. Use databases in app code
@@ -291,8 +291,10 @@ primitive databases import-csv <database-id> <file.csv> --model <name> \
 Generate TypeScript record interfaces and op param/result types from the database-type TOML:
 
 ```bash
-primitive databases codegen --sync-dir ./config --output ./src/generated/db
+primitive databases codegen -o ./src/generated/db
 ```
+
+Codegen reads the database-type TOML from the auto-resolved sync directory (`.primitive/sync/<env>/<appId>/`); pass `--sync-dir <path>` only when overriding it. With no `-o`, generated files land in `<sync-dir>/database-types/generated/`.
 
 **Codegen enum / union / required typing.** When a field or an operation param restricts a string to a fixed set of values, codegen emits a TypeScript string-literal union (e.g. `status: "open" | "in-progress" | "closed"`) instead of `string`, and enum params are validated server-side as well. Fields that operation params mark `required` are emitted as non-optional on the generated record interface. This keeps generated types aligned with the server's validation instead of widening everything to `string`.
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_INTEGRATIONS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_INTEGRATIONS.swift.md
@@ -373,15 +373,18 @@ primitive integrations tests runs <id> [--limit 20] [--group <comparison-group>]
 ### Sync (TOML <-> server)
 
 ```bash
-primitive sync init [--dir ./config]    # create config tree + .primitive-sync.json
-primitive sync pull [--dir ./config]    # server -> local TOML
-primitive sync push [--dry-run] [--force] [--dir ./config]
-primitive sync diff [--dir ./config]
+primitive sync init     # create config tree + .primitive-sync.json
+primitive sync pull     # server -> local TOML
+primitive sync push [--dry-run] [--force]
+primitive sync diff
 ```
 
-`init` creates these subdirs: `integrations/`, `webhooks/`, `cron-triggers/`, `blob-buckets/`, `prompts/`, `workflows/`, `database-types/`, `rule-sets/`, `group-type-configs/`, `collection-type-configs/`, `email-templates/`. Integration files live at `config/integrations/<key>.toml`.
+The sync directory auto-resolves to `.primitive/sync/<env>/<appId>/`; pass `--dir <path>` to override it. `init` creates these subdirs: `integrations/`, `webhooks/`, `cron-triggers/`, `blob-buckets/`, `prompts/`, `workflows/`, `database-types/`, `rule-sets/`, `group-type-configs/`, `collection-type-configs/`, `email-templates/`. Integration files live at `integrations/<key>.toml`.
 
 ## Typical Workflow
+
+# This worked example pins a fixed sync dir (`--dir ./config`) so the file paths
+# below are concrete; omit `--dir` to use the default `.primitive/sync/<env>/<appId>/`.
 
 ```bash
 # Initial setup
@@ -407,8 +410,8 @@ defaultMethod = "POST"
 EOF
 
 # Push and configure
-primitive sync push --dry-run
-primitive sync push
+primitive sync push --dir ./config --dry-run
+primitive sync push --dir ./config
 primitive secrets set OPENAI_API_KEY --value sk-...
 primitive integrations test <integration-id> --method POST --path /v1/responses \
   --body '{"model":"gpt-4.1-mini","input":"hi"}'

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_INTEGRATIONS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_INTEGRATIONS.template.md
@@ -366,15 +366,18 @@ primitive integrations tests runs <id> [--limit 20] [--group <comparison-group>]
 ### Sync (TOML <-> server)
 
 ```bash
-primitive sync init [--dir ./config]    # create config tree + .primitive-sync.json
-primitive sync pull [--dir ./config]    # server -> local TOML
-primitive sync push [--dry-run] [--force] [--dir ./config]
-primitive sync diff [--dir ./config]
+primitive sync init     # create config tree + .primitive-sync.json
+primitive sync pull     # server -> local TOML
+primitive sync push [--dry-run] [--force]
+primitive sync diff
 ```
 
-`init` creates these subdirs: `integrations/`, `webhooks/`, `cron-triggers/`, `blob-buckets/`, `prompts/`, `workflows/`, `database-types/`, `rule-sets/`, `group-type-configs/`, `collection-type-configs/`, `email-templates/`. Integration files live at `config/integrations/<key>.toml`.
+The sync directory auto-resolves to `.primitive/sync/<env>/<appId>/`; pass `--dir <path>` to override it. `init` creates these subdirs: `integrations/`, `webhooks/`, `cron-triggers/`, `blob-buckets/`, `prompts/`, `workflows/`, `database-types/`, `rule-sets/`, `group-type-configs/`, `collection-type-configs/`, `email-templates/`. Integration files live at `integrations/<key>.toml`.
 
 ## Typical Workflow
+
+# This worked example pins a fixed sync dir (`--dir ./config`) so the file paths
+# below are concrete; omit `--dir` to use the default `.primitive/sync/<env>/<appId>/`.
 
 ```bash
 # Initial setup
@@ -400,8 +403,8 @@ defaultMethod = "POST"
 EOF
 
 # Push and configure
-primitive sync push --dry-run
-primitive sync push
+primitive sync push --dir ./config --dry-run
+primitive sync push --dir ./config
 primitive secrets set OPENAI_API_KEY --value sk-...
 primitive integrations test <integration-id> --method POST --path /v1/responses \
   --body '{"model":"gpt-4.1-mini","input":"hi"}'

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_INTEGRATIONS.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_INTEGRATIONS.ts.md
@@ -373,15 +373,18 @@ primitive integrations tests runs <id> [--limit 20] [--group <comparison-group>]
 ### Sync (TOML <-> server)
 
 ```bash
-primitive sync init [--dir ./config]    # create config tree + .primitive-sync.json
-primitive sync pull [--dir ./config]    # server -> local TOML
-primitive sync push [--dry-run] [--force] [--dir ./config]
-primitive sync diff [--dir ./config]
+primitive sync init     # create config tree + .primitive-sync.json
+primitive sync pull     # server -> local TOML
+primitive sync push [--dry-run] [--force]
+primitive sync diff
 ```
 
-`init` creates these subdirs: `integrations/`, `webhooks/`, `cron-triggers/`, `blob-buckets/`, `prompts/`, `workflows/`, `database-types/`, `rule-sets/`, `group-type-configs/`, `collection-type-configs/`, `email-templates/`. Integration files live at `config/integrations/<key>.toml`.
+The sync directory auto-resolves to `.primitive/sync/<env>/<appId>/`; pass `--dir <path>` to override it. `init` creates these subdirs: `integrations/`, `webhooks/`, `cron-triggers/`, `blob-buckets/`, `prompts/`, `workflows/`, `database-types/`, `rule-sets/`, `group-type-configs/`, `collection-type-configs/`, `email-templates/`. Integration files live at `integrations/<key>.toml`.
 
 ## Typical Workflow
+
+# This worked example pins a fixed sync dir (`--dir ./config`) so the file paths
+# below are concrete; omit `--dir` to use the default `.primitive/sync/<env>/<appId>/`.
 
 ```bash
 # Initial setup
@@ -407,8 +410,8 @@ defaultMethod = "POST"
 EOF
 
 # Push and configure
-primitive sync push --dry-run
-primitive sync push
+primitive sync push --dir ./config --dry-run
+primitive sync push --dir ./config
 primitive secrets set OPENAI_API_KEY --value sk-...
 primitive integrations test <integration-id> --method POST --path /v1/responses \
   --body '{"model":"gpt-4.1-mini","input":"hi"}'

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_PROMPTS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_PROMPTS.swift.md
@@ -432,9 +432,11 @@ Upload size limit: **10 MB**. Attachments are sent to the model as file parts (`
 ## Sync (TOML version control)
 
 ```bash
-primitive sync pull [app-id] [--dir ./config]
-primitive sync push [app-id] [--dir ./config] [--dry-run]
+primitive sync pull [app-id]
+primitive sync push [app-id] [--dry-run]
 ```
+
+The sync directory auto-resolves to `.primitive/sync/<env>/<appId>/`; pass `--dir <path>` to override it.
 
 ### Directory layout (verified in `cli/src/commands/sync.ts` — see the layout block in the `sync` command's help text)
 
@@ -584,13 +586,13 @@ primitive prompts tests runs <prompt-id> --json     # compare runs across config
 ### Version control
 
 ```bash
-primitive sync pull --dir ./config
-git add ./config && git commit -m "Snapshot prompts"
+primitive sync pull
+git add .primitive/sync && git commit -m "Snapshot prompts"
 
-# edit ./config/prompts/*.toml
+# edit the synced prompts/*.toml files
 
-primitive sync push --dir ./config --dry-run        # preview
-primitive sync push --dir ./config                  # apply
+primitive sync push --dry-run        # preview
+primitive sync push                  # apply
 ```
 
 ---

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_PROMPTS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_PROMPTS.template.md
@@ -424,9 +424,11 @@ Upload size limit: **10 MB**. Attachments are sent to the model as file parts (`
 ## Sync (TOML version control)
 
 ```bash
-primitive sync pull [app-id] [--dir ./config]
-primitive sync push [app-id] [--dir ./config] [--dry-run]
+primitive sync pull [app-id]
+primitive sync push [app-id] [--dry-run]
 ```
+
+The sync directory auto-resolves to `.primitive/sync/<env>/<appId>/`; pass `--dir <path>` to override it.
 
 ### Directory layout (verified in `cli/src/commands/sync.ts` — see the layout block in the `sync` command's help text)
 
@@ -576,13 +578,13 @@ primitive prompts tests runs <prompt-id> --json     # compare runs across config
 ### Version control
 
 ```bash
-primitive sync pull --dir ./config
-git add ./config && git commit -m "Snapshot prompts"
+primitive sync pull
+git add .primitive/sync && git commit -m "Snapshot prompts"
 
-# edit ./config/prompts/*.toml
+# edit the synced prompts/*.toml files
 
-primitive sync push --dir ./config --dry-run        # preview
-primitive sync push --dir ./config                  # apply
+primitive sync push --dry-run        # preview
+primitive sync push                  # apply
 ```
 
 ---

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_PROMPTS.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_PROMPTS.ts.md
@@ -429,9 +429,11 @@ Upload size limit: **10 MB**. Attachments are sent to the model as file parts (`
 ## Sync (TOML version control)
 
 ```bash
-primitive sync pull [app-id] [--dir ./config]
-primitive sync push [app-id] [--dir ./config] [--dry-run]
+primitive sync pull [app-id]
+primitive sync push [app-id] [--dry-run]
 ```
+
+The sync directory auto-resolves to `.primitive/sync/<env>/<appId>/`; pass `--dir <path>` to override it.
 
 ### Directory layout (verified in `cli/src/commands/sync.ts` — see the layout block in the `sync` command's help text)
 
@@ -581,13 +583,13 @@ primitive prompts tests runs <prompt-id> --json     # compare runs across config
 ### Version control
 
 ```bash
-primitive sync pull --dir ./config
-git add ./config && git commit -m "Snapshot prompts"
+primitive sync pull
+git add .primitive/sync && git commit -m "Snapshot prompts"
 
-# edit ./config/prompts/*.toml
+# edit the synced prompts/*.toml files
 
-primitive sync push --dir ./config --dry-run        # preview
-primitive sync push --dir ./config                  # apply
+primitive sync push --dry-run        # preview
+primitive sync push                  # apply
 ```
 
 ---

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.swift.md
@@ -384,7 +384,7 @@ autoAddCreator = true          # auto-add creator as member when the config exis
 Push to the server:
 
 ```bash
-primitive sync push --dir ./config
+primitive sync push
 ```
 
 **Defaults & gotchas:**
@@ -577,7 +577,7 @@ autoAddCreator = true
 Push both configs:
 
 ```bash
-primitive sync push --dir ./config
+primitive sync push
 ```
 
 ### Rule CEL context
@@ -659,7 +659,7 @@ Test a rule set with a simulated request, or debug against a real user's live me
   ))
 ```
 
-`result.trace` shows every `isMemberOf`/`memberGroups`/`hasRole` call and its result. To update rule sets, edit the TOML file and run `primitive sync push --dir ./config`.
+`result.trace` shows every `isMemberOf`/`memberGroups`/`hasRole` call and its result. To update rule sets, edit the TOML file and run `primitive sync push`.
 
 ## Rule Sets for Collection Management
 
@@ -732,7 +732,7 @@ collectionType = "class-reports"
 ruleSetName    = "class-reports-rules"
 ```
 
-Then push with `primitive sync push --dir ./config`. The SDK equivalents are `client.collectionTypeConfigs.{ list, get, create, update, delete }` (parallel to `client.groupTypeConfigs.*`).
+Then push with `primitive sync push`. The SDK equivalents are `client.collectionTypeConfigs.{ list, get, create, update, delete }` (parallel to `client.groupTypeConfigs.*`).
 
 ## Common Patterns
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.template.md
@@ -229,7 +229,7 @@ autoAddCreator = true          # auto-add creator as member when the config exis
 Push to the server:
 
 ```bash
-primitive sync push --dir ./config
+primitive sync push
 ```
 
 **Defaults & gotchas:**
@@ -405,7 +405,7 @@ autoAddCreator = true
 Push both configs:
 
 ```bash
-primitive sync push --dir ./config
+primitive sync push
 ```
 
 ### Rule CEL context
@@ -459,7 +459,7 @@ Test a rule set with a simulated request, or debug against a real user's live me
 
 {{ example: users-and-groups/rule-sets-test }}
 
-`result.trace` shows every `isMemberOf`/`memberGroups`/`hasRole` call and its result. To update rule sets, edit the TOML file and run `primitive sync push --dir ./config`.
+`result.trace` shows every `isMemberOf`/`memberGroups`/`hasRole` call and its result. To update rule sets, edit the TOML file and run `primitive sync push`.
 
 ## Rule Sets for Collection Management
 
@@ -532,7 +532,7 @@ collectionType = "class-reports"
 ruleSetName    = "class-reports-rules"
 ```
 
-Then push with `primitive sync push --dir ./config`. The SDK equivalents are `client.collectionTypeConfigs.{ list, get, create, update, delete }` (parallel to `client.groupTypeConfigs.*`).
+Then push with `primitive sync push`. The SDK equivalents are `client.collectionTypeConfigs.{ list, get, create, update, delete }` (parallel to `client.groupTypeConfigs.*`).
 
 ## Common Patterns
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.ts.md
@@ -369,7 +369,7 @@ autoAddCreator = true          # auto-add creator as member when the config exis
 Push to the server:
 
 ```bash
-primitive sync push --dir ./config
+primitive sync push
 ```
 
 **Defaults & gotchas:**
@@ -559,7 +559,7 @@ autoAddCreator = true
 Push both configs:
 
 ```bash
-primitive sync push --dir ./config
+primitive sync push
 ```
 
 ### Rule CEL context
@@ -640,7 +640,7 @@ Test a rule set with a simulated request, or debug against a real user's live me
   });
 ```
 
-`result.trace` shows every `isMemberOf`/`memberGroups`/`hasRole` call and its result. To update rule sets, edit the TOML file and run `primitive sync push --dir ./config`.
+`result.trace` shows every `isMemberOf`/`memberGroups`/`hasRole` call and its result. To update rule sets, edit the TOML file and run `primitive sync push`.
 
 ## Rule Sets for Collection Management
 
@@ -713,7 +713,7 @@ collectionType = "class-reports"
 ruleSetName    = "class-reports-rules"
 ```
 
-Then push with `primitive sync push --dir ./config`. The SDK equivalents are `client.collectionTypeConfigs.{ list, get, create, update, delete }` (parallel to `client.groupTypeConfigs.*`).
+Then push with `primitive sync push`. The SDK equivalents are `client.collectionTypeConfigs.{ list, get, create, update, delete }` (parallel to `client.groupTypeConfigs.*`).
 
 ## Common Patterns
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.swift.md
@@ -931,7 +931,7 @@ firedAt = "{{now}}"
 ```
 
 ```bash
-primitive sync push --dir ./config
+primitive sync push
 ```
 
 The TOML key `key` maps to the API field `triggerKey`. The field name is `cron` (not `schedule`).
@@ -1171,12 +1171,12 @@ Setting `status = "active"` without an active config or revision returns: `Canno
 ## CLI
 
 ```bash
-# Sync (recommended for everything)
-primitive sync init --dir ./config
-primitive sync pull --dir ./config
-primitive sync diff --dir ./config
-primitive sync push --dir ./config --dry-run
-primitive sync push --dir ./config
+# Sync (recommended for everything; sync dir auto-resolves to .primitive/sync/<env>/<appId>/)
+primitive sync init
+primitive sync pull
+primitive sync diff
+primitive sync push --dry-run
+primitive sync push
 
 # Workflow CRUD (when not using sync)
 primitive workflows list [--status active] [--json]

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md
@@ -931,7 +931,7 @@ firedAt = "{{now}}"
 ```
 
 ```bash
-primitive sync push --dir ./config
+primitive sync push
 ```
 
 The TOML key `key` maps to the API field `triggerKey`. The field name is `cron` (not `schedule`).
@@ -1139,12 +1139,12 @@ Setting `status = "active"` without an active config or revision returns: `Canno
 ## CLI
 
 ```bash
-# Sync (recommended for everything)
-primitive sync init --dir ./config
-primitive sync pull --dir ./config
-primitive sync diff --dir ./config
-primitive sync push --dir ./config --dry-run
-primitive sync push --dir ./config
+# Sync (recommended for everything; sync dir auto-resolves to .primitive/sync/<env>/<appId>/)
+primitive sync init
+primitive sync pull
+primitive sync diff
+primitive sync push --dry-run
+primitive sync push
 
 # Workflow CRUD (when not using sync)
 primitive workflows list [--status active] [--json]

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.ts.md
@@ -931,7 +931,7 @@ firedAt = "{{now}}"
 ```
 
 ```bash
-primitive sync push --dir ./config
+primitive sync push
 ```
 
 The TOML key `key` maps to the API field `triggerKey`. The field name is `cron` (not `schedule`).
@@ -1177,12 +1177,12 @@ Setting `status = "active"` without an active config or revision returns: `Canno
 ## CLI
 
 ```bash
-# Sync (recommended for everything)
-primitive sync init --dir ./config
-primitive sync pull --dir ./config
-primitive sync diff --dir ./config
-primitive sync push --dir ./config --dry-run
-primitive sync push --dir ./config
+# Sync (recommended for everything; sync dir auto-resolves to .primitive/sync/<env>/<appId>/)
+primitive sync init
+primitive sync pull
+primitive sync diff
+primitive sync push --dry-run
+primitive sync push
 
 # Workflow CRUD (when not using sync)
 primitive workflows list [--status active] [--json]


### PR DESCRIPTION
## What the issue reported
Several sync/database guides still taught the legacy `--dir ./config` / `--sync-dir ./config` override as the default form, even though the CLI now defaults the sync directory to `.primitive/sync/<env>/<appId>/` in project mode. New projects copy the old form and end up overriding the sync dir repo-wide.

## Verified against source
- `library_repos/js-bao-wss/cli/src/lib/sync-paths.ts` — `resolveSyncDir` defaults to `<projectRoot>/.primitive/sync/<env>/<appId>/`; `--dir` is the legacy override; backups resolve to `.primitive/sync-backups/<env>/<appId>/`.
- `cli/src/commands/databases.ts` codegen — defaults sync-dir to `.primitive/sync/<env>/<appId>/`, output to `<sync-dir>/database-types/generated/`, and accepts `-o, --output`.
- The issue's sub-claim that `CONFIGURATION.template.md` was out of sync with the rendered `.md` is **moot** — they matched; the real fix was the leading `--dir` in both.

## What changed
Swept **all** occurrences (full sweep, not just the cited subset — guide-sync rule):
- **6 guide templates**: CONFIGURATION, DATABASES, INTEGRATIONS, WORKFLOWS, PROMPTS, USERS_AND_GROUPS — sync examples default to the no-flag form; `--dir`/`--sync-dir` shown only as an explicit override (kept the DATABASES "Override with a fixed path" demo and the INTEGRATIONS worked example, which now consistently pins `--dir ./config` with a note).
- **7 human-docs pages**: configuring-primitive-services, primitive-cli, working-with-databases, workflows, prompts, api-integrations, blobs-and-files.
- `databases codegen` → `primitive databases codegen -o <out>` (drops `--sync-dir ./config`).
- Rendered guides regenerated (`pnpm render:guides`).

## Validation
- `pnpm check:examples` — pass (435 CLI invocations validated against submodule `primitive-admin`, TOML valid, stamp gate green).
- `npx vitepress build docs` — pass (no dead links).

Fixes #146