### PR TITLE
Fix Swift users guide: ownedDocumentsPage and pending-signup cancellation (#154, #155)

### DIFF
--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.swift.md
@@ -210,7 +210,7 @@ The current authenticated user has its own namespace. Use it for "me"-scoped rea
   let pending = try await client.me.pendingDocumentInvitations()
 ```
 
-- `ownedDocuments()` is cache-backed and offline-aware. Pass `returnPage: true` to get a paginated `DocumentListPage`; the root document is excluded by default (`includeRoot: false`).
+- `ownedDocuments()` is cache-backed and offline-aware and returns `[DocumentInfo]`. Use `ownedDocumentsPage(...)` when you need a paginated `DocumentListPage`; the root document is excluded by default (`includeRoot: false`).
 - `sharedDocuments()` returns the unified `{ items, cursor }` envelope (raw-JSON cursor, NOT base64url). Group- and collection-scoped shares do NOT appear here — those are accessed via the group or collection. Each `SharedDocument` extends `DocumentInfo`, so rows carry the base document fields plus the share extras (`permission`, `source`, `grantedBy`, `invitationId`).
 - `pendingDocumentInvitations()` returns `[{ invitationId, documentId, title?, email, permission, invitedAt, invitedBy, expiresAt?, accepted, document?: {...} }, ...]`.
 
@@ -899,7 +899,7 @@ CEL can check any level: `"isMemberOf('org', database.metadata.orgId)"`, `"isMem
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
-| `addMember` returns `status: "pending_signup"` | Email isn't an app user yet | Expected. Membership resolves when they sign up or accept via `inviteToken`. Render a pending-members UI; cancel via `removeMember({ email })` or `invitations.revokeDeferredGrant(deferredId, "group")`. |
+| `addMember` returns `status: "pending_signup"` | Email isn't an app user yet | Expected. Membership resolves when they sign up or accept via `inviteToken`. Render a pending-members UI; cancel via `removeMemberByEmail(groupType:groupId:email:)` or `invitations.revokeDeferredGrant(deferredId:type: .group)`. |
 | `addMember` returns `status: "already_member"` | User already in the group | Idempotent — no error. |
 | 409 on `groups.create` | A group with that `(groupType, groupId)` already exists | Use a different `groupId` or call `groups.get` first. |
 | 403 on `groups.create` (member role) | The group type has a `GroupTypeConfig` row with no rule set attached (explicit opt-out), OR a configured `group.create` rule denied the caller | Either delete the `GroupTypeConfig` row to fall back to the permissive default (`group.create = "true"`), attach a rule set with a permissive `group.create`, or call as an owner/admin. |

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.template.md
@@ -128,7 +128,12 @@ The current authenticated user has its own namespace. Use it for "me"-scoped rea
 
 {{ example: users-and-groups/me-documents }}
 
+{{#lang ts}}
 - `ownedDocuments()` is cache-backed and offline-aware. Pass `returnPage: true` to get a paginated `DocumentListPage`; the root document is excluded by default (`includeRoot: false`).
+{{/lang}}
+{{#lang swift}}
+- `ownedDocuments()` is cache-backed and offline-aware and returns `[DocumentInfo]`. Use `ownedDocumentsPage(...)` when you need a paginated `DocumentListPage`; the root document is excluded by default (`includeRoot: false`).
+{{/lang}}
 - `sharedDocuments()` returns the unified `{ items, cursor }` envelope (raw-JSON cursor, NOT base64url). Group- and collection-scoped shares do NOT appear here — those are accessed via the group or collection. Each `SharedDocument` extends `DocumentInfo`, so rows carry the base document fields plus the share extras (`permission`, `source`, `grantedBy`, `invitationId`).
 - `pendingDocumentInvitations()` returns `[{ invitationId, documentId, title?, email, permission, invitedAt, invitedBy, expiresAt?, accepted, document?: {...} }, ...]`.
 
@@ -626,7 +631,12 @@ CEL can check any level: `"isMemberOf('org', database.metadata.orgId)"`, `"isMem
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
+{{#lang ts}}
 | `addMember` returns `status: "pending_signup"` | Email isn't an app user yet | Expected. Membership resolves when they sign up or accept via `inviteToken`. Render a pending-members UI; cancel via `removeMember({ email })` or `invitations.revokeDeferredGrant(deferredId, "group")`. |
+{{/lang}}
+{{#lang swift}}
+| `addMember` returns `status: "pending_signup"` | Email isn't an app user yet | Expected. Membership resolves when they sign up or accept via `inviteToken`. Render a pending-members UI; cancel via `removeMemberByEmail(groupType:groupId:email:)` or `invitations.revokeDeferredGrant(deferredId:type: .group)`. |
+{{/lang}}
 | `addMember` returns `status: "already_member"` | User already in the group | Idempotent — no error. |
 | 409 on `groups.create` | A group with that `(groupType, groupId)` already exists | Use a different `groupId` or call `groups.get` first. |
 | 403 on `groups.create` (member role) | The group type has a `GroupTypeConfig` row with no rule set attached (explicit opt-out), OR a configured `group.create` rule denied the caller | Either delete the `GroupTypeConfig` row to fall back to the permissive default (`group.create = "true"`), attach a rule set with a permissive `group.create`, or call as an owner/admin. |


### PR DESCRIPTION
## What the issues reported
- **#154** — shared prose said to pass `returnPage: true` for a paginated `DocumentListPage`. In Swift, `ownedDocuments()` returns a flat `[DocumentInfo]` and pagination is a separate method, `ownedDocumentsPage(...)`.
- **#155** — the pending-signup common-errors row inherited JS-shaped cancellation calls (`removeMember({ email })`, `revokeDeferredGrant(deferredId, "group")`) for the Swift build.

## Verified against source
js-bao-wss@`12a0fc9b` (stamped `next` pin), `swift-client/Sources/JsBaoClient`:
- `MeAPI.ownedDocuments(...) -> [DocumentInfo]` and a separate `MeAPI.ownedDocumentsPage(...) -> DocumentListPage`.
- `GroupsAPI.removeMemberByEmail(groupType:groupId:email:)`.
- `InvitationsAPI.revokeDeferredGrant(deferredId:type:)` with `DeferredGrantType.group`.

## Changed
- `guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.template.md` — split the documents-view bullet and the pending-signup error row into `{{#lang ts}}` / `{{#lang swift}}` so each build shows its own client's surface. Rendered `.ts.md` / `.swift.md` updated via `pnpm render:guides`.

The TS wording is unchanged. The human `users-and-groups.md` page does not name these client methods, so no human-doc sync was needed.

## Validation
- `pnpm check:examples` — pass
- `npx vitepress build docs` — pass (no dead links)
- Confirmed the `.ts.md` build contains no Swift-only forms and the `.swift.md` build carries the corrected methods.

Fixes #154
Fixes #155