### PR TITLE
Fix analytics guide: Swift rate limiter is fixed-window and destroy() is async (#156, #157)

### DIFF
--- a/docs/getting-started/analytics.md
+++ b/docs/getting-started/analytics.md
@@ -43,7 +43,7 @@ Every event — auto or custom — gets these fields populated automatically: `t
 
 ### Offline Persistence
 
-Events are persisted on the device while offline and flushed on reconnect. A rate limiter caps emission at 300 events/minute with a 60-token burst. No code required.
+Events are persisted on the device while offline and flushed on reconnect. A rate limiter caps emission at roughly 300 events per minute, with a short burst allowance of about 60. No code required.
 
 ## Emitting Custom Events
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_ANALYTICS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_ANALYTICS.swift.md
@@ -58,7 +58,8 @@ Workflow and prompt events also record `duration_ms` and LLM token counts (`inpu
 
 ### Offline Persistence and Rate Limiting
 
-Events are buffered on the device and persisted locally while offline; persisted events are flushed automatically when the WebSocket reconnects. A rate limiter caps emission at **300 events/minute with a 60-token burst** — events over the cap are dropped silently. No special code needed.
+Events are buffered on the device and persisted locally while offline; persisted events are flushed automatically when the WebSocket reconnects.
+A rate limiter caps emission at **300 events per 60-second window, with no more than 60 events in the first 10 seconds** — events over the cap are dropped silently. No special code needed.
 
 The offline buffer is persisted with a **~1 MiB** cap; when it exceeds the cap the **oldest** events are dropped.
 
@@ -139,7 +140,7 @@ Events are buffered and flushed automatically — including when the WebSocket r
   client.analytics.flush()
 ```
 
-The queue auto-flushes every **100ms** (or earlier when batched). `client.destroy()` cancels the flush timer and triggers a final flush before storage closes, so you don't need a manual flush on teardown.
+The queue auto-flushes every **100ms** (or earlier when batched). `await client.destroy()` cancels the flush timer and triggers a final flush before storage closes, so you don't need a manual flush on teardown.
 
 ---
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_ANALYTICS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_ANALYTICS.template.md
@@ -86,7 +86,13 @@ Every event (auto or custom) gets these populated automatically:
 
 ### Offline Persistence and Rate Limiting
 
-Events are buffered on the device and persisted locally while offline; persisted events are flushed automatically when the WebSocket reconnects. A rate limiter caps emission at **300 events/minute with a 60-token burst** — events over the cap are dropped silently. No special code needed.
+Events are buffered on the device and persisted locally while offline; persisted events are flushed automatically when the WebSocket reconnects.
+{{#lang ts}}
+A rate limiter caps emission at **300 events/minute with a 60-token burst** — events over the cap are dropped silently. No special code needed.
+{{/lang}}
+{{#lang swift}}
+A rate limiter caps emission at **300 events per 60-second window, with no more than 60 events in the first 10 seconds** — events over the cap are dropped silently. No special code needed.
+{{/lang}}
 
 The offline buffer is persisted with a **~1 MiB** cap; when it exceeds the cap the **oldest** events are dropped.
 
@@ -204,7 +210,7 @@ Pre-existing browser hooks (added by the client itself):
 So **don't** add your own `beforeunload → flush` listener — it's redundant and `session_end` is already handled.
 {{/lang}}
 {{#lang swift}}
-The queue auto-flushes every **100ms** (or earlier when batched). `client.destroy()` cancels the flush timer and triggers a final flush before storage closes, so you don't need a manual flush on teardown.
+The queue auto-flushes every **100ms** (or earlier when batched). `await client.destroy()` cancels the flush timer and triggers a final flush before storage closes, so you don't need a manual flush on teardown.
 {{/lang}}
 
 ---

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_ANALYTICS.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_ANALYTICS.ts.md
@@ -82,7 +82,8 @@ Every event (auto or custom) gets these populated automatically:
 
 ### Offline Persistence and Rate Limiting
 
-Events are buffered on the device and persisted locally while offline; persisted events are flushed automatically when the WebSocket reconnects. A rate limiter caps emission at **300 events/minute with a 60-token burst** — events over the cap are dropped silently. No special code needed.
+Events are buffered on the device and persisted locally while offline; persisted events are flushed automatically when the WebSocket reconnects.
+A rate limiter caps emission at **300 events/minute with a 60-token burst** — events over the cap are dropped silently. No special code needed.
 
 The offline buffer is persisted with a **~1 MiB** cap; when it exceeds the cap the **oldest** events are dropped.
 


### PR DESCRIPTION
## What the issues reported
- **#156** — the rate-limiter prose described a token bucket ("300/minute with a 60-token burst"). The Swift analytics queue is a fixed 60-second counter with a separate first-10-seconds burst cap, not a token bucket.
- **#157** — the Swift teardown text used `client.destroy()`, but `destroy()` is `async` and must be awaited.

## Verified against source
js-bao-wss@`12a0fc9b` (stamped `next` pin):
- Swift `Internal/AnalyticsQueue.swift`: `rateLimit = 300`, `burstCap = 60`, reset when `windowElapsed >= 60`, burst gate `rateCounter >= burstCap && windowElapsed < 10`, `flushIntervalMs = 100`. Fixed-window, not a token bucket.
- Swift `JsBaoClient.swift`: `public func destroy() async`.
- **TS** `src/client/internal/analyticsQueue.ts` *is* a real token bucket (`refillTokens`: `(MAX_EVENTS_PER_MINUTE / 60000) * elapsed`, capped at `RATE_BURST_CAP = 60`), so the existing TS wording is correct and stays.

## Changed
- `guides/latest/AGENT_GUIDE_TO_PRIMITIVE_ANALYTICS.template.md` — split the rate-limiter sentence into `{{#lang ts}}` (token bucket, unchanged) / `{{#lang swift}}` (fixed window); Swift teardown now `await client.destroy()`. Rendered builds updated.
- `docs/getting-started/analytics.md` — neutralized "60-token burst" (a TS-mechanism term) to wording true for both clients, at tutorial altitude, without narrating the platform difference.

## Validation
- `pnpm check:examples` — pass
- `npx vitepress build docs` — pass (no dead links)
- Confirmed the `.ts.md` build retains token-bucket wording and has no `await`/fixed-window text; `.swift.md` carries the corrected forms.

Fixes #156
Fixes #157