### PR TITLE
Steer Swift raw permission/collection reads to the typed summary wrappers (#190)

### DIFF
--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.swift.md
@@ -1197,6 +1197,8 @@ Pick the call that answers the question you're actually asking:
 
 `options:` takes a `PaginationOptions(limit:cursor:)`; the paginated reads return `PaginatedResult` (`.data`, `.nextCursor`, `.hasMore`).
 
+For the permission / collection reads — `documents.getPermissions(_:)`, `collections.getAccess(_:)`, `documents`/`collections.listPendingInvitations(_:)` — prefer the typed `*Summaries` companions ([above](#typed-summaries-for-permission--collection-reads)) when rendering a UI: `permissionSummaries` / `accessSummary` / `pendingInvitationSummaries` resolve `email`/`name` and do the owned + shared merge, so display screens don't reassemble the raw rows. Reach for the raw reads only when you need the unresolved server shape.
+
 **Anti-patterns:**
 
 - Calling a method that doesn't exist: `setPermissions`, `setGroupPermission`. The correct names are `updatePermissions(documentId:params:)` and `grantGroupPermission(documentId:params:)`; resolve a user by email with `client.users.lookup(email:)`.

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.swift.md
@@ -1197,7 +1197,7 @@ Pick the call that answers the question you're actually asking:
 
 `options:` takes a `PaginationOptions(limit:cursor:)`; the paginated reads return `PaginatedResult` (`.data`, `.nextCursor`, `.hasMore`).
 
-For the permission / collection reads — `documents.getPermissions(_:)`, `collections.getAccess(_:)`, `documents`/`collections.listPendingInvitations(_:)` — prefer the typed `*Summaries` companions ([above](#typed-summaries-for-permission--collection-reads)) when rendering a UI: `permissionSummaries` / `accessSummary` / `pendingInvitationSummaries` resolve `email`/`name` and do the owned + shared merge, so display screens don't reassemble the raw rows. Reach for the raw reads only when you need the unresolved server shape.
+For the permission / collection reads — `documents.getPermissions(_:)`, `collections.getAccess(_:)`, `documents`/`collections.listPendingInvitations(_:)` — prefer the typed `*Summaries` companions ([above](#typed-summaries-for-permission--collection-reads)) when rendering a UI: `permissionSummaries` / `accessSummary` / `pendingInvitationSummaries` return display-ready types (resolving `email`/`name` on permission rows), so display screens don't reassemble the raw rows. Reach for the raw reads only when you need the unresolved server shape.
 
 **Anti-patterns:**
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.template.md
@@ -1679,6 +1679,8 @@ Pick the call that answers the question you're actually asking:
 | Pending email invites on a document / group / collection | `client.documents.listPendingInvitations(documentId:)` / `groups.listPendingInvitations(groupType:groupId:)` / `collections.listPendingInvitations(collectionId:)` |
 
 `options:` takes a `PaginationOptions(limit:cursor:)`; the paginated reads return `PaginatedResult` (`.data`, `.nextCursor`, `.hasMore`).
+
+For the permission / collection reads — `documents.getPermissions(_:)`, `collections.getAccess(_:)`, `documents`/`collections.listPendingInvitations(_:)` — prefer the typed `*Summaries` companions ([above](#typed-summaries-for-permission--collection-reads)) when rendering a UI: `permissionSummaries` / `accessSummary` / `pendingInvitationSummaries` resolve `email`/`name` and do the owned + shared merge, so display screens don't reassemble the raw rows. Reach for the raw reads only when you need the unresolved server shape.
 {{/lang}}
 
 **Anti-patterns:**

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.template.md
@@ -1680,7 +1680,7 @@ Pick the call that answers the question you're actually asking:
 
 `options:` takes a `PaginationOptions(limit:cursor:)`; the paginated reads return `PaginatedResult` (`.data`, `.nextCursor`, `.hasMore`).
 
-For the permission / collection reads — `documents.getPermissions(_:)`, `collections.getAccess(_:)`, `documents`/`collections.listPendingInvitations(_:)` — prefer the typed `*Summaries` companions ([above](#typed-summaries-for-permission--collection-reads)) when rendering a UI: `permissionSummaries` / `accessSummary` / `pendingInvitationSummaries` resolve `email`/`name` and do the owned + shared merge, so display screens don't reassemble the raw rows. Reach for the raw reads only when you need the unresolved server shape.
+For the permission / collection reads — `documents.getPermissions(_:)`, `collections.getAccess(_:)`, `documents`/`collections.listPendingInvitations(_:)` — prefer the typed `*Summaries` companions ([above](#typed-summaries-for-permission--collection-reads)) when rendering a UI: `permissionSummaries` / `accessSummary` / `pendingInvitationSummaries` return display-ready types (resolving `email`/`name` on permission rows), so display screens don't reassemble the raw rows. Reach for the raw reads only when you need the unresolved server shape.
 {{/lang}}
 
 **Anti-patterns:**


### PR DESCRIPTION
## What the issue reported
The Swift `documents` guide recommends the typed `*Summaries` wrappers for permission/collection reads, but the most discoverable, obviously-named methods (`documents.getPermissions`, `collections.getAccess`, `listPendingInvitations`) are what a reader reaches for first — and the raw read-API quick reference listed them with no pointer to the typed path.

## Verified against source
Confirmed against the stamped `js-bao-wss` submodule that the typed companions exist on the Swift client (`permissionSummaries` / `accessSummary` / `pendingInvitationSummaries`), and that the Swift read quick-reference table listed only the raw reads.

## What changed
- `guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.template.md` — added a one-line steer under the Swift read quick-reference pointing the raw permission/collection reads at the typed `*Summaries` companions for display, in the existing `{{#lang swift}}` block (renders into the Swift build only).
- Rebuilt `AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.swift.md` via `pnpm render:guides`.

Guide-template only — the human docs don't carry this read quick-reference table, so no `docs/` change.

## Validation
- `pnpm check:examples` — pass (parity, compilation, TOML, CLI, stamp gate)
- `npx vitepress build docs` — pass (no dead links)

Fixes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)