### PR TITLE
Add platforms block to the guides manifest (#194)

### DIFF
--- a/guides/latest/guides.json
+++ b/guides/latest/guides.json
@@ -3,6 +3,17 @@
     "language": "ts",
     "platform": "web"
   },
+  "platforms": {
+    "web": {
+      "language": "ts"
+    },
+    "ios": {
+      "language": "swift"
+    },
+    "macos": {
+      "language": "swift"
+    }
+  },
   "builtAgainst": {
     "stampedAt": "2026-06-25",
     "channel": "next",

--- a/scripts/stamp-sources.mjs
+++ b/scripts/stamp-sources.mjs
@@ -102,6 +102,7 @@ if (MODE === "write") {
   const manifest = readJson(GUIDES_JSON);
   const out = {
     defaults: manifest.defaults,
+    platforms: manifest.platforms,
     builtAgainst: { stampedAt: stamp.stampedAt, channel: CHANNEL, packages: mergedPackages(libraries) },
     guides: manifest.guides,
   };

--- a/scripts/sync-guides-json.mjs
+++ b/scripts/sync-guides-json.mjs
@@ -5,6 +5,9 @@
 //
 //   {
 //     "defaults": { "language": "ts", "platform": "web" },
+//     "platforms": {                                        // platform→language
+//       "web": { "language": "ts" }, "ios": { "language": "swift" }, ...
+//     },
 //     "guides": [
 //       { "topic": "...",
 //         "file": "<BASE>.ts.md",                       // default variant, always present
@@ -26,7 +29,7 @@
 import { readdirSync, readFileSync, writeFileSync, existsSync } from "node:fs";
 import { join, dirname, basename } from "node:path";
 import { fileURLToPath } from "node:url";
-import { VARIANTS, DEFAULT_VARIANT_ID, MANIFEST_DEFAULTS, manifestVariant } from "./variants.mjs";
+import { VARIANTS, DEFAULT_VARIANT_ID, MANIFEST_DEFAULTS, MANIFEST_PLATFORMS, manifestVariant } from "./variants.mjs";
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 const GUIDES_DIR = join(ROOT, "guides", "latest");
@@ -49,6 +52,15 @@ if (JSON.stringify(manifest.defaults) !== JSON.stringify(MANIFEST_DEFAULTS)) {
     problems.push(`✘ guides.json "defaults" doesn't match variants.mjs MANIFEST_DEFAULTS`);
   } else {
     manifest.defaults = MANIFEST_DEFAULTS;
+    changed++;
+  }
+}
+
+if (JSON.stringify(manifest.platforms) !== JSON.stringify(MANIFEST_PLATFORMS)) {
+  if (CHECK) {
+    problems.push(`✘ guides.json "platforms" doesn't match variants.mjs MANIFEST_PLATFORMS`);
+  } else {
+    manifest.platforms = MANIFEST_PLATFORMS;
     changed++;
   }
 }
@@ -116,8 +128,9 @@ if (problems.length) {
   process.exit(1);
 }
 if (!CHECK && changed) {
-  // `defaults` first, then `guides` — the manifest's documented key order.
-  const out = { defaults: manifest.defaults, ...manifest };
+  // `defaults`, then `platforms`, then the rest — the manifest's documented
+  // key order (guides last).
+  const out = { defaults: manifest.defaults, platforms: manifest.platforms, ...manifest };
   writeFileSync(JSON_PATH, JSON.stringify(out, null, 2) + "\n");
 }
 console.log(CHECK ? "guides.json is current." : `Updated ${changed} guides.json entr${changed === 1 ? "y" : "ies"}.`);

--- a/scripts/variants.mjs
+++ b/scripts/variants.mjs
@@ -50,6 +50,21 @@ export const DEFAULT_VARIANT_ID = "ts";
 // platform) the CLI assumes when a project declares neither.
 export const MANIFEST_DEFAULTS = { language: "ts", platform: "web" };
 
+// Top-level `platforms` block emitted into guides.json — declares which
+// platforms the CLI's `--platform` flag accepts and the default language each
+// maps to. The CLI (js-bao-wss#1219) validates `--platform P` against these
+// keys and, when only `--platform` is given, infers the language from
+// `platforms[P].language` (so `--platform ios` serves the Swift guide even
+// though no guide ships a platform-gated variant). Per-platform objects rather
+// than a flat string→string map leave room for more metadata later without a
+// schema change. These are the CLI-facing platform names (web/ios/macos), a
+// separate vocabulary from the `PLATFORMS` filename-infix tokens above.
+export const MANIFEST_PLATFORMS = {
+  web: { language: "ts" },
+  ios: { language: "swift" },
+  macos: { language: "swift" },
+};
+
 export const variantById = new Map(VARIANTS.map((v) => [v.id, v]));
 
 // Languages that have a platform-agnostic ("base") variant. Corpus parity is


### PR DESCRIPTION
## What the issue reported
#194 asks for a top-level `platforms` block in the guides manifest (`guides.json`) mapping each supported platform to its default language. It's the docs-side dependency of the CLI fix in js-bao-wss#1219, which makes `primitive guides --platform` a validated flag: the CLI validates `--platform P` against the keys of `platforms` and, when only `--platform` is given, infers the language from `platforms[P].language` (so `--platform ios` serves the Swift guide even though no guide ships a platform-gated variant).

## Verified against source
- The CLI-facing platform vocabulary is `web` / `ios` / `macos` — confirmed in the stamped submodule's `cli/src/commands/guides.ts` help text and `--platform` examples (lines 519, 547, 624). The issue's proposed mapping (`web→ts`, `ios→swift`, `macos→swift`) matches it. (Note: `macos`, the CLI name, is deliberately distinct from the `mac` filename-infix token in `scripts/variants.mjs` `PLATFORMS`, which is an internal example-override concern.)
- The stamped CLI does **not** yet read a `platforms` block (its `Manifest` interface has only `defaults` + `guides`; `--platform` is still non-enforcing), so js-bao-wss#1219 has not landed. That's fine — the issue is designed for the block to land independently: it's inert metadata the current CLI ignores, and it only becomes useful once both sides are in.

## What changed
Metadata + tooling only — **no guide files change**, no `{{#platform}}` content fencing:
- `scripts/variants.mjs` — new `MANIFEST_PLATFORMS` export (the single source for the block).
- `scripts/sync-guides-json.mjs` — emits the block into `guides.json` and validates it in `--check` mode (mirrors the existing `defaults` handling); orders keys `defaults`, `platforms`, then the rest.
- `scripts/stamp-sources.mjs` — carries `platforms` through its `guides.json` rewrite, so a `pnpm stamp:sources` pass can't silently drop it.
- `guides/latest/guides.json` — regenerated with the new block.

## Validation
- `pnpm check:examples` — passes (parity, compilation, TOML, guide render/registry, CLI, source-stamp gate; `sync-guides-json --check` green).
- `npx vitepress build docs` — passes (no dead links).

Fixes #194