### PR TITLE
docs-next-sync: js-bao-wss changes (automated)

### DIFF
--- a/docs-sources.json
+++ b/docs-sources.json
@@ -1,13 +1,13 @@
 {
   "channel": "next",
-  "stampedAt": "2026-06-23",
+  "stampedAt": "2026-06-24",
   "libraries": {
     "js-bao-wss": {
-      "commit": "b1dc864e000e4f95a55d397bb85c65bf47d1f18e",
+      "commit": "12a0fc9b5f07e27fd985168aa01d6bdb75efd6dc",
       "npm": {
-        "js-bao-wss-client": "2.0.1",
+        "js-bao-wss-client": "2.0.2",
         "js-bao": "0.5.1",
-        "primitive-admin": "1.0.50"
+        "primitive-admin": "1.0.51"
       }
     },
     "primitive-app-dev": {

--- a/docs/getting-started/workflows.md
+++ b/docs/getting-started/workflows.md
@@ -314,6 +314,56 @@ capabilities = ["membership"]
 
 [`iterate-users`](#iterate-users) is system-only — it fans out across the entire user roster, which no single caller has the standing to do. A workflow that uses it must set `runAs = "system"`, or the server rejects it when you push.
 
+### Acting on Behalf of a User
+
+A system run acts as the app, not as any one member — but a per-user job often needs to work *about* a specific user: read the documents they can see, run a database operation under their access rules, or attribute an event to them. The `*ForUser` step variants do exactly that. Each takes an explicit `userId` **subject** and operates as if it were checking that user, while the run's actor stays the system principal for the audit trail — the workflow acts *about* the user, never *as* them.
+
+These steps are **system-only** — a `runAs = "caller"` workflow that calls one is rejected — and the subject must be a member of the app, or the step fails. `userId` can be set on the step or inherited from `input.userId`, so a child workflow fanned out by [`iterate-users`](#iterate-users) gets the iterated user as its subject with no wiring:
+
+```toml
+[[steps]]
+id = "ensure-profile"
+kind = "document.getOrCreateWithAliasForUser"
+userId = "{{ input.userId }}"
+aliasKey = "profile"
+title = "Profile"
+# permission = "write"   # the subject's grant on a freshly created doc; default "write"
+
+[[steps]]
+id = "assignments"
+kind = "database.queryForUser"
+userId = "{{ input.userId }}"
+databaseId = "{{ input.classroomDbId }}"
+operationName = "listAssignments"
+saveAs = "assignments"
+
+[[steps]]
+id = "track"
+kind = "analytics.writeForUser"
+userId = "{{ input.userId }}"
+action = "profile.processed"
+feature = "onboarding"
+```
+
+A `database.*ForUser` step evaluates the operation's CEL access rules and database triggers as the **subject** — `user.userId`, `hasRole(...)`, and `isMemberOf(...)` all refer to that user — even though the actor recorded on the run stays the system principal.
+
+The subject-user steps:
+
+| Kind | Returns |
+|---|---|
+| `user.get` | The subject's profile: `{ userId, email, name, appRole, rootDocId, disabled }` |
+| `user.resolve` | Resolve a subject by `userId` or `email`; `{ userId: null }` when no app member matches, else `{ userId, user }` |
+| `document.resolveAliasForUser` | Resolve the subject's user-scoped alias (app-privileged); `{ documentId: null }` on miss |
+| `document.listForUser` | Documents visible to the subject — direct and root-document grants — as `{ items, cursor }` |
+| `document.getForUser` | One document as the subject sees it: `{ document, permission }`, or `{ document: null }` when they have no effective access. Pass `systemBypass = true` for an app-privileged read by id |
+| `document.getOrCreateWithAliasForUser` | Ensure a per-subject document exists (created by the system actor, with the alias and a default `write` grant to the subject): `{ documentId, aliasKey, userId, created }` |
+| `database.*ForUser` | `queryForUser` / `mutateForUser` / `countForUser` / `aggregateForUser` / `pipelineForUser` / `applyToQueryForUser` — the matching `database.*` step, run under the subject's access rules and trigger context |
+| `analytics.writeForUser` | Emit an analytics event attributed to the subject |
+
+`document.listForUser` covers the subject's direct and root-document grants; documents reachable only through a group or collection aren't included yet.
+
+Once a subject method hands back a concrete `documentId`, the ordinary `document.query` / `save` / `patch` / `delete` steps read and write it app-privileged — there are no separate `*ForUser` write kinds. Those CRUD steps also accept an inline subject alias, `documentAlias = { scope = "user", aliasKey = "...", userId = "..." }`, which resolves the subject's alias in place and fails the step if it doesn't exist.
+
 ## Testing and Debugging Workflows
 
 **Test cases** live alongside the workflow and run against the real engine:
@@ -389,6 +439,8 @@ Every step has an `id` (unique within the workflow) and a `kind` (the step type)
 | `blob.upload` / `blob.download` / `blob.signedUrl` | Read, write, or sign blob URLs |
 | `analytics.write` / `analytics.query` | Emit analytics events or query server-side aggregates |
 | `noop` | Return `{ message, payload }`; useful as a placeholder |
+
+System workflows add subject-user variants — `user.get` / `user.resolve`, `document.*ForUser`, `database.*ForUser`, and `analytics.writeForUser` — for acting about a specific user; see [Acting on Behalf of a User](#acting-on-behalf-of-a-user).
 
 Steps that reach across the network — `llm.chat`, `gemini.generate`, the `database.*` steps, and `email.send` — are bounded by a timeout: 120 seconds for the LLM and Gemini steps, 30 seconds for database and email. Override it per step with a `timeout` field (in milliseconds). A step that exceeds its timeout fails without retrying, recording a failed step-run rather than hanging the run.
 
@@ -716,7 +768,7 @@ groupId = "{{ input.teamId }}"
 userId = "{{ input.userId }}"   # or email = "...", not both
 ```
 
-Group steps evaluate the group type's rule sets like any other caller; rules can match workflow-issued operations with `fromWorkflow("workflowKey")` — see [Access Control](./access-control.md).
+Group steps evaluate the group type's rule sets like any other caller; rules can match workflow-issued operations with `fromWorkflow("workflowKey")` — see [Access Control](./access-control.md). In a [system run](#system-workflows), `addMember` and `removeMember` record the app's system principal as the member's `addedBy` — not the admin or trigger that started the run.
 
 ### `collect`
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.swift.md
@@ -309,7 +309,7 @@ A missing `documentId`/`modelName` (or `recordId` on a write), or a `documentId`
 
 **Caller-mode ACL.** When the run is `runAs: "caller"` (the default — see [Execution identity](#execution-identity-runas-system-workflows)), every op enforces the caller's per-document permission: `query`/`queryOne`/`count` need `reader`, `save`/`patch` need `read-write`, `delete` needs `owner`. A `null`/insufficient permission throws `DocumentAccessDeniedError` (non-retryable) — a templated/user-supplied `documentId` can't bypass the ACL. `runAs: "system"` runs app-privileged (no per-caller check).
 
-**Targeting by alias.** Supply a `documentAlias { scope, aliasKey }` block instead of `documentId` (exactly one of the two). `scope = "user"` resolves the caller's own alias (forces `userId = caller`; requires `runAs: "caller"`); `scope = "app"` resolves an app-scoped alias after checking the caller's effective permission. A non-resolving alias fails the step like a bad `documentId` (Option A — hard fail).
+**Targeting by alias.** Supply a `documentAlias { scope, aliasKey }` block instead of `documentId` (exactly one of the two). In a caller run, `scope = "user"` resolves the caller's own alias (forces `userId = caller`); `scope = "app"` resolves an app-scoped alias after checking the caller's effective permission. In a **system** run, a `scope = "user"` alias requires an explicit subject `userId` on the block — `documentAlias { scope = "user", aliasKey, userId }` — resolved app-privileged (see [subject-user methods](#subject-user-methods-system-workflows)). A non-resolving alias fails the step like a bad `documentId` (Option A — hard fail).
 
 ```toml
 [[steps]]
@@ -354,7 +354,7 @@ userId = "{{ input.userId }}"   # OR email = "...", not both
 
 `addMember` is idempotent. With `email`, returns `{ status: "pending_signup", invitationId, inviteToken, ... }` if the email has no AppUser yet.
 
-Group operations evaluate the group type's CEL rules. For workflow-issued operations, rules can match `fromWorkflow("workflowKey")`.
+Group operations evaluate the group type's CEL rules. For workflow-issued operations, rules can match `fromWorkflow("workflowKey")`. In a system run, `addMember`/`removeMember` record `sys:<appId>` as the membership's `addedBy` (not the admin/cron/webhook that initiated the run).
 
 ### `collect`
 
@@ -873,6 +873,40 @@ capabilities = ["membership"]
 `membership` gates the `group.addMember` / `group.removeMember` steps in a **system** run — without the grant they reject (`group.addMember requires the 'membership' capability`). Read-only group steps (`checkMembership`, `listMembers`, `listUserMemberships`) are never gated, and caller runs are governed by access rules, not capabilities, so the gate never applies to them.
 
 **`iterate-users` is system-only.** A workflow containing an `iterate-users` step must set `runAs = "system"` — otherwise it's rejected at save time (`'iterate-users' is system-only and may appear only in a runAs:"system" workflow`).
+
+### Subject-user methods (system workflows)
+
+A system run can act **about** a specific app user without impersonating them — the run's actor stays `sys:<appId>` for audit; `userId` is an explicit **subject** parameter. The `*ForUser` step kinds are **system-only** (calling one from a `runAs: "caller"` run throws non-retryably: `<kind> is only supported in runAs:"system" workflows`). In each, `userId` may be set on the step or inherited from `input.userId` (e.g. the iterated subject under `iterate-users`). The subject must be an `AppUser` of the app, or the step fails non-retryably (`Subject user <id> is not a member of app <appId>`). These reads need no `capabilities` grant — being a system run is the gate.
+
+| Kind | Key fields | Output |
+|---|---|---|
+| `user.get` | `userId` | `{ userId, email, name, appRole, rootDocId, disabled }` |
+| `user.resolve` | `userId` **or** `email` | `{ userId: null }` on no app-member match, else `{ userId, user }` (`user` shaped like `user.get`) |
+| `document.resolveAliasForUser` | `userId`, `aliasKey` | `{ documentId: string \| null, aliasKey, userId }` — app-privileged (alias existence ≠ subject access); `null` on miss (vs. the inline `documentAlias.userId` form, which hard-fails) |
+| `document.listForUser` | `userId`, `limit?`, `includeRoot?` (default `true`), `ownerOnly?`, `tag?`, `cursor?`, `forward?` | `{ items: [DocumentInfo...], cursor? }` — direct + root grants only (group/collection-derived discovery not yet included) |
+| `document.getForUser` | `userId`, `documentId`, `systemBypass?` | `{ document: DocumentInfo \| null, permission? }` — requires the subject's effective (direct + group) permission by default (`{ document: null }` when none); `systemBypass: true` reads by id app-privileged (`permission: "system"`) |
+| `document.getOrCreateWithAliasForUser` | `userId`, `aliasKey`, `title?`, `permission?` (`read`\|`write`\|`owner`, default `write`), `tags?` | `{ documentId, aliasKey, userId, created }` — created with `createdBy = sys:<appId>`; subject gets the alias + the default grant; race-safe |
+| `database.queryForUser` / `mutateForUser` / `countForUser` / `aggregateForUser` / `pipelineForUser` / `applyToQueryForUser` | same fields as the base `database.*` kind, plus `userId` | base kind's output; CEL rules + DB triggers evaluate as the **subject** (`user.userId`, `hasRole`, `isMemberOf` refer to the subject), actor stays system. `ok`/verdict semantics match the base kind |
+| `analytics.writeForUser` | `userId`, `action`, `feature` | event attributed to the subject; system actor + workflow run id carried in the event context for audit |
+
+```toml
+[[steps]]
+id = "ensure"
+kind = "document.getOrCreateWithAliasForUser"
+userId = "{{ input.userId }}"   # explicit subject, or inherited from input.userId
+aliasKey = "profile"
+title = "Profile"
+
+[[steps]]
+id = "assignments"
+kind = "database.queryForUser"
+userId = "{{ input.userId }}"
+databaseId = "{{ input.classroomDbId }}"
+operationName = "listAssignments"
+saveAs = "assignments"
+```
+
+Once a subject method returns a concrete `documentId`, the app-privileged `document.query` / `save` / `patch` / `delete` steps read/write it — there are **no** `*ForUser` write kinds. The CRUD `document.*` steps also accept `documentAlias { scope = "user", aliasKey, userId }` to resolve a subject's alias inline (hard-fails on miss).
 
 ## Inbound webhooks
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md
@@ -309,7 +309,7 @@ A missing `documentId`/`modelName` (or `recordId` on a write), or a `documentId`
 
 **Caller-mode ACL.** When the run is `runAs: "caller"` (the default — see [Execution identity](#execution-identity-runas-system-workflows)), every op enforces the caller's per-document permission: `query`/`queryOne`/`count` need `reader`, `save`/`patch` need `read-write`, `delete` needs `owner`. A `null`/insufficient permission throws `DocumentAccessDeniedError` (non-retryable) — a templated/user-supplied `documentId` can't bypass the ACL. `runAs: "system"` runs app-privileged (no per-caller check).
 
-**Targeting by alias.** Supply a `documentAlias { scope, aliasKey }` block instead of `documentId` (exactly one of the two). `scope = "user"` resolves the caller's own alias (forces `userId = caller`; requires `runAs: "caller"`); `scope = "app"` resolves an app-scoped alias after checking the caller's effective permission. A non-resolving alias fails the step like a bad `documentId` (Option A — hard fail).
+**Targeting by alias.** Supply a `documentAlias { scope, aliasKey }` block instead of `documentId` (exactly one of the two). In a caller run, `scope = "user"` resolves the caller's own alias (forces `userId = caller`); `scope = "app"` resolves an app-scoped alias after checking the caller's effective permission. In a **system** run, a `scope = "user"` alias requires an explicit subject `userId` on the block — `documentAlias { scope = "user", aliasKey, userId }` — resolved app-privileged (see [subject-user methods](#subject-user-methods-system-workflows)). A non-resolving alias fails the step like a bad `documentId` (Option A — hard fail).
 
 ```toml
 [[steps]]
@@ -354,7 +354,7 @@ userId = "{{ input.userId }}"   # OR email = "...", not both
 
 `addMember` is idempotent. With `email`, returns `{ status: "pending_signup", invitationId, inviteToken, ... }` if the email has no AppUser yet.
 
-Group operations evaluate the group type's CEL rules. For workflow-issued operations, rules can match `fromWorkflow("workflowKey")`.
+Group operations evaluate the group type's CEL rules. For workflow-issued operations, rules can match `fromWorkflow("workflowKey")`. In a system run, `addMember`/`removeMember` record `sys:<appId>` as the membership's `addedBy` (not the admin/cron/webhook that initiated the run).
 
 ### `collect`
 
@@ -873,6 +873,40 @@ capabilities = ["membership"]
 `membership` gates the `group.addMember` / `group.removeMember` steps in a **system** run — without the grant they reject (`group.addMember requires the 'membership' capability`). Read-only group steps (`checkMembership`, `listMembers`, `listUserMemberships`) are never gated, and caller runs are governed by access rules, not capabilities, so the gate never applies to them.
 
 **`iterate-users` is system-only.** A workflow containing an `iterate-users` step must set `runAs = "system"` — otherwise it's rejected at save time (`'iterate-users' is system-only and may appear only in a runAs:"system" workflow`).
+
+### Subject-user methods (system workflows)
+
+A system run can act **about** a specific app user without impersonating them — the run's actor stays `sys:<appId>` for audit; `userId` is an explicit **subject** parameter. The `*ForUser` step kinds are **system-only** (calling one from a `runAs: "caller"` run throws non-retryably: `<kind> is only supported in runAs:"system" workflows`). In each, `userId` may be set on the step or inherited from `input.userId` (e.g. the iterated subject under `iterate-users`). The subject must be an `AppUser` of the app, or the step fails non-retryably (`Subject user <id> is not a member of app <appId>`). These reads need no `capabilities` grant — being a system run is the gate.
+
+| Kind | Key fields | Output |
+|---|---|---|
+| `user.get` | `userId` | `{ userId, email, name, appRole, rootDocId, disabled }` |
+| `user.resolve` | `userId` **or** `email` | `{ userId: null }` on no app-member match, else `{ userId, user }` (`user` shaped like `user.get`) |
+| `document.resolveAliasForUser` | `userId`, `aliasKey` | `{ documentId: string \| null, aliasKey, userId }` — app-privileged (alias existence ≠ subject access); `null` on miss (vs. the inline `documentAlias.userId` form, which hard-fails) |
+| `document.listForUser` | `userId`, `limit?`, `includeRoot?` (default `true`), `ownerOnly?`, `tag?`, `cursor?`, `forward?` | `{ items: [DocumentInfo...], cursor? }` — direct + root grants only (group/collection-derived discovery not yet included) |
+| `document.getForUser` | `userId`, `documentId`, `systemBypass?` | `{ document: DocumentInfo \| null, permission? }` — requires the subject's effective (direct + group) permission by default (`{ document: null }` when none); `systemBypass: true` reads by id app-privileged (`permission: "system"`) |
+| `document.getOrCreateWithAliasForUser` | `userId`, `aliasKey`, `title?`, `permission?` (`read`\|`write`\|`owner`, default `write`), `tags?` | `{ documentId, aliasKey, userId, created }` — created with `createdBy = sys:<appId>`; subject gets the alias + the default grant; race-safe |
+| `database.queryForUser` / `mutateForUser` / `countForUser` / `aggregateForUser` / `pipelineForUser` / `applyToQueryForUser` | same fields as the base `database.*` kind, plus `userId` | base kind's output; CEL rules + DB triggers evaluate as the **subject** (`user.userId`, `hasRole`, `isMemberOf` refer to the subject), actor stays system. `ok`/verdict semantics match the base kind |
+| `analytics.writeForUser` | `userId`, `action`, `feature` | event attributed to the subject; system actor + workflow run id carried in the event context for audit |
+
+```toml
+[[steps]]
+id = "ensure"
+kind = "document.getOrCreateWithAliasForUser"
+userId = "{{ input.userId }}"   # explicit subject, or inherited from input.userId
+aliasKey = "profile"
+title = "Profile"
+
+[[steps]]
+id = "assignments"
+kind = "database.queryForUser"
+userId = "{{ input.userId }}"
+databaseId = "{{ input.classroomDbId }}"
+operationName = "listAssignments"
+saveAs = "assignments"
+```
+
+Once a subject method returns a concrete `documentId`, the app-privileged `document.query` / `save` / `patch` / `delete` steps read/write it — there are **no** `*ForUser` write kinds. The CRUD `document.*` steps also accept `documentAlias { scope = "user", aliasKey, userId }` to resolve a subject's alias inline (hard-fails on miss).
 
 ## Inbound webhooks
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.ts.md
@@ -309,7 +309,7 @@ A missing `documentId`/`modelName` (or `recordId` on a write), or a `documentId`
 
 **Caller-mode ACL.** When the run is `runAs: "caller"` (the default — see [Execution identity](#execution-identity-runas-system-workflows)), every op enforces the caller's per-document permission: `query`/`queryOne`/`count` need `reader`, `save`/`patch` need `read-write`, `delete` needs `owner`. A `null`/insufficient permission throws `DocumentAccessDeniedError` (non-retryable) — a templated/user-supplied `documentId` can't bypass the ACL. `runAs: "system"` runs app-privileged (no per-caller check).
 
-**Targeting by alias.** Supply a `documentAlias { scope, aliasKey }` block instead of `documentId` (exactly one of the two). `scope = "user"` resolves the caller's own alias (forces `userId = caller`; requires `runAs: "caller"`); `scope = "app"` resolves an app-scoped alias after checking the caller's effective permission. A non-resolving alias fails the step like a bad `documentId` (Option A — hard fail).
+**Targeting by alias.** Supply a `documentAlias { scope, aliasKey }` block instead of `documentId` (exactly one of the two). In a caller run, `scope = "user"` resolves the caller's own alias (forces `userId = caller`); `scope = "app"` resolves an app-scoped alias after checking the caller's effective permission. In a **system** run, a `scope = "user"` alias requires an explicit subject `userId` on the block — `documentAlias { scope = "user", aliasKey, userId }` — resolved app-privileged (see [subject-user methods](#subject-user-methods-system-workflows)). A non-resolving alias fails the step like a bad `documentId` (Option A — hard fail).
 
 ```toml
 [[steps]]
@@ -354,7 +354,7 @@ userId = "{{ input.userId }}"   # OR email = "...", not both
 
 `addMember` is idempotent. With `email`, returns `{ status: "pending_signup", invitationId, inviteToken, ... }` if the email has no AppUser yet.
 
-Group operations evaluate the group type's CEL rules. For workflow-issued operations, rules can match `fromWorkflow("workflowKey")`.
+Group operations evaluate the group type's CEL rules. For workflow-issued operations, rules can match `fromWorkflow("workflowKey")`. In a system run, `addMember`/`removeMember` record `sys:<appId>` as the membership's `addedBy` (not the admin/cron/webhook that initiated the run).
 
 ### `collect`
 
@@ -873,6 +873,40 @@ capabilities = ["membership"]
 `membership` gates the `group.addMember` / `group.removeMember` steps in a **system** run — without the grant they reject (`group.addMember requires the 'membership' capability`). Read-only group steps (`checkMembership`, `listMembers`, `listUserMemberships`) are never gated, and caller runs are governed by access rules, not capabilities, so the gate never applies to them.
 
 **`iterate-users` is system-only.** A workflow containing an `iterate-users` step must set `runAs = "system"` — otherwise it's rejected at save time (`'iterate-users' is system-only and may appear only in a runAs:"system" workflow`).
+
+### Subject-user methods (system workflows)
+
+A system run can act **about** a specific app user without impersonating them — the run's actor stays `sys:<appId>` for audit; `userId` is an explicit **subject** parameter. The `*ForUser` step kinds are **system-only** (calling one from a `runAs: "caller"` run throws non-retryably: `<kind> is only supported in runAs:"system" workflows`). In each, `userId` may be set on the step or inherited from `input.userId` (e.g. the iterated subject under `iterate-users`). The subject must be an `AppUser` of the app, or the step fails non-retryably (`Subject user <id> is not a member of app <appId>`). These reads need no `capabilities` grant — being a system run is the gate.
+
+| Kind | Key fields | Output |
+|---|---|---|
+| `user.get` | `userId` | `{ userId, email, name, appRole, rootDocId, disabled }` |
+| `user.resolve` | `userId` **or** `email` | `{ userId: null }` on no app-member match, else `{ userId, user }` (`user` shaped like `user.get`) |
+| `document.resolveAliasForUser` | `userId`, `aliasKey` | `{ documentId: string \| null, aliasKey, userId }` — app-privileged (alias existence ≠ subject access); `null` on miss (vs. the inline `documentAlias.userId` form, which hard-fails) |
+| `document.listForUser` | `userId`, `limit?`, `includeRoot?` (default `true`), `ownerOnly?`, `tag?`, `cursor?`, `forward?` | `{ items: [DocumentInfo...], cursor? }` — direct + root grants only (group/collection-derived discovery not yet included) |
+| `document.getForUser` | `userId`, `documentId`, `systemBypass?` | `{ document: DocumentInfo \| null, permission? }` — requires the subject's effective (direct + group) permission by default (`{ document: null }` when none); `systemBypass: true` reads by id app-privileged (`permission: "system"`) |
+| `document.getOrCreateWithAliasForUser` | `userId`, `aliasKey`, `title?`, `permission?` (`read`\|`write`\|`owner`, default `write`), `tags?` | `{ documentId, aliasKey, userId, created }` — created with `createdBy = sys:<appId>`; subject gets the alias + the default grant; race-safe |
+| `database.queryForUser` / `mutateForUser` / `countForUser` / `aggregateForUser` / `pipelineForUser` / `applyToQueryForUser` | same fields as the base `database.*` kind, plus `userId` | base kind's output; CEL rules + DB triggers evaluate as the **subject** (`user.userId`, `hasRole`, `isMemberOf` refer to the subject), actor stays system. `ok`/verdict semantics match the base kind |
+| `analytics.writeForUser` | `userId`, `action`, `feature` | event attributed to the subject; system actor + workflow run id carried in the event context for audit |
+
+```toml
+[[steps]]
+id = "ensure"
+kind = "document.getOrCreateWithAliasForUser"
+userId = "{{ input.userId }}"   # explicit subject, or inherited from input.userId
+aliasKey = "profile"
+title = "Profile"
+
+[[steps]]
+id = "assignments"
+kind = "database.queryForUser"
+userId = "{{ input.userId }}"
+databaseId = "{{ input.classroomDbId }}"
+operationName = "listAssignments"
+saveAs = "assignments"
+```
+
+Once a subject method returns a concrete `documentId`, the app-privileged `document.query` / `save` / `patch` / `delete` steps read/write it — there are **no** `*ForUser` write kinds. The CRUD `document.*` steps also accept `documentAlias { scope = "user", aliasKey, userId }` to resolve a subject's alias inline (hard-fails on miss).
 
 ## Inbound webhooks
 

--- a/guides/latest/guides.json
+++ b/guides/latest/guides.json
@@ -4,12 +4,12 @@
     "platform": "web"
   },
   "builtAgainst": {
-    "stampedAt": "2026-06-23",
+    "stampedAt": "2026-06-24",
     "channel": "next",
     "packages": {
-      "js-bao-wss-client": "2.0.1",
+      "js-bao-wss-client": "2.0.2",
       "js-bao": "0.5.1",
-      "primitive-admin": "1.0.50",
+      "primitive-admin": "1.0.51",
       "primitive-app": "3.0.1"
     }
   },


### PR DESCRIPTION
Automated `docs-next-sync` pass against the library main tips, triggered by the nightly release js-bao-wss#1189.

> **Rolling PR.** This PR is updated in place each night until it merges — every update is a complete, gate-green superset of everything new since the last merge (branched fresh from `next`, not stacked). Merge it to advance the baseline; the next nightly then starts fresh and small.

# docs-next-sync report — 2026-06-24 (next channel)

**Channel:** next · **Branch:** next · **Submodules trued to:** js-bao-wss `12a0fc9b` (was `b1dc864e`); primitive-app-dev `fc60fa57` and swift-primitive-app-dev `9ddb48a5` unchanged.

**Gates:** `pnpm check:examples` ✅ (corpus 161×[ts,swift] compiles vs submodule source; 437 CLI invocations valid; 172 TOML blocks valid — including the new `*ForUser` workflow blocks against the regenerated CLI allowlist; sources stamp matches). `npx vitepress build docs` ✅ (no dead links). Swift compile step is SKIPPED on this Linux runner (covered by macOS CI) — relevant to the deferred issue #132 below.

## Summary

One developer-facing capability landed this batch — **#1179 subject-user methods for system workflows** — and it is **drafted** into both the human workflows page and the agent workflows guide (verified against submodule source, not the PR summary). Everything else in the 27-commit batch is internal (refactors, an internal race fix, library-repo design proposals, production-deploy bookkeeping). No JS/Swift **client** surface changed (only a `src/client/package.json` version bump), so no parity gap was introduced and no parity issue was filed this pass.

## Per-PR disposition (27 commits triaged)

| PR / commits | Surface | Disposition |
|---|---|---|
| **#1187 / #1179** — subject-user methods for system runs (Phase 0–6: `2113967c`, `b2b08655`, `66088829`, `ed92d8a2`, `42ae66c7`, `25426f82`, `69fe7de7`, `1ef0d32b`, merge `c42fe747`) | Workflow engine — new step kinds (`user.get`/`resolve`, `document.*ForUser`, `database.*ForUser`, `analytics.writeForUser`, inline `documentAlias.userId`); system-run attribution for group/integration/blob steps | **updated** `docs/getting-started/workflows.md` (new *Acting on Behalf of a User* subsection under System Workflows + Step-Reference pointer + Group-Steps attribution note) and `AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md` (new *Subject-user methods* reference subsection + `documentAlias` system-mode note + group attribution note). All step kinds/outputs/gating verified against `src/workflows/steps/{user-step,document-subject-step,database-step,analytics-write-step}.ts` and `runner/subject-user-context.ts`. |
| **#1187 follow-up** `12a0fc9b` — regenerate CLI allowlist for the new step kinds/fields | CLI generated artifact (`cli/src/lib/generated-allowlist.ts`) | internal — no doc change. (Materially relevant only in that it makes the new `*ForUser` TOML blocks pass `sync push`/`check:examples`; verified the gate accepts them.) |
| **#1186 / #1175** — `sync diff` content-aware for workflows (`42abd4a8`, merge `d37df0dd`) | CLI `sync diff` now reports **Modified** when a workflow's deployed content drifts from local TOML | internal — no doc change. Our docs describe `sync diff` only as "see what changed"/"see what would change" and document no per-entry status vocabulary, so nothing stated is contradicted; the fix makes `diff` accurate to what the docs already imply. |
| **#1152 / #1148** — route analytics step through the rule-set registry (`21b6facf`, `c431b445`, `3fa8adbf`, merge `4afadec7`) | Internal refactor; behavior preserved on documented divergences; adds a singleton guard (2nd analytics rule set → 409) and documents `fromWorkflow()` in the analytics schema | internal — no doc change. We do not document an `analytics` rule-set `resourceType` (rule sets are documented for groups/collections/blob buckets only); analytics access is documented as "default-deny, admin-only" (`analytics.md`), which remains true. The 409 guard governs an undocumented surface. |
| **#1163 / #1162** — graceful no-op for YjsRoom delete-vs-update race (`79a93135`, `16964955`, merge `224612c7`) | Document-collaboration DO delete/write race → 410 instead of 500; no client-visible contract change | internal — no doc change (bug fix that removes error noise; no documented behavior changes). |
| **#1184 / #1180** — library-repo design proposals (`db632172` unified block model, `900ef2d5` system-workflow subject-user context, merges `47a278d6` / `69f47999`) | Markdown proposals inside `js-bao-wss/docs/` | internal — no doc change (upstream design docs, not platform behavior). The #1180 proposal is the design behind #1179, already shipped and documented above. |
| Production-deploy bookkeeping — `854150cb`, `7cedda6b`, `0555fedd`, `fa106a80` (#1164/#1165, version bumps) | Deploy markers / version bumps | internal — no doc change. |

## Issues touched

- **#132** — *Promote DOCUMENTS "Loading Related Data (Includes)" fence to the corpus* — **actionable, deferred this pass.** Its blocker (Swift `IncludeResolver`) is confirmed present in the trued tips (`swift-client/.../Schema/IncludeResolver.swift`), so the work is unblocked — but it is **not** unblocked by *this* batch (it landed at an earlier pin), and promoting the fence requires writing `examples/documents/includes.swift` that re-enters the **Swift compile + parity gate**. That gate is SKIPPED on this Linux runner, so a promoted Swift example could not be compile-verified here; shipping it unverified would violate source-true discipline. **Recommend** picking this up in a pass with the macOS Swift toolchain (or a docs sweep on a macOS host). Left open.
- **#120** — *re-true Swift blob bucket preset/updateBucket parity when js-bao-wss#1135 merges* — **still deferred.** Gating ref js-bao-wss#1135 is **not** in the trued tips (no `updateBucket`/`preset` in `swift-client/Sources`, #1135 absent from the js-bao-wss log). Docs correctly continue to omit the Swift-side preset/`updateBucket` API. Left open.

No promote-on-parity issue was unblocked *by this batch*, and no new parity/platform-gap issue was filed (no one-language client capability landed — the #1179 surface is server-side workflow TOML, language-neutral).

## Whole-set audit (docs-set-audit)

Clean bill — no edits required.

- **Orphans:** none (all 20 `getting-started/` pages are in the sidebar).
- **Build + links:** ✅ (vitepress build green).
- **Parity inventory:** 4 inline-pair, 6 lone-js, 3 lone-swift, 173 neutral — all pre-existing and unchanged by this pass; my #1179 additions are neutral TOML fences (no new lone-language blocks). The lone-js at `working-with-documents.md:619` is the Includes fence tracked by #132 above.
- **Structure mirror / manifest integrity:** ✅ (verified via `check:examples`; `guides.json` `relatedGuides`/`prerequisites` intact).
- **Cross-page consistency of the new facts:** the subject-user concept is net-new and lives only on the workflows page/guide (no duplication). The new system-run `addedBy = sys:<appId>` fact does not conflict with the `addedBy` membership-event field documented in the users-and-groups guide (which doesn't specify the workflow-issued value). No inconsistencies found.

## Flagged for reviewer attention

- **Larger change:** the *Acting on Behalf of a User* subsection (human docs) and *Subject-user methods* subsection (guide) are the only substantive new prose. Both were placed **inside the existing System Workflows / Execution-identity sections** (capability lives on its concept's page — no new page, no restructure). Worth a reviewer's eye on altitude and the subject-user step table.
- **#132** deferred for a macOS-capable pass (reason above) — the one actionable item this pass did not execute.

## Unresolved source/doc contradictions

None.

---
Review the doc changes and the disposition above, then merge into `next`. Publishing to `main` happens separately at a production release.

> Generated unattended by the Claude Code CLI. Verify facts against source before merging.