### PR TITLE
Fix DATABASES Swift guide: databases.get gating, direct record APIs, operation-type caveat, subscribe teardown (#165-168)

### DIFF
--- a/docs/getting-started/working-with-databases.md
+++ b/docs/getting-started/working-with-databases.md
@@ -457,9 +457,9 @@ If your app relies on `databases.list()` to populate a dashboard, invited team m
 
 :::
 
-### `databases.get()` — Any Authenticated User
+### `databases.get()` — Permission-Gated Resolution
 
-Unlike `list()`, `databases.get(databaseId)` works for any authenticated user who knows the database ID — no owner/manager permission required. It also resolves **group-based** access, so users who only have access through a shared group can still load database metadata.
+`databases.get(databaseId)` resolves a database by id for users with owner or manager permission, an effective **group-based** permission, or app-admin access — otherwise the server returns `403`. It reaches wider than `list()` (which only surfaces direct `owner`/`manager` grants) because it also resolves group-based access, so a user who has access through a shared group can still load database metadata. Operation-only CEL access does **not** grant `databases.get`.
 
 ### Group-Based Database Access
 

--- a/examples/databases/db-list-get.swift
+++ b/examples/databases/db-list-get.swift
@@ -6,7 +6,8 @@ func listAndGetDatabases(client: JsBaoClient, databaseId: String) async throws {
   // Databases where you're owner or manager
   let databases = try await client.databases.list()
 
-  // Any authenticated user can resolve a database by id
+  // Resolve a database by id — gated on owner/manager permission, an effective
+  // group permission, or app-admin access; otherwise the server returns 403.
   let db = try await client.databases.get(databaseId: databaseId)
   // #endregion example
   _ = (databases, db)

--- a/examples/databases/db-list-get.ts
+++ b/examples/databases/db-list-get.ts
@@ -6,7 +6,8 @@ export async function listAndGetDatabases(client: JsBaoClient, databaseId: strin
   // Databases where you're owner or manager
   const databases = await client.databases.list();
 
-  // Any authenticated user can resolve a database by id
+  // Resolve a database by id — gated on owner/manager permission, an effective
+  // group permission, or app-admin access; otherwise the server returns 403.
   const db = await client.databases.get(databaseId);
   // #endregion example
   return { databases, db };

--- a/examples/databases/db-subscribe.swift
+++ b/examples/databases/db-subscribe.swift
@@ -8,7 +8,7 @@ func watchOpenTickets(
   databaseId: String,
   removeTicket: @escaping (String) -> Void,
   upsertTicket: @escaping (Any?) -> Void
-) throws {
+) throws -> () -> Void {
   // #region example
   let unsub = try client.databases.subscribe(
     databaseId: databaseId,
@@ -28,7 +28,7 @@ func watchOpenTickets(
     })
   )
 
-  // Later — required for cleanup
-  unsub()
+  // Return the teardown handle — call it on unmount to stop receiving deltas.
+  return unsub
   // #endregion example
 }

--- a/examples/databases/db-subscribe.ts
+++ b/examples/databases/db-subscribe.ts
@@ -8,7 +8,7 @@ export function watchOpenTickets(
   databaseId: string,
   removeTicket: (id: string) => void,
   upsertTicket: (data: unknown) => void
-) {
+): () => void {
   // #region example
   const unsub = client.databases.subscribe(databaseId, "my-open-tickets", {
     onChange: (event) => {
@@ -27,7 +27,7 @@ export function watchOpenTickets(
     },
   });
 
-  // Later — required for cleanup
-  unsub();
+  // Return the teardown handle — call it on unmount to stop receiving deltas.
+  return unsub;
   // #endregion example
 }

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.swift.md
@@ -21,7 +21,8 @@ Guidelines for building apps with Primitive's server-side database storage.
   // Databases where you're owner or manager
   let databases = try await client.databases.list()
 
-  // Any authenticated user can resolve a database by id
+  // Resolve a database by id — gated on owner/manager permission, an effective
+  // group permission, or app-admin access; otherwise the server returns 403.
   let db = try await client.databases.get(databaseId: databaseId)
 ```
 
@@ -48,7 +49,7 @@ A **database** is:
 **Properties:**
 
 - Each database is an isolated instance with its own SQLite storage — strong consistency, zero-config scaling
-- All data access goes through **registered operations** with per-operation authorization
+- End-user scoped app access goes through **registered operations** with per-operation authorization; owners, managers, and app admins additionally have direct record-access APIs (schemaless save/patch/find/query/delete/count, atomic increment and StringSet ops, batch writes, aggregation, and index management) for administrative access
 - Databases can be organized by **type** — a named configuration shared across many database instances
 - Supports queries, mutations, counts, aggregates, multi-step pipelines, atomic operations, batch writes, apply-to-query, and real-time subscriptions
 
@@ -304,6 +305,8 @@ A **database type** is a named configuration shared across many databases. It pr
 - **`defaultAccess`** — fallback CEL access rule applied to operations that omit their own `access`
 - **`[models.*]` schema** — optional server-enforced model declaration. When present, every op edit (and the schema edit itself) is checked against it; see [Schema gate](#schema-gate)
 - **Rule set attachment** — controls who can edit the type config and its operations
+
+Swift `executeOperation` can call **any** registered operation regardless of its `type` (it returns `JSONValue`). Operation *management* is narrower: Swift's `DatabaseOperationType` enum — used by `createOperation` / `listOperations` — models only `query`, `mutation`, `count`, and `aggregate`. Define and manage `pipeline` and `applyToQuery` operations through TOML and the `primitive` CLI rather than the typed Swift management API.
 
 
 ### Triggers

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.template.md
@@ -28,7 +28,7 @@ A **database** is:
 **Properties:**
 
 - Each database is an isolated instance with its own SQLite storage — strong consistency, zero-config scaling
-- All data access goes through **registered operations** with per-operation authorization
+- End-user scoped app access goes through **registered operations** with per-operation authorization; owners, managers, and app admins additionally have direct record-access APIs (schemaless save/patch/find/query/delete/count, atomic increment and StringSet ops, batch writes, aggregation, and index management) for administrative access
 - Databases can be organized by **type** — a named configuration shared across many database instances
 - Supports queries, mutations, counts, aggregates, multi-step pipelines, atomic operations, batch writes, apply-to-query, and real-time subscriptions
 
@@ -286,6 +286,10 @@ A **database type** is a named configuration shared across many databases. It pr
 - **Subscriptions** — type-scoped real-time subscription definitions (managed via `[[subscriptions]]` blocks in the TOML)
 {{/lang}}
 - **Rule set attachment** — controls who can edit the type config and its operations
+
+{{#lang swift}}
+Swift `executeOperation` can call **any** registered operation regardless of its `type` (it returns `JSONValue`). Operation *management* is narrower: Swift's `DatabaseOperationType` enum — used by `createOperation` / `listOperations` — models only `query`, `mutation`, `count`, and `aggregate`. Define and manage `pipeline` and `applyToQuery` operations through TOML and the `primitive` CLI rather than the typed Swift management API.
+{{/lang}}
 
 {{#lang ts}}
 Real-time subscriptions are also part of the type config — see [Real-Time Subscriptions](#real-time-subscriptions). One subscription definition serves every database of that type. Define them as `[[subscriptions]]` blocks in the same TOML file; `primitive sync push` manages them alongside operations.

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.ts.md
@@ -19,7 +19,8 @@ Guidelines for building apps with Primitive's server-side database storage.
   // Databases where you're owner or manager
   const databases = await client.databases.list();
 
-  // Any authenticated user can resolve a database by id
+  // Resolve a database by id — gated on owner/manager permission, an effective
+  // group permission, or app-admin access; otherwise the server returns 403.
   const db = await client.databases.get(databaseId);
 ```
 
@@ -45,7 +46,7 @@ A **database** is:
 **Properties:**
 
 - Each database is an isolated instance with its own SQLite storage — strong consistency, zero-config scaling
-- All data access goes through **registered operations** with per-operation authorization
+- End-user scoped app access goes through **registered operations** with per-operation authorization; owners, managers, and app admins additionally have direct record-access APIs (schemaless save/patch/find/query/delete/count, atomic increment and StringSet ops, batch writes, aggregation, and index management) for administrative access
 - Databases can be organized by **type** — a named configuration shared across many database instances
 - Supports queries, mutations, counts, aggregates, multi-step pipelines, atomic operations, batch writes, apply-to-query, and real-time subscriptions
 
@@ -310,6 +311,7 @@ A **database type** is a named configuration shared across many databases. It pr
 - **`[models.*]` schema** — optional server-enforced model declaration. When present, every op edit (and the schema edit itself) is checked against it; see [Schema gate](#schema-gate)
 - **Subscriptions** — type-scoped real-time subscription definitions (managed via `[[subscriptions]]` blocks in the TOML)
 - **Rule set attachment** — controls who can edit the type config and its operations
+
 
 Real-time subscriptions are also part of the type config — see [Real-Time Subscriptions](#real-time-subscriptions). One subscription definition serves every database of that type. Define them as `[[subscriptions]]` blocks in the same TOML file; `primitive sync push` manages them alongside operations.
 
@@ -1307,8 +1309,8 @@ The two phases see different contexts:
     },
   });
 
-  // Later — required for cleanup
-  unsub();
+  // Return the teardown handle — call it on unmount to stop receiving deltas.
+  return unsub;
 ```
 
 Parameterized:


### PR DESCRIPTION
Fixes four Swift-accuracy issues in the DATABASES guide, examples corpus, and the human `working-with-databases.md` page. Re-verified against `js-bao-wss` at the stamped pin (`12a0fc9b`).

## What was reported / what changed

- **#165** — `databases.get` is **permission-gated** (server checks app-admin / direct permission / group-based effective permission, else `403`); operation-only CEL access does not grant it. Corrected the `db-list-get` example comments (both languages) and the human-docs "any authenticated user" section.
- **#166** — "All data access goes through registered operations" was too absolute. Scoped it to **end-user** access and noted that owners, managers, and app admins also have direct record-access APIs.
- **#167** — Added a Swift management caveat: `executeOperation` can run **any** registered operation (returns `JSONValue`), but the typed `DatabaseOperationType` enum used by `createOperation` / `listOperations` models only `query`/`mutation`/`count`/`aggregate` — manage `pipeline` / `applyToQuery` via TOML and the `primitive` CLI.
- **#168** — `db-subscribe.swift` called `unsub()` immediately, defeating the subscription. It now returns the teardown handle (matching `db-load-subscribe.swift`). The TS example had the identical defect and is fixed too for parity.

## Source verification

`src/app-api/controllers/databases-controller.ts` (`resolveEffectiveDatabasePermission` + 403), `swift-client/API/DoDb.swift` (direct record-access path), `Types/DatabasesTypes.swift` (`DatabaseOperationType` enum cases), `API/DatabasesAPI.swift` (`executeOperation` → `JSONValue`, `subscribe` → `() -> Void`).

## Validation

- `pnpm check:examples` ✅
- `npx vitepress build docs` ✅
- Swift caveat renders into the Swift build only; TS build unaffected.

Fixes #165
Fixes #166
Fixes #167
Fixes #168