### PR TITLE
Fix Swift auth guide: storage-provider JWT persistence and event-case names (#152, #153)

### DIFF
--- a/examples/auth/jwt-persistence.swift
+++ b/examples/auth/jwt-persistence.swift
@@ -1,9 +1,10 @@
 import JsBaoClient
 
 // Opt in to JWT persistence so a relaunch can reuse the short-lived token while
-// it is still valid, instead of forcing a fresh sign-in. The token is stored in
-// the Keychain under `storageKeyPrefix`. `waitForAuthBootstrap()` restores any
-// persisted session before the client is used.
+// it is still valid, instead of forcing a fresh sign-in. The token is persisted
+// through the client's storage provider (SQLite by default), namespaced by
+// `storageKeyPrefix`. `waitForAuthBootstrap()` restores any persisted session
+// before the client is used.
 func setupPersistedClient() async throws -> JsBaoClient {
   // #region example
   let client = JsBaoClient(options: JsBaoClientOptions(

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_AUTHENTICATION.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_AUTHENTICATION.swift.md
@@ -370,7 +370,7 @@ Optional — opt in through the client's `auth` options so a relaunch reuses the
   let info = client.getAuthPersistenceInfo()
 ```
 
-The token is stored in the Keychain; `storageKeyPrefix` namespaces it. `waitForAuthBootstrap()` restores any persisted session, so an authenticated user stays signed in on relaunch. `getAuthPersistenceInfo()` returns `["mode": "persisted" | "memory", "prefix": <storageKeyPrefix>]`. Tokens within ~2 min of expiry are not reused, and are cleared on logout and on `authFailed`.
+The token is persisted through the client's storage provider (SQLite by default); `storageKeyPrefix` namespaces it. The Keychain holds offline-access grants, not the JWT session. `waitForAuthBootstrap()` restores any persisted session, so an authenticated user stays signed in on relaunch. `getAuthPersistenceInfo()` returns `["mode": "persisted" | "memory", "prefix": <storageKeyPrefix>]`. Tokens within ~2 min of expiry are not reused; an expired persisted token triggers a cookie-based refresh on startup and is cleared if that refresh fails. `logout(wipeLocal: true)` clears the persisted JWT.
 
 ---
 
@@ -498,7 +498,7 @@ Overrides are tracked by `primitive sync` (TOML in `email-templates/`). Custom t
 1. Call `getAuthConfig()` to discover enabled methods before rendering UI.
 2. Implement at least one primary method (OAuth or Magic Link).
 3. Handle the OAuth callback (`code` + `state`) and the Magic Link `magic_token`.
-4. Listen to `authFailed` and `onlineAuthRequired` (minimum) to prompt re-login.
+4. Listen to `.authFailed` and `.authOnlineRequired` (minimum) to prompt re-login.
 5. Catch `AuthError` and switch on `error.code`.
 6. Gate your app layout on `isAuthenticated` (via `AuthGateView`) so child views can assume an authenticated user.
 7. Observe `authManager.$isAuthenticated` in downstream state (it changes both directions).

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_AUTHENTICATION.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_AUTHENTICATION.template.md
@@ -407,7 +407,7 @@ const client = await initializeClient({
 `baseUrl` must be a same-origin worker that forwards `/auth/*` and `/oauth/callback` to `/app/:appId/api/auth/*`. When configured, `magicLinkVerify`, `otpVerify`, `handleOAuthCallback`, `logout`, and the OAuth-code static helper all route through the proxy.
 {{/lang}}
 {{#lang swift}}
-The token is stored in the Keychain; `storageKeyPrefix` namespaces it. `waitForAuthBootstrap()` restores any persisted session, so an authenticated user stays signed in on relaunch. `getAuthPersistenceInfo()` returns `["mode": "persisted" | "memory", "prefix": <storageKeyPrefix>]`. Tokens within ~2 min of expiry are not reused, and are cleared on logout and on `authFailed`.
+The token is persisted through the client's storage provider (SQLite by default); `storageKeyPrefix` namespaces it. The Keychain holds offline-access grants, not the JWT session. `waitForAuthBootstrap()` restores any persisted session, so an authenticated user stays signed in on relaunch. `getAuthPersistenceInfo()` returns `["mode": "persisted" | "memory", "prefix": <storageKeyPrefix>]`. Tokens within ~2 min of expiry are not reused; an expired persisted token triggers a cookie-based refresh on startup and is cleared if that refresh fails. `logout(wipeLocal: true)` clears the persisted JWT.
 {{/lang}}
 
 ---
@@ -626,7 +626,7 @@ Overrides are tracked by `primitive sync` (TOML in `email-templates/`). Custom t
 10. Customize email templates via CLI if you need branded auth emails.
 {{/lang}}
 {{#lang swift}}
-4. Listen to `authFailed` and `onlineAuthRequired` (minimum) to prompt re-login.
+4. Listen to `.authFailed` and `.authOnlineRequired` (minimum) to prompt re-login.
 5. Catch `AuthError` and switch on `error.code`.
 6. Gate your app layout on `isAuthenticated` (via `AuthGateView`) so child views can assume an authenticated user.
 7. Observe `authManager.$isAuthenticated` in downstream state (it changes both directions).


### PR DESCRIPTION
## What the issues reported
- **#152** — the Swift auth guide and `examples/auth/jwt-persistence.swift` said the persisted JWT is stored in the Keychain. The Swift client persists it through its storage provider; the Keychain is only used for offline-access grants.
- **#153** — the Swift quick-start checklist used JS-shaped event names (`authFailed`, `onlineAuthRequired`) instead of the Swift enum cases.

## Verified against source
js-bao-wss@`12a0fc9b` (the stamped `next` pin), `swift-client/Sources/JsBaoClient`:
- `AuthController.persistJwt` → `offlineStore.persistJwt(...)` (storage provider; SQLite by default per SPAD). `enableOfflineAccess` is the only Keychain path.
- `getAuthPersistenceInfo()` returns `["mode": ..., "prefix": ...]`; `JsBaoClient.isTokenExpiring(thresholdSeconds: 120)` confirms the ~2 min reuse threshold; expired persisted tokens trigger a cookie refresh on startup and are cleared only if it fails; `logout(wipeLocal: true)` clears the persisted JWT.
- `Events.swift`: `case authOnlineRequired = "auth:onlineAuthRequired"`, `.authFailed`.

## Changed
- `guides/latest/AGENT_GUIDE_TO_PRIMITIVE_AUTHENTICATION.template.md` (Swift blocks only) + rendered `.swift.md`
- `examples/auth/jwt-persistence.swift` comment

The TS blocks (string event names + `client.on`) are correct and untouched. The human `authentication.md` page does not mention Keychain or the Swift enum cases, so no human-doc sync was needed.

## Validation
- `pnpm check:examples` — pass (parity, compilation, CLI, stamp gate)
- `npx vitepress build docs` — pass (no dead links)

Fixes #152
Fixes #153