### PR TITLE
Fix PROMPTS Swift guide: prompts.execute call shape (#169)

### DIFF
--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_PROMPTS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_PROMPTS.swift.md
@@ -660,11 +660,11 @@ The first arg is the `promptKey`, NOT the `promptId`. The endpoint is `POST /pro
 
 ```swift
 // WRONG — passing the prompt id instead of the prompt key
-try await client.prompts.execute("01HXY...PROMPT_ID", variables: [:])
+try await client.prompts.execute(promptKey: "01HXY...PROMPT_ID", options: ExecutePromptOptions(variables: [:]))
 // → 404. Use the key from the TOML.
 
 // WRONG — expecting a top-level variable
-try await client.prompts.execute("p", variables: ["name": "Alice"])
+try await client.prompts.execute(promptKey: "p", options: ExecutePromptOptions(variables: ["name": "Alice"]))
 // template: "Hi {{ name }}"   ← won't resolve, renders as "Hi "
 // Fix: template: "Hi {{ input.name }}"
 ```

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_PROMPTS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_PROMPTS.template.md
@@ -649,11 +649,11 @@ await client.prompts.execute("p", { variables: { name: "Alice" } });
 {{#lang swift}}
 ```swift
 // WRONG — passing the prompt id instead of the prompt key
-try await client.prompts.execute("01HXY...PROMPT_ID", variables: [:])
+try await client.prompts.execute(promptKey: "01HXY...PROMPT_ID", options: ExecutePromptOptions(variables: [:]))
 // → 404. Use the key from the TOML.
 
 // WRONG — expecting a top-level variable
-try await client.prompts.execute("p", variables: ["name": "Alice"])
+try await client.prompts.execute(promptKey: "p", options: ExecutePromptOptions(variables: ["name": "Alice"]))
 // template: "Hi {{ name }}"   ← won't resolve, renders as "Hi "
 // Fix: template: "Hi {{ input.name }}"
 ```


### PR DESCRIPTION
The PROMPTS guide's Swift "common mistakes" snippets used the JS-shaped `execute(_:variables:)` overload. The real Swift surface is `execute(promptKey:options:)` taking `ExecutePromptOptions` (which carries `variables: [String: JSONValue]`).

## What changed

Updated the two Swift "WRONG" examples to the real call shape — they still illustrate the intended mistakes (passing a prompt id instead of a key → 404; expecting a top-level `{{ name }}` instead of `{{ input.name }}`), but now with the correct `execute(promptKey:options: ExecutePromptOptions(variables:))` form.

## Source verification

`swift-client/API/PromptsAPI.swift` (`execute(promptKey:options:)`) and `Types/PromptsTypes.swift` (`ExecutePromptOptions.variables`), cross-checked against the compiled `examples/prompts/prompt-execute.swift`.

## Validation

- `pnpm check:examples` ✅
- `npx vitepress build docs` ✅
- No human-docs prompts page references this call shape.

Fixes #169