### PR TITLE
Fix PERFORMANCE Swift guide: executeOperation API, integrations.call request, JSONValue bundle read, throwing auth-config loader (#170-173)

### DIFF
--- a/examples/performance/pipeline-bundle.swift
+++ b/examples/performance/pipeline-bundle.swift
@@ -5,11 +5,12 @@ import JsBaoClient
 // the client just executes it and reads each step's `data` off `steps`.
 func loadBundle(client: JsBaoClient, databaseId: String) async throws {
   // #region example
+  // executeOperation returns a JSONValue — use its object/array accessors and
+  // string-keyed subscript to read each step's `data` off `steps`.
   let bundle = try await client.databases.executeOperation(databaseId: databaseId, name: "dashboardBundle")
-  let steps = (bundle as? [String: Any])?["steps"] as? [String: Any]
-  let groups = (steps?["groups"] as? [String: Any])?["data"] as? [[String: Any]] ?? []
-  let accounts = (steps?["accounts"] as? [String: Any])?["data"] as? [[String: Any]] ?? []
-  let holdings = (steps?["holdings"] as? [String: Any])?["data"] as? [[String: Any]] ?? []
+  let groups = bundle["steps"]?["groups"]?["data"]?.arrayValue ?? []
+  let accounts = bundle["steps"]?["accounts"]?["data"]?.arrayValue ?? []
+  let holdings = bundle["steps"]?["holdings"]?["data"]?.arrayValue ?? []
   // #endregion example
   _ = (groups, accounts, holdings)
 }

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_PERFORMANCE.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_PERFORMANCE.swift.md
@@ -43,11 +43,11 @@ A page needs several pieces of data from the same database, fetched one at a tim
 
 ```swift
 // 5 sequential round trips to the SAME database
-let groups = try await db.executeOperation(name: "listGroups")
-let accounts = try await db.executeOperation(name: "listAccounts")
-let holdings = try await db.executeOperation(name: "listHoldings")
-let targets = try await db.executeOperation(name: "listAllTargets")
-let latest = try await db.executeOperation(name: "listLatestSnapshot")
+let groups = try await client.databases.executeOperation(databaseId: dbId, name: "listGroups")
+let accounts = try await client.databases.executeOperation(databaseId: dbId, name: "listAccounts")
+let holdings = try await client.databases.executeOperation(databaseId: dbId, name: "listHoldings")
+let targets = try await client.databases.executeOperation(databaseId: dbId, name: "listAllTargets")
+let latest = try await client.databases.executeOperation(databaseId: dbId, name: "listLatestSnapshot")
 ```
 
 Each call has its own request/response overhead. They serialize even though none depend on each other.
@@ -76,11 +76,12 @@ definition = '''
 Then execute it in one round trip and read each step's `data`:
 
 ```swift
+  // executeOperation returns a JSONValue — use its object/array accessors and
+  // string-keyed subscript to read each step's `data` off `steps`.
   let bundle = try await client.databases.executeOperation(databaseId: databaseId, name: "dashboardBundle")
-  let steps = (bundle as? [String: Any])?["steps"] as? [String: Any]
-  let groups = (steps?["groups"] as? [String: Any])?["data"] as? [[String: Any]] ?? []
-  let accounts = (steps?["accounts"] as? [String: Any])?["data"] as? [[String: Any]] ?? []
-  let holdings = (steps?["holdings"] as? [String: Any])?["data"] as? [[String: Any]] ?? []
+  let groups = bundle["steps"]?["groups"]?["data"]?.arrayValue ?? []
+  let accounts = bundle["steps"]?["accounts"]?["data"]?.arrayValue ?? []
+  let holdings = bundle["steps"]?["holdings"]?["data"]?.arrayValue ?? []
 ```
 
 ### When to reach for it
@@ -103,9 +104,10 @@ A per-item operation called once for every item in a collection:
 
 ```swift
 for group in groups {
-  let targets = try await db.executeOperation(
+  let targets = try await client.databases.executeOperation(
+    databaseId: dbId,
     name: "listTargetsByGroup",
-    params: ["groupId": group.id]
+    options: ExecuteOperationOptions(params: ["groupId": .string(group.id)])
   )
   // ...use targets
 }
@@ -150,9 +152,9 @@ Any time you find an `await ...executeOperation(...)` inside a `for` loop. This 
 Three independent reads awaited one after another:
 
 ```swift
-let a = try await db.executeOperation(name: "opA")
-let b = try await db.executeOperation(name: "opB")
-let c = try await db.executeOperation(name: "opC")
+let a = try await client.databases.executeOperation(databaseId: dbId, name: "opA")
+let b = try await client.databases.executeOperation(databaseId: dbId, name: "opB")
+let c = try await client.databases.executeOperation(databaseId: dbId, name: "opC")
 ```
 
 Three sequential round trips even though none depends on the others.
@@ -186,11 +188,12 @@ One proxy call per ID — here, 21 calls for 21 symbols:
 ```swift
 // 21 individual proxy calls for 21 symbols
 for symbol in symbols {
-  _ = try await client.integrations.call(
+  _ = try await client.integrations.call(IntegrationCallRequest(
     integrationKey: "yahoo-finance",
+    method: "GET",
     path: "/v8/finance/chart/\(symbol)"
     // ...
-  )
+  ))
 }
 ```
 
@@ -265,8 +268,11 @@ func initialize() async throws {
 // Lazy: idempotent, de-duped
 func loadAuthConfig() async {
   if authConfig != nil { return }
-  if let task = authConfigTask { return await task.value }
-  let task = Task { normalize(try await client.auth.getAuthConfig()) }
+  // getAuthConfig() is `throws`; catch inside the Task so the cached task —
+  // and this loader — stay non-throwing (callers fire it without `try`).
+  let task = authConfigTask ?? Task {
+    (try? await client.auth.getAuthConfig()).map(normalize)
+  }
   authConfigTask = task
   authConfig = await task.value
 }
@@ -469,7 +475,7 @@ When auditing an existing Primitive app, these usually find real wins:
 | Eager full-reload on every state change | a change observer whose body does `try await load…` |
 | Awaiting non-critical init | `try await client.auth.getAuthConfig()`, `try await listUserMemberships`, `try await initializeUserPrefs()` inside `initialize()` / `completeAuthentication()` |
 | Cached value behind a re-block | `await ensurePrefsReady(); let cached = getPref(...)` (yes — really) |
-| Sequential awaits | three or more consecutive `try await db.executeOperation(...)` lines |
+| Sequential awaits | three or more consecutive `try await client.databases.executeOperation(...)` lines |
 
 ## Measuring
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_PERFORMANCE.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_PERFORMANCE.template.md
@@ -54,11 +54,11 @@ const latest   = await db.executeOperation("listLatestSnapshot");
 {{#lang swift}}
 ```swift
 // 5 sequential round trips to the SAME database
-let groups = try await db.executeOperation(name: "listGroups")
-let accounts = try await db.executeOperation(name: "listAccounts")
-let holdings = try await db.executeOperation(name: "listHoldings")
-let targets = try await db.executeOperation(name: "listAllTargets")
-let latest = try await db.executeOperation(name: "listLatestSnapshot")
+let groups = try await client.databases.executeOperation(databaseId: dbId, name: "listGroups")
+let accounts = try await client.databases.executeOperation(databaseId: dbId, name: "listAccounts")
+let holdings = try await client.databases.executeOperation(databaseId: dbId, name: "listHoldings")
+let targets = try await client.databases.executeOperation(databaseId: dbId, name: "listAllTargets")
+let latest = try await client.databases.executeOperation(databaseId: dbId, name: "listLatestSnapshot")
 ```
 {{/lang}}
 
@@ -120,9 +120,10 @@ for (const group of groups) {
 {{#lang swift}}
 ```swift
 for group in groups {
-  let targets = try await db.executeOperation(
+  let targets = try await client.databases.executeOperation(
+    databaseId: dbId,
     name: "listTargetsByGroup",
-    params: ["groupId": group.id]
+    options: ExecuteOperationOptions(params: ["groupId": .string(group.id)])
   )
   // ...use targets
 }
@@ -169,9 +170,9 @@ const c = await db.executeOperation("opC");
 {{/lang}}
 {{#lang swift}}
 ```swift
-let a = try await db.executeOperation(name: "opA")
-let b = try await db.executeOperation(name: "opB")
-let c = try await db.executeOperation(name: "opC")
+let a = try await client.databases.executeOperation(databaseId: dbId, name: "opA")
+let b = try await client.databases.executeOperation(databaseId: dbId, name: "opB")
+let c = try await client.databases.executeOperation(databaseId: dbId, name: "opC")
 ```
 {{/lang}}
 
@@ -213,11 +214,12 @@ for (const symbol of symbols) {
 ```swift
 // 21 individual proxy calls for 21 symbols
 for symbol in symbols {
-  _ = try await client.integrations.call(
+  _ = try await client.integrations.call(IntegrationCallRequest(
     integrationKey: "yahoo-finance",
+    method: "GET",
     path: "/v8/finance/chart/\(symbol)"
     // ...
-  )
+  ))
 }
 ```
 {{/lang}}
@@ -336,8 +338,11 @@ func initialize() async throws {
 // Lazy: idempotent, de-duped
 func loadAuthConfig() async {
   if authConfig != nil { return }
-  if let task = authConfigTask { return await task.value }
-  let task = Task { normalize(try await client.auth.getAuthConfig()) }
+  // getAuthConfig() is `throws`; catch inside the Task so the cached task —
+  // and this loader — stay non-throwing (callers fire it without `try`).
+  let task = authConfigTask ?? Task {
+    (try? await client.auth.getAuthConfig()).map(normalize)
+  }
   authConfigTask = task
   authConfig = await task.value
 }
@@ -643,7 +648,7 @@ When auditing an existing Primitive app, these usually find real wins:
 | Eager full-reload on every state change | a change observer whose body does `try await load…` |
 | Awaiting non-critical init | `try await client.auth.getAuthConfig()`, `try await listUserMemberships`, `try await initializeUserPrefs()` inside `initialize()` / `completeAuthentication()` |
 | Cached value behind a re-block | `await ensurePrefsReady(); let cached = getPref(...)` (yes — really) |
-| Sequential awaits | three or more consecutive `try await db.executeOperation(...)` lines |
+| Sequential awaits | three or more consecutive `try await client.databases.executeOperation(...)` lines |
 {{/lang}}
 
 ## Measuring


### PR DESCRIPTION
Fixes four stale Swift call shapes in the PERFORMANCE guide and `examples/performance/pipeline-bundle.swift`. Re-verified against `swift-client` at the stamped `js-bao-wss` pin (`12a0fc9b`).

## What was reported / what changed

- **#170** — Database operations call `client.databases.executeOperation(databaseId:name:options:)` (params inside `ExecuteOperationOptions`), not `db.executeOperation(name:)` — there is no such convenience on the Swift client. Updated every inline Swift snippet (sequential reads, N+1 loop, parallel reads) and the cheat-sheet grep hint.
- **#171** — `pipeline-bundle.swift` cast the result to `[String: Any]`; `executeOperation` returns `JSONValue`, so it now reads via the string-keyed subscript and `.arrayValue` (`bundle["steps"]?["groups"]?["data"]?.arrayValue`).
- **#172** — `integrations.call` takes a single `IntegrationCallRequest` value, not named `integrationKey:path:` params.
- **#173** — The `loadAuthConfig` sample awaited a throwing `Task` value from a non-throwing function with no `try`/`catch`. It now catches `getAuthConfig()` inside the `Task`, keeping both the cached task and the loader non-throwing.

## Source verification

`API/DatabasesAPI.swift` (`executeOperation` → `JSONValue`) + `Types/DatabasesTypes.swift` (`ExecuteOperationOptions.params`), `Types/JSONValue.swift` (subscript / `.arrayValue`), `API/IntegrationsAPI.swift` + `Types/IntegrationsTypes.swift` (`IntegrationCallRequest`), `API/AuthAPI.swift` (`getAuthConfig() async throws`). Param shape cross-checked against the compiled `db-execute-operation.swift`.

## Validation

- `pnpm check:examples` (compiles `pipeline-bundle.swift`) ✅
- `npx vitepress build docs` ✅
- No human-docs sibling (PERFORMANCE is agent-guide-only).

Fixes #170
Fixes #171
Fixes #172
Fixes #173