### PR TITLE
Add Apple + Passkey rows to the Swift Auth Methods table (#189)

### DIFF
--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_AUTHENTICATION.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_AUTHENTICATION.swift.md
@@ -9,6 +9,8 @@ Implementing auth flows for Primitive apps. All methods live on `JsBaoClient` (p
 | OAuth (Google) | Primary auth, redirect-based |
 | Magic Link | Passwordless email link |
 | OTP | 6-digit email code (10 min expiry) |
+| Sign in with Apple | Native one-call sign-in (`signInWithApple`); gate on `hasApple` |
+| Passkey | Native one-call sign-in/registration via `AuthenticationServices`; for returning users |
 
 Each method must be enabled in the Admin Console. Check availability with `getAuthConfig()` before showing UI.
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_AUTHENTICATION.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_AUTHENTICATION.template.md
@@ -12,6 +12,10 @@ Implementing auth flows for Primitive apps. All methods live on `JsBaoClient` (p
 {{#lang ts}}
 | Passkey | WebAuthn for returning users (requires existing account) |
 {{/lang}}
+{{#lang swift}}
+| Sign in with Apple | Native one-call sign-in (`signInWithApple`); gate on `hasApple` |
+| Passkey | Native one-call sign-in/registration via `AuthenticationServices`; for returning users |
+{{/lang}}
 
 Each method must be enabled in the Admin Console. Check availability with `getAuthConfig()` before showing UI.
 


### PR DESCRIPTION
## What the issue reported
In `primitive guides get authentication --language swift`, the "Auth Methods" table listed only OAuth / Magic Link / OTP — omitting Apple (which the body documents) and Passkey — and the issue reported the passkey API section as rendering nothing for Swift.

## Verified against source
Re-verified against the stamped `js-bao-wss` submodule:
- The Swift client ships native passkeys (`AuthAPI+NativePasskeys.swift`: `signInWithPasskey`, `registerPasskey`, plus `passkeyList/Update/Delete`) and native Sign in with Apple (`signInWithApple`).
- **The passkey-section claim is already resolved:** the auth guide template already carries a complete `{{#lang swift}}` Passkeys section (sign-in, register, manage, gating) that renders into the Swift build. No change needed there.
- The remaining defect was the **Auth Methods table**: `Passkey` lived inside a `{{#lang ts}}` fence and `Apple` was absent, so the Swift-rendered table showed only OAuth / Magic Link / OTP while the Swift body documented both Apple and passkeys.

## What changed
- `guides/latest/AGENT_GUIDE_TO_PRIMITIVE_AUTHENTICATION.template.md` — added a `{{#lang swift}}` block to the Auth Methods table with `Sign in with Apple` and `Passkey` rows (Apple native sign-in is Swift-only; the TS table keeps its existing WebAuthn Passkey row).
- Rebuilt `AGENT_GUIDE_TO_PRIMITIVE_AUTHENTICATION.swift.md` via `pnpm render:guides`.

The human auth page (`docs/getting-started/authentication.md`) already documents Apple and passkeys in prose, so the docs/guides pair stays in sync without a `docs/` change.

## Validation
- `pnpm check:examples` — pass
- `npx vitepress build docs` — pass (no dead links)

Fixes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)