### PR TITLE
docs-next-sync: js-bao-wss changes (automated)

### DIFF
--- a/docs-sources.json
+++ b/docs-sources.json
@@ -1,9 +1,9 @@
 {
   "channel": "next",
-  "stampedAt": "2026-06-25",
+  "stampedAt": "2026-06-26",
   "libraries": {
     "js-bao-wss": {
-      "commit": "1734ecbdaaff88f7b78f5de111f3e2599236573a",
+      "commit": "c7c199b4e47fdeaaabba702287a6e6516f57b226",
       "npm": {
         "js-bao-wss-client": "2.0.2",
         "js-bao": "0.5.1",

--- a/docs/getting-started/workflows.md
+++ b/docs/getting-started/workflows.md
@@ -92,6 +92,17 @@ Every step output carries an engine-managed `ok` boolean (and `skipped: true` wh
 
 CEL optional types are enabled in every workflow context, so you can collapse multi-conjunct null guards: `steps.fetch.?data.?items.orValue([]).size() > 0`.
 
+When a step reads a value from an upstream step that can itself be skipped, list that upstream in `skipWhenSkipped` so the dependent skips too instead of failing on the missing output:
+
+```toml
+[[steps]]
+id = "summarize"
+kind = "llm.chat"
+skipWhenSkipped = ["fetch"]   # if "fetch" was skipped, skip this step without evaluating runIf
+```
+
+The skip cascades — a step skipped this way will in turn skip its own `skipWhenSkipped` dependents. List only earlier step ids. A step that *errored* under `continueOnError` does not trigger the skip; only a genuinely skipped upstream does.
+
 ## The Run Lifecycle
 
 Every invocation creates a persistent **workflow run**. A run moves through `queued` → `running` → a terminal state (`completed`, `failed`, or `terminated`). Workflows that apply their results into local-first documents add two more states — `apply_pending` and `apply_claimed` — between the last step and completion (see [Applying Results to Local Data](#applying-results-to-local-data-client-apply)).

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_SCRIPTS.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_SCRIPTS.md
@@ -67,30 +67,16 @@ The script's return value is its last expression. Given `steps.fetch.body = { "i
 - **`NaN`/`Infinity` can't survive JSON output** — they serialize as `null`. Return a sentinel value instead of relying on them.
 - **Map key order is normalized** at serialization, so output is byte-stable regardless of insertion order.
 
-## The `parse_json` top-level-array gotcha
+## `parse_json`
 
-`parse_json(...)` parses a JSON **object** string into a map. It is **object-only**: handed a string whose top-level JSON value is an **array**, it raises a type error that surfaces as:
-
-```
-output type mismatch: want map, got array
-```
-
-The wording is misleading — "output type" refers to what `parse_json` expected to produce (a map), **not** the script step's output. The error fires from the `parse_json` call, but because the message reads like an output-shape complaint, it's easy to misread as a problem with the script's return value even when the script clearly returns a map. A common trigger is a database or document field that stores a JSON **array** as a string (a weights array, a composition list).
-
-Wrap the array in an object before parsing, then extract:
+`parse_json(str)` parses a strict-JSON string into the matching Rhai value: a JSON object becomes a map, an array becomes an array, and primitives and `null` map to their Rhai equivalents. A database or document field that stores a JSON **array** as a string (a weights array, a composition list) parses straight into an array — no wrapper needed.
 
 ```
-fn parse_json_array(raw) {
-  if raw == () || type_of(raw) != "string" || raw == "" { return []; }
-  let wrapped = parse_json("{\"a\":" + raw + "}");
-  if type_of(wrapped) == "map" && type_of(wrapped.a) == "array" { return wrapped.a; }
-  []
-}
-
-// let weights = parse_json_array(input.weightsJson);
+let weights = parse_json(input.weightsJson);   // "[0.2, 0.5, 0.3]" → [0.2, 0.5, 0.3]
+let config  = parse_json(input.configJson);    // "{\"limit\": 10}" → #{ "limit": 10 }
 ```
 
-`parse_json` on a top-level **object** string needs no workaround.
+Input must be **strict JSON**. Trailing commas, `//` or `/* */` comments, single-quoted strings, and hex literals are rejected. Invalid input fails the step with a non-retryable `SCRIPT_RUNTIME_ERROR` carrying a positioned message — `parse_json: invalid JSON at line N column M: …` — and, when the input matches one of those non-standard forms, a hint pointing at strict JSON. Map keys are sorted at output, so a parsed-then-returned object is byte-stable.
 
 ## Per-step limits
 
@@ -126,7 +112,7 @@ Deterministic failures (the script will fail the same way every time) come back 
 |---|---|---|
 | `SCRIPT_PARSE_ERROR` | Input or source JSON failed to parse | No |
 | `SCRIPT_COMPILE_ERROR` | Rhai source failed to compile | No |
-| `SCRIPT_TYPE_ERROR` | Type mismatch — includes the `parse_json` array gotcha above | No |
+| `SCRIPT_TYPE_ERROR` | Type mismatch in the script body (a string used where a number is required, etc.) | No |
 | `SCRIPT_RUNTIME_ERROR` | Arithmetic error, stack overflow, or other runtime fault | No |
 | `SCRIPT_OPERATION_LIMIT` | Exceeded `maxOperations` | No |
 | `SCRIPT_OUTPUT_LIMIT` | Exceeded an output size/shape cap | No |

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_SCRIPTS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_SCRIPTS.template.md
@@ -67,30 +67,16 @@ The script's return value is its last expression. Given `steps.fetch.body = { "i
 - **`NaN`/`Infinity` can't survive JSON output** — they serialize as `null`. Return a sentinel value instead of relying on them.
 - **Map key order is normalized** at serialization, so output is byte-stable regardless of insertion order.
 
-## The `parse_json` top-level-array gotcha
+## `parse_json`
 
-`parse_json(...)` parses a JSON **object** string into a map. It is **object-only**: handed a string whose top-level JSON value is an **array**, it raises a type error that surfaces as:
-
-```
-output type mismatch: want map, got array
-```
-
-The wording is misleading — "output type" refers to what `parse_json` expected to produce (a map), **not** the script step's output. The error fires from the `parse_json` call, but because the message reads like an output-shape complaint, it's easy to misread as a problem with the script's return value even when the script clearly returns a map. A common trigger is a database or document field that stores a JSON **array** as a string (a weights array, a composition list).
-
-Wrap the array in an object before parsing, then extract:
+`parse_json(str)` parses a strict-JSON string into the matching Rhai value: a JSON object becomes a map, an array becomes an array, and primitives and `null` map to their Rhai equivalents. A database or document field that stores a JSON **array** as a string (a weights array, a composition list) parses straight into an array — no wrapper needed.
 
 ```
-fn parse_json_array(raw) {
-  if raw == () || type_of(raw) != "string" || raw == "" { return []; }
-  let wrapped = parse_json("{\"a\":" + raw + "}");
-  if type_of(wrapped) == "map" && type_of(wrapped.a) == "array" { return wrapped.a; }
-  []
-}
-
-// let weights = parse_json_array(input.weightsJson);
+let weights = parse_json(input.weightsJson);   // "[0.2, 0.5, 0.3]" → [0.2, 0.5, 0.3]
+let config  = parse_json(input.configJson);    // "{\"limit\": 10}" → #{ "limit": 10 }
 ```
 
-`parse_json` on a top-level **object** string needs no workaround.
+Input must be **strict JSON**. Trailing commas, `//` or `/* */` comments, single-quoted strings, and hex literals are rejected. Invalid input fails the step with a non-retryable `SCRIPT_RUNTIME_ERROR` carrying a positioned message — `parse_json: invalid JSON at line N column M: …` — and, when the input matches one of those non-standard forms, a hint pointing at strict JSON. Map keys are sorted at output, so a parsed-then-returned object is byte-stable.
 
 ## Per-step limits
 
@@ -126,7 +112,7 @@ Deterministic failures (the script will fail the same way every time) come back 
 |---|---|---|
 | `SCRIPT_PARSE_ERROR` | Input or source JSON failed to parse | No |
 | `SCRIPT_COMPILE_ERROR` | Rhai source failed to compile | No |
-| `SCRIPT_TYPE_ERROR` | Type mismatch — includes the `parse_json` array gotcha above | No |
+| `SCRIPT_TYPE_ERROR` | Type mismatch in the script body (a string used where a number is required, etc.) | No |
 | `SCRIPT_RUNTIME_ERROR` | Arithmetic error, stack overflow, or other runtime fault | No |
 | `SCRIPT_OPERATION_LIMIT` | Exceeded `maxOperations` | No |
 | `SCRIPT_OUTPUT_LIMIT` | Exceeded an output size/shape cap | No |

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.swift.md
@@ -50,6 +50,7 @@ All steps support these in addition to their own:
 | `concurrency` | Parallel forEach lanes (integer 1-100; default 1 = sequential). Results preserve insertion order. |
 | `successWhen` | CEL predicate evaluated per forEach iteration to classify the result as functionally succeeded vs empty (see `forEach` below) |
 | `continueOnError` | Capture errors as `{ error, errorDetails, ok: false, errored: true }` instead of failing the workflow |
+| `skipWhenSkipped` | Array of earlier step ids. Before this step's own `runIf` is evaluated, skip this step (with the same `{ ok: false, skipped: true }` stub) if any listed upstream was skipped. Transitive; reacts only to `skipped: true`, not `errored: true`. Unknown/forward ids are tolerated at run time and warned at save time. |
 | `strict` | Throw if any template expression in this step is unresolved |
 
 ## Data flow
@@ -280,6 +281,8 @@ Read and write records in a document's models server-side. All take `documentId`
 | `document.delete` | `recordId` | `{ deleted: true, id }` |
 
 `filter` uses the same operator syntax as client-side model queries; empty or omitted matches all records. `options` supports `sort` (`{ field = 1 }` / `-1`), `limit`, and cursor pagination (`uniqueStartKey` — feed it the previous page's `nextCursor`).
+
+Writing a `stringset` field (which also backs `refersToMany`) in `save`/`patch` `data` takes either a plain array — `{ tagNames: ["a", "b"] }`, which **replaces** the whole set — or a per-member delta op-object `{ $add?: [...], $remove?: [...], $clear?: true }`. The delta applies `$clear` first, then `$remove`, then `$add` (so `$add` wins a tie), touching only the named members, so it merges cleanly with concurrent client `.add()` / `.delete()`. A returned stringset field reads back as a member array. The op-object is rejected on a non-collection field; a declared stringset given a non-array, non-op value also fails.
 
 ```toml
 [[steps]]
@@ -533,7 +536,7 @@ Given `steps.fetch.body = { "items": [{ "sku": "a1", "qty": 2, "price": 5.0 }, {
 - **Result nesting.** A script step's return value lands under `steps.<id>.output.*` (alongside `scriptMetrics` and the engine's `ok`) — unlike `transform`, whose result is the templated table directly (`steps.<id>.<field>`). Wire downstream templates/`runIf` as `{{ steps.normalize.output.total }}`, not `{{ steps.normalize.total }}`.
 - **Script bodies resolve live at run time.** The runner looks up the script's active config body on each execution; there is no publish-time snapshot. Pushing a changed `.rhai` file (`primitive sync push`) creates a new config and activates it — referencing workflows pick up the new body on their next run with no re-publish step. Pin a specific config with `configId = "..."` on the step to bypass the active-config lookup when determinism is required.
 - Handy patterns: `parse_json(input.someJsonString)` for JSON-string fields (e.g. payload columns stored as strings); missing keys read as `()` (test with `h.symbol != ()`); `NaN`/`Infinity` can't survive JSON output — they serialize as `null`, so return a sentinel instead.
-- **`parse_json` is object-only.** Handed a string whose top-level JSON value is an **array**, it raises `output type mismatch: want map, got array` — the "output type" is `parse_json`'s expected output, not the step's, so it reads like an output-shape problem even when the script returns a map. Wrap the array first: `parse_json("{\"a\":" + raw + "}").a`. Top-level objects need no workaround.
+- **`parse_json` parses any strict-JSON value** — object→map, array→array, plus primitives and `null` — so a field storing a JSON array string parses straight into an array. Input must be strict JSON (no trailing commas, comments, single quotes, or hex literals); invalid input fails the step with a non-retryable `SCRIPT_RUNTIME_ERROR` and a positioned message.
 - `limits` (optional) lets a step lower the per-run ceilings (`maxOperations`, `wallMsHint`, `maxOutputBytes`, `maxArrayLength`, `maxObjectKeys`, `maxNestingDepth`, `maxStringSize`, `maxCallDepth`, `maxLogBytes`); requested values are clamped at the app ceiling, never raised.
 - Deterministic failures (parse / compile / runtime / limit / validation) come back as a non-retryable step error so durable retries don't re-run a guaranteed failure; transient/transport errors throw and retry normally. The runtime fails closed — it never silently passes input through.
 - Each execution records per-step telemetry on the `WorkflowRun.scriptMetrics` array (operation counts, input/output byte sizes, runtime version), visible in run detail.
@@ -817,7 +820,7 @@ Every entry in `steps[id]` carries a reserved verdict namespace alongside the ru
 | Field | When set |
 |---|---|
 | `ok: boolean` | Always. `true` if the step ran and the runner classified it as successful; `false` for skipped, errored, or kind-specific failures (e.g. an `integration.call` that returned HTTP 5xx) |
-| `skipped: true` | The step's `runIf` evaluated falsy. The runner did NOT execute. |
+| `skipped: true` | The step's `runIf` evaluated falsy, or a step listed in its `skipWhenSkipped` was itself skipped. The runner did NOT execute. |
 | `errored: true` | The step threw but was captured by `continueOnError = true` |
 | `error`, `errorDetails` | Companion fields populated when `errored: true` |
 
@@ -827,6 +830,8 @@ Every entry in `steps[id]` carries a reserved verdict namespace alongside the ru
 runIf = "steps.fetch.ok"
 runIf = "!steps.fetch.skipped && !steps.fetch.errored"
 ```
+
+When a step reads `steps.<upstream>.output.*` and that upstream can be skipped, a skipped upstream leaves no `output` key and an unguarded multi-segment read throws `No such key: output`. Two structural fixes: guard the read with safe navigation (`steps.fetch.?output.?items`), or declare `skipWhenSkipped = ["fetch"]` so the dependent auto-skips whenever `fetch` skips — its `runIf` is never evaluated. The skip is transitive and reacts only to `skipped: true` (an upstream that errored under `continueOnError` does not trigger it). List only earlier step ids; a save-time warning flags an unguarded skippable read or a `skipWhenSkipped` entry naming an unknown or forward step id.
 
 ## Access control
 
@@ -931,7 +936,9 @@ status = "active"
 
 Receive endpoint: `POST /app/{appId}/webhook/{webhookKey}`. The platform verifies the signature per `verificationScheme`, then starts `workflowKey` with the event payload as input; `inputMapping` (e.g. `"data.object"`) extracts a nested path first. Always pair a webhook-triggered workflow with `accessRule = "hasRole('owner')"` (see Access control above) so clients can't start it directly with a crafted payload.
 
-CLI: `primitive webhooks list | get | create | update | delete | rotate-secret | test | events <webhook-key>` — `events` lists recent deliveries (accepted / rejected / duplicate).
+CLI: `primitive webhooks list | get | create | update | delete | rotate-secret | test | events <webhook-key>` — `events` lists recent deliveries (accepted / rejected / duplicate / `workflow_not_active`).
+
+A `workflow_not_active` delivery means the bound workflow was draft or archived when the event arrived: the request is acked with HTTP 202 `{ received: true }` (so the sender doesn't retry) but the workflow is **not dispatched**. Activate the workflow and resend — these events are excluded from deduplication, so the resend isn't dropped as a duplicate. Binding a webhook to a not-yet-active workflow succeeds and returns a non-blocking `warning` carrying `WORKFLOW_NOT_ACTIVE`.
 
 ## Cron triggers
 
@@ -1130,10 +1137,12 @@ Trigger states:
 
 - `active` — scheduled, alarm armed.
 - `paused` — manual pause; alarm cancelled until `resume`.
-- `error_paused` — set automatically when the workflow start fails or the cron expression becomes unparseable. `lastError` is populated. Call `resume` to clear and reschedule.
+- `error_paused` — set automatically when a fire fails hard (the target workflow is **not found**, or a binding/runtime error), when the cron expression becomes unparseable, or after 50 consecutive skips against a **not-active** target. `lastError` is populated (carrying `WORKFLOW_NOT_FOUND` or `WORKFLOW_NOT_ACTIVE`). Call `resume` to clear and reschedule.
 - `archived` — soft-deleted; never returns from list.
 
-`skippedCount` increments when `overlapPolicy: "skip"` blocks a fire because the prior run is still active.
+A target workflow that is draft or archived (**not active**) does NOT error-pause on the first fire: the fire is skipped and rescheduled, `lastError` is set to `WORKFLOW_NOT_ACTIVE`, and `consecutiveNotActiveCount` increments. It auto-recovers once the workflow is activated (the counter resets and `lastError` clears); only after 50 consecutive not-active skips does it escalate to `error_paused`. A target that is **not found**, by contrast, error-pauses immediately.
+
+`skippedCount` increments when `overlapPolicy: "skip"` blocks a fire because the prior run is still active — distinct from `consecutiveNotActiveCount`.
 
 ### Driving subscriptions from cron
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md
@@ -50,6 +50,7 @@ All steps support these in addition to their own:
 | `concurrency` | Parallel forEach lanes (integer 1-100; default 1 = sequential). Results preserve insertion order. |
 | `successWhen` | CEL predicate evaluated per forEach iteration to classify the result as functionally succeeded vs empty (see `forEach` below) |
 | `continueOnError` | Capture errors as `{ error, errorDetails, ok: false, errored: true }` instead of failing the workflow |
+| `skipWhenSkipped` | Array of earlier step ids. Before this step's own `runIf` is evaluated, skip this step (with the same `{ ok: false, skipped: true }` stub) if any listed upstream was skipped. Transitive; reacts only to `skipped: true`, not `errored: true`. Unknown/forward ids are tolerated at run time and warned at save time. |
 | `strict` | Throw if any template expression in this step is unresolved |
 
 ## Data flow
@@ -280,6 +281,8 @@ Read and write records in a document's models server-side. All take `documentId`
 | `document.delete` | `recordId` | `{ deleted: true, id }` |
 
 `filter` uses the same operator syntax as client-side model queries; empty or omitted matches all records. `options` supports `sort` (`{ field = 1 }` / `-1`), `limit`, and cursor pagination (`uniqueStartKey` — feed it the previous page's `nextCursor`).
+
+Writing a `stringset` field (which also backs `refersToMany`) in `save`/`patch` `data` takes either a plain array — `{ tagNames: ["a", "b"] }`, which **replaces** the whole set — or a per-member delta op-object `{ $add?: [...], $remove?: [...], $clear?: true }`. The delta applies `$clear` first, then `$remove`, then `$add` (so `$add` wins a tie), touching only the named members, so it merges cleanly with concurrent client `.add()` / `.delete()`. A returned stringset field reads back as a member array. The op-object is rejected on a non-collection field; a declared stringset given a non-array, non-op value also fails.
 
 ```toml
 [[steps]]
@@ -533,7 +536,7 @@ Given `steps.fetch.body = { "items": [{ "sku": "a1", "qty": 2, "price": 5.0 }, {
 - **Result nesting.** A script step's return value lands under `steps.<id>.output.*` (alongside `scriptMetrics` and the engine's `ok`) — unlike `transform`, whose result is the templated table directly (`steps.<id>.<field>`). Wire downstream templates/`runIf` as `{{ steps.normalize.output.total }}`, not `{{ steps.normalize.total }}`.
 - **Script bodies resolve live at run time.** The runner looks up the script's active config body on each execution; there is no publish-time snapshot. Pushing a changed `.rhai` file (`primitive sync push`) creates a new config and activates it — referencing workflows pick up the new body on their next run with no re-publish step. Pin a specific config with `configId = "..."` on the step to bypass the active-config lookup when determinism is required.
 - Handy patterns: `parse_json(input.someJsonString)` for JSON-string fields (e.g. payload columns stored as strings); missing keys read as `()` (test with `h.symbol != ()`); `NaN`/`Infinity` can't survive JSON output — they serialize as `null`, so return a sentinel instead.
-- **`parse_json` is object-only.** Handed a string whose top-level JSON value is an **array**, it raises `output type mismatch: want map, got array` — the "output type" is `parse_json`'s expected output, not the step's, so it reads like an output-shape problem even when the script returns a map. Wrap the array first: `parse_json("{\"a\":" + raw + "}").a`. Top-level objects need no workaround.
+- **`parse_json` parses any strict-JSON value** — object→map, array→array, plus primitives and `null` — so a field storing a JSON array string parses straight into an array. Input must be strict JSON (no trailing commas, comments, single quotes, or hex literals); invalid input fails the step with a non-retryable `SCRIPT_RUNTIME_ERROR` and a positioned message.
 - `limits` (optional) lets a step lower the per-run ceilings (`maxOperations`, `wallMsHint`, `maxOutputBytes`, `maxArrayLength`, `maxObjectKeys`, `maxNestingDepth`, `maxStringSize`, `maxCallDepth`, `maxLogBytes`); requested values are clamped at the app ceiling, never raised.
 - Deterministic failures (parse / compile / runtime / limit / validation) come back as a non-retryable step error so durable retries don't re-run a guaranteed failure; transient/transport errors throw and retry normally. The runtime fails closed — it never silently passes input through.
 - Each execution records per-step telemetry on the `WorkflowRun.scriptMetrics` array (operation counts, input/output byte sizes, runtime version), visible in run detail.
@@ -817,7 +820,7 @@ Every entry in `steps[id]` carries a reserved verdict namespace alongside the ru
 | Field | When set |
 |---|---|
 | `ok: boolean` | Always. `true` if the step ran and the runner classified it as successful; `false` for skipped, errored, or kind-specific failures (e.g. an `integration.call` that returned HTTP 5xx) |
-| `skipped: true` | The step's `runIf` evaluated falsy. The runner did NOT execute. |
+| `skipped: true` | The step's `runIf` evaluated falsy, or a step listed in its `skipWhenSkipped` was itself skipped. The runner did NOT execute. |
 | `errored: true` | The step threw but was captured by `continueOnError = true` |
 | `error`, `errorDetails` | Companion fields populated when `errored: true` |
 
@@ -827,6 +830,8 @@ Every entry in `steps[id]` carries a reserved verdict namespace alongside the ru
 runIf = "steps.fetch.ok"
 runIf = "!steps.fetch.skipped && !steps.fetch.errored"
 ```
+
+When a step reads `steps.<upstream>.output.*` and that upstream can be skipped, a skipped upstream leaves no `output` key and an unguarded multi-segment read throws `No such key: output`. Two structural fixes: guard the read with safe navigation (`steps.fetch.?output.?items`), or declare `skipWhenSkipped = ["fetch"]` so the dependent auto-skips whenever `fetch` skips — its `runIf` is never evaluated. The skip is transitive and reacts only to `skipped: true` (an upstream that errored under `continueOnError` does not trigger it). List only earlier step ids; a save-time warning flags an unguarded skippable read or a `skipWhenSkipped` entry naming an unknown or forward step id.
 
 ## Access control
 
@@ -931,7 +936,9 @@ status = "active"
 
 Receive endpoint: `POST /app/{appId}/webhook/{webhookKey}`. The platform verifies the signature per `verificationScheme`, then starts `workflowKey` with the event payload as input; `inputMapping` (e.g. `"data.object"`) extracts a nested path first. Always pair a webhook-triggered workflow with `accessRule = "hasRole('owner')"` (see Access control above) so clients can't start it directly with a crafted payload.
 
-CLI: `primitive webhooks list | get | create | update | delete | rotate-secret | test | events <webhook-key>` — `events` lists recent deliveries (accepted / rejected / duplicate).
+CLI: `primitive webhooks list | get | create | update | delete | rotate-secret | test | events <webhook-key>` — `events` lists recent deliveries (accepted / rejected / duplicate / `workflow_not_active`).
+
+A `workflow_not_active` delivery means the bound workflow was draft or archived when the event arrived: the request is acked with HTTP 202 `{ received: true }` (so the sender doesn't retry) but the workflow is **not dispatched**. Activate the workflow and resend — these events are excluded from deduplication, so the resend isn't dropped as a duplicate. Binding a webhook to a not-yet-active workflow succeeds and returns a non-blocking `warning` carrying `WORKFLOW_NOT_ACTIVE`.
 
 ## Cron triggers
 
@@ -1107,10 +1114,12 @@ Trigger states:
 
 - `active` — scheduled, alarm armed.
 - `paused` — manual pause; alarm cancelled until `resume`.
-- `error_paused` — set automatically when the workflow start fails or the cron expression becomes unparseable. `lastError` is populated. Call `resume` to clear and reschedule.
+- `error_paused` — set automatically when a fire fails hard (the target workflow is **not found**, or a binding/runtime error), when the cron expression becomes unparseable, or after 50 consecutive skips against a **not-active** target. `lastError` is populated (carrying `WORKFLOW_NOT_FOUND` or `WORKFLOW_NOT_ACTIVE`). Call `resume` to clear and reschedule.
 - `archived` — soft-deleted; never returns from list.
 
-`skippedCount` increments when `overlapPolicy: "skip"` blocks a fire because the prior run is still active.
+A target workflow that is draft or archived (**not active**) does NOT error-pause on the first fire: the fire is skipped and rescheduled, `lastError` is set to `WORKFLOW_NOT_ACTIVE`, and `consecutiveNotActiveCount` increments. It auto-recovers once the workflow is activated (the counter resets and `lastError` clears); only after 50 consecutive not-active skips does it escalate to `error_paused`. A target that is **not found**, by contrast, error-pauses immediately.
+
+`skippedCount` increments when `overlapPolicy: "skip"` blocks a fire because the prior run is still active — distinct from `consecutiveNotActiveCount`.
 
 ### Driving subscriptions from cron
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.ts.md
@@ -50,6 +50,7 @@ All steps support these in addition to their own:
 | `concurrency` | Parallel forEach lanes (integer 1-100; default 1 = sequential). Results preserve insertion order. |
 | `successWhen` | CEL predicate evaluated per forEach iteration to classify the result as functionally succeeded vs empty (see `forEach` below) |
 | `continueOnError` | Capture errors as `{ error, errorDetails, ok: false, errored: true }` instead of failing the workflow |
+| `skipWhenSkipped` | Array of earlier step ids. Before this step's own `runIf` is evaluated, skip this step (with the same `{ ok: false, skipped: true }` stub) if any listed upstream was skipped. Transitive; reacts only to `skipped: true`, not `errored: true`. Unknown/forward ids are tolerated at run time and warned at save time. |
 | `strict` | Throw if any template expression in this step is unresolved |
 
 ## Data flow
@@ -280,6 +281,8 @@ Read and write records in a document's models server-side. All take `documentId`
 | `document.delete` | `recordId` | `{ deleted: true, id }` |
 
 `filter` uses the same operator syntax as client-side model queries; empty or omitted matches all records. `options` supports `sort` (`{ field = 1 }` / `-1`), `limit`, and cursor pagination (`uniqueStartKey` — feed it the previous page's `nextCursor`).
+
+Writing a `stringset` field (which also backs `refersToMany`) in `save`/`patch` `data` takes either a plain array — `{ tagNames: ["a", "b"] }`, which **replaces** the whole set — or a per-member delta op-object `{ $add?: [...], $remove?: [...], $clear?: true }`. The delta applies `$clear` first, then `$remove`, then `$add` (so `$add` wins a tie), touching only the named members, so it merges cleanly with concurrent client `.add()` / `.delete()`. A returned stringset field reads back as a member array. The op-object is rejected on a non-collection field; a declared stringset given a non-array, non-op value also fails.
 
 ```toml
 [[steps]]
@@ -533,7 +536,7 @@ Given `steps.fetch.body = { "items": [{ "sku": "a1", "qty": 2, "price": 5.0 }, {
 - **Result nesting.** A script step's return value lands under `steps.<id>.output.*` (alongside `scriptMetrics` and the engine's `ok`) — unlike `transform`, whose result is the templated table directly (`steps.<id>.<field>`). Wire downstream templates/`runIf` as `{{ steps.normalize.output.total }}`, not `{{ steps.normalize.total }}`.
 - **Script bodies resolve live at run time.** The runner looks up the script's active config body on each execution; there is no publish-time snapshot. Pushing a changed `.rhai` file (`primitive sync push`) creates a new config and activates it — referencing workflows pick up the new body on their next run with no re-publish step. Pin a specific config with `configId = "..."` on the step to bypass the active-config lookup when determinism is required.
 - Handy patterns: `parse_json(input.someJsonString)` for JSON-string fields (e.g. payload columns stored as strings); missing keys read as `()` (test with `h.symbol != ()`); `NaN`/`Infinity` can't survive JSON output — they serialize as `null`, so return a sentinel instead.
-- **`parse_json` is object-only.** Handed a string whose top-level JSON value is an **array**, it raises `output type mismatch: want map, got array` — the "output type" is `parse_json`'s expected output, not the step's, so it reads like an output-shape problem even when the script returns a map. Wrap the array first: `parse_json("{\"a\":" + raw + "}").a`. Top-level objects need no workaround.
+- **`parse_json` parses any strict-JSON value** — object→map, array→array, plus primitives and `null` — so a field storing a JSON array string parses straight into an array. Input must be strict JSON (no trailing commas, comments, single quotes, or hex literals); invalid input fails the step with a non-retryable `SCRIPT_RUNTIME_ERROR` and a positioned message.
 - `limits` (optional) lets a step lower the per-run ceilings (`maxOperations`, `wallMsHint`, `maxOutputBytes`, `maxArrayLength`, `maxObjectKeys`, `maxNestingDepth`, `maxStringSize`, `maxCallDepth`, `maxLogBytes`); requested values are clamped at the app ceiling, never raised.
 - Deterministic failures (parse / compile / runtime / limit / validation) come back as a non-retryable step error so durable retries don't re-run a guaranteed failure; transient/transport errors throw and retry normally. The runtime fails closed — it never silently passes input through.
 - Each execution records per-step telemetry on the `WorkflowRun.scriptMetrics` array (operation counts, input/output byte sizes, runtime version), visible in run detail.
@@ -817,7 +820,7 @@ Every entry in `steps[id]` carries a reserved verdict namespace alongside the ru
 | Field | When set |
 |---|---|
 | `ok: boolean` | Always. `true` if the step ran and the runner classified it as successful; `false` for skipped, errored, or kind-specific failures (e.g. an `integration.call` that returned HTTP 5xx) |
-| `skipped: true` | The step's `runIf` evaluated falsy. The runner did NOT execute. |
+| `skipped: true` | The step's `runIf` evaluated falsy, or a step listed in its `skipWhenSkipped` was itself skipped. The runner did NOT execute. |
 | `errored: true` | The step threw but was captured by `continueOnError = true` |
 | `error`, `errorDetails` | Companion fields populated when `errored: true` |
 
@@ -827,6 +830,8 @@ Every entry in `steps[id]` carries a reserved verdict namespace alongside the ru
 runIf = "steps.fetch.ok"
 runIf = "!steps.fetch.skipped && !steps.fetch.errored"
 ```
+
+When a step reads `steps.<upstream>.output.*` and that upstream can be skipped, a skipped upstream leaves no `output` key and an unguarded multi-segment read throws `No such key: output`. Two structural fixes: guard the read with safe navigation (`steps.fetch.?output.?items`), or declare `skipWhenSkipped = ["fetch"]` so the dependent auto-skips whenever `fetch` skips — its `runIf` is never evaluated. The skip is transitive and reacts only to `skipped: true` (an upstream that errored under `continueOnError` does not trigger it). List only earlier step ids; a save-time warning flags an unguarded skippable read or a `skipWhenSkipped` entry naming an unknown or forward step id.
 
 ## Access control
 
@@ -931,7 +936,9 @@ status = "active"
 
 Receive endpoint: `POST /app/{appId}/webhook/{webhookKey}`. The platform verifies the signature per `verificationScheme`, then starts `workflowKey` with the event payload as input; `inputMapping` (e.g. `"data.object"`) extracts a nested path first. Always pair a webhook-triggered workflow with `accessRule = "hasRole('owner')"` (see Access control above) so clients can't start it directly with a crafted payload.
 
-CLI: `primitive webhooks list | get | create | update | delete | rotate-secret | test | events <webhook-key>` — `events` lists recent deliveries (accepted / rejected / duplicate).
+CLI: `primitive webhooks list | get | create | update | delete | rotate-secret | test | events <webhook-key>` — `events` lists recent deliveries (accepted / rejected / duplicate / `workflow_not_active`).
+
+A `workflow_not_active` delivery means the bound workflow was draft or archived when the event arrived: the request is acked with HTTP 202 `{ received: true }` (so the sender doesn't retry) but the workflow is **not dispatched**. Activate the workflow and resend — these events are excluded from deduplication, so the resend isn't dropped as a duplicate. Binding a webhook to a not-yet-active workflow succeeds and returns a non-blocking `warning` carrying `WORKFLOW_NOT_ACTIVE`.
 
 ## Cron triggers
 
@@ -1135,10 +1142,12 @@ Trigger states:
 
 - `active` — scheduled, alarm armed.
 - `paused` — manual pause; alarm cancelled until `resume`.
-- `error_paused` — set automatically when the workflow start fails or the cron expression becomes unparseable. `lastError` is populated. Call `resume` to clear and reschedule.
+- `error_paused` — set automatically when a fire fails hard (the target workflow is **not found**, or a binding/runtime error), when the cron expression becomes unparseable, or after 50 consecutive skips against a **not-active** target. `lastError` is populated (carrying `WORKFLOW_NOT_FOUND` or `WORKFLOW_NOT_ACTIVE`). Call `resume` to clear and reschedule.
 - `archived` — soft-deleted; never returns from list.
 
-`skippedCount` increments when `overlapPolicy: "skip"` blocks a fire because the prior run is still active.
+A target workflow that is draft or archived (**not active**) does NOT error-pause on the first fire: the fire is skipped and rescheduled, `lastError` is set to `WORKFLOW_NOT_ACTIVE`, and `consecutiveNotActiveCount` increments. It auto-recovers once the workflow is activated (the counter resets and `lastError` clears); only after 50 consecutive not-active skips does it escalate to `error_paused`. A target that is **not found**, by contrast, error-pauses immediately.
+
+`skippedCount` increments when `overlapPolicy: "skip"` blocks a fire because the prior run is still active — distinct from `consecutiveNotActiveCount`.
 
 ### Driving subscriptions from cron
 

--- a/guides/latest/guides.json
+++ b/guides/latest/guides.json
@@ -15,7 +15,7 @@
     }
   },
   "builtAgainst": {
-    "stampedAt": "2026-06-25",
+    "stampedAt": "2026-06-26",
     "channel": "next",
     "packages": {
       "js-bao-wss-client": "2.0.2",


### PR DESCRIPTION
Automated `docs-next-sync` pass against the library main tips, triggered by the nightly release js-bao-wss#1248.

> **Rolling PR.** This PR is updated in place each night until it merges — every update is a complete, gate-green superset of everything new since the last merge (branched fresh from `next`, not stacked). Merge it to advance the baseline; the next nightly then starts fresh and small.

# docs-next-sync disposition report — 2026-06-26

**Channel:** next · **Branch:** next (working tree only — no commit/push; PR opened by the workflow)
**Submodules stamped at:** js-bao-wss `c7c199b4` · primitive-app-dev `fc60fa57` (no change) · swift-primitive-app-dev `943ba1ab` (no change)
**Gates:** `check:examples` ✅ (TS compile green against submodule source; Swift compile skipped — needs macOS host, covered by macOS CI) · `vitepress build` ✅ (no dead links) · stamp gate ✅
**Open docs issues:** none (`gh issue list` empty) — no upstream-keyed / promote-on-parity issues to action or defer.
**Parity issues filed:** none — every change this batch is language-agnostic (workflow TOML config + Rhai scripting). No JS/Swift client gap surfaced.

> Tooling note: the sandbox's `pnpm` shim regressed mid-run from 10.28.2 → 9.0.0 and refused `pnpm <script>` on the `packageManager` pin. All gates were instead run via their underlying `node scripts/*.mjs` invocations (identical commands) and the local `vitepress` binary directly. Results are real green runs; this is an environment quirk, not a doc problem.

## Per-commit disposition (js-bao-wss, 47 commits since `1734ecbd`)

Commits collapse into 6 developer-facing PRs plus nightly/skills/test-page noise.

| Item | Disposition |
|---|---|
| **#1182** `feat(rhai-runtime): arrays as first-class via parse_json` (merge `6ad71174` / `39bc3086` + review commits) | **updated SCRIPTS guide + WORKFLOWS guide.** `parse_json` now parses any strict-JSON value (object→map, array→array, primitives, null), strict-only, invalid input → non-retryable `SCRIPT_RUNTIME_ERROR`. Rewrote the SCRIPTS guide's now-false "parse_json top-level-array gotcha" section, fixed the error-table row (dropped the `SCRIPT_TYPE_ERROR` array-gotcha clause), and corrected the stale "parse_json is object-only" bullet in the WORKFLOWS guide `script` section. |
| **#1200** `docs(app-api): RouteMeta for Batch-1 REST endpoints` (merge `1999c607` + the `docs(app-api): …` commits + `249e10d3`) | **internal — no change.** Pure additive route metadata (summary/tags/auth) + regenerated `openapi.json`. Verified zero route/shape/enum/limit changes (283 `register()` calls before and after; no `validateRequest`/`request`/`deprecated` set). No doc references `openapi.json`; the REST-path citations in docs are unchanged. |
| **#1207** `fix(workflows): isolate per-user dispatch failures in iterate-users onPartialFailure=continue` (merge `55409147` / `fefdccf3` / `9d02ef16`) | **internal — bug fix, docs already correct.** `onPartialFailure` (`"continue"` default \| `"fail"`) and `iterate-users` are already documented in both workflows.md and the WORKFLOWS guide with the exact contract this fix restores ("`continue` tallies/skips per-user failures and keeps going"). The added failure taxonomy / 50-id cap are below page/guide altitude. |
| **#1208** `feat(workflows): skipWhenSkipped auto-skip for dependents of a skipped step` (merge `4ac18d12` / `03959cdd` + review/test commits) | **updated workflows.md + WORKFLOWS guide.** New per-step field `skipWhenSkipped: string[]` (array of earlier step ids; opt-in). Added a tutorial paragraph + TOML example to workflows.md "Conditional Execution"; added a step-fields table row, a uniform-verdict note (the `No such key: output` footgun + the two structural fixes), and updated the `skipped: true` definition in the WORKFLOWS guide. Verified field name/type against `src/workflows/runner/types.ts:109` and the regenerated CLI allowlist. |
| **#1221** `feat(workflows): cron+webhook not-active vs not-found parity` (merge `5996160a` / `f225cea5` / `44ed2b35` / `f3080449`) | **updated WORKFLOWS guide.** Cron: a not-active (draft/archived) target skips + reschedules (`lastError = WORKFLOW_NOT_ACTIVE`, `consecutiveNotActiveCount++`), auto-recovers on activation, escalates to `error_paused` only after 50 consecutive skips; a not-found target error-pauses immediately. Webhook: not-active fire is acked HTTP 202 but not dispatched, logged as event status `workflow_not_active`, excluded from dedup. Rewrote the cron `error_paused` state bullet + added a not-active behavior note, and expanded the webhook `events` status list. Verified against `src/cron-trigger-do.ts` (threshold = 50, `cron-trigger-do.ts:35`) and `src/app-api/services/webhook-receiver.ts:218,236`. Human workflows.md kept tutorial-level (no trigger-state detail) — see flagged editorial call below. |
| **#1242 / #1244** `fix(workflows): schema-aware server-direct stringset/refersToMany writes` (squash `605d601a`) | **drafted new capability in WORKFLOWS guide — FLAGGED (see below).** Core is an internal correctness fix (server-direct `document.save`/`patch` now write the canonical nested `Y.Map` for stringset/refersToMany instead of a verbatim array), but it also introduces a *new authoring capability*: `data` for a stringset field accepts a plain array (replace) **or** a delta op-object `{ $add?, $remove?, $clear? }`. Drafted a concise note on the `document.*` steps section. Verified shape against `src/yjs-room-v2.ts:113-157`. |
| Nightly/CI: `c7c199b4`, `47309370`, `35ca86a5`, `57c9d364` (CLI allowlist regen, RouteMeta for test-scheduled route, test-page meta export) | **internal — no change.** The allowlist regen is what makes `skipWhenSkipped` / `onPartialFailure` pass CLI validation — captured implicitly by the green `check-cli` gate. |
| Skills tooling: all `chore(skills): …` commits (`f05555a0`, `8b2944ce`, `84d2e346`, `b7818a61`, `aa92318c`, `ed67a6eb`, `187aeab6`, `eb67828b`, `ab27646b`, `bc962fbb`, `8ba792e3`, `238ba127`, `4f1ccaf5`, `551db030`, `f7cb2594`, `91ebbc86`) | **internal — no change.** Library-side automation/skills, not developer-facing. |
| Test pages: `29120067`, `e5cfbed1`, `467595da`, `469fec7a`, `aa92318c` and the `address review feedback` commits | **internal — no change.** Sample-app manual test pages / PR review iterations folded into the feature PRs above. |

primitive-app-dev and swift-primitive-app-dev: **0 commits** since their stamps — nothing to triage.

## Larger / judgment-call changes flagged for review

1. **New authoring capability drafted (not parked) — stringset delta ops in workflow document writes (#1244).** Per the unattended "draft, don't defer" rule, I documented the new `{ $add / $remove / $clear }` op-object syntax for `document.save`/`patch` writes to `stringset`/`refersToMany` fields, in the WORKFLOWS *guide only*. Rationale: the guide's `document.*` section is the natural home and there's precedent (the `database.mutate` step documents `addToSet`/`removeFromSet`), but per-field-type write shapes are reference-grade detail below the human workflows.md page's tutorial altitude — so I did not mirror it onto the human page. **Reviewer check:** confirm the guide-only placement and altitude call.

2. **Guide-only updates for cron/webhook not-active states (#1221).** These trigger-state mechanics (the 50-skip escalation, `consecutiveNotActiveCount`, the `workflow_not_active` delivery status) went into the WORKFLOWS guide but not the human workflows.md, which deliberately documents cron/webhooks at tutorial altitude and carries no trigger-state reference at all. This is a defensible guide-side-only sync (the human page never stated the facts being refined), consistent with STYLE's two-reader split — flagging because it's an asymmetric docs/guide update.

3. **Human workflows.md webhook delivery-status sampling left unchanged.** Line ~269 reads "recent deliveries (accepted, rejected, duplicate)" and now omits the new `workflow_not_active` status. Conservative editorial call: this parenthetical is an illustrative sampling at tutorial altitude, not an exhaustive enum; the complete list lives in the guide. Left as-is rather than turning a teaching aside into a four-item reference. **Reviewer check:** confirm you're comfortable not expanding it.

## Whole-set audit (docs-set-audit)

- **Mechanical sweeps — clean.** No orphan pages (every `getting-started/*.md` is in the sidebar); `guides.json` manifest references all resolve; example-parity inventory unchanged from baseline (6 lone-js, 4 lone-swift, all pre-existing — none in the pages touched this pass; my edits added only language-neutral TOML/prose); `vitepress build` link check passes.
- **Cross-page judgment — one real finding, fixed.** The `parse_json` correction surfaced a set-wide inconsistency: the WORKFLOWS guide `script` section still carried the old "parse_json is object-only / `output type mismatch` array gotcha" bullet, contradicting the corrected SCRIPTS guide. Fixed it in the same pass (now both state strict-JSON-any-value). The `parse_json(input.payload)` mention in the DATABASES guide is generic and remained correct. `skipWhenSkipped` facts are consistent between workflows.md and the WORKFLOWS guide (transitive, skipped-only, earlier-ids). No duplication, boundary, or set-ramp violations introduced.

## Files changed

- `docs/getting-started/workflows.md` — skipWhenSkipped section (Conditional Execution)
- `guides/latest/AGENT_GUIDE_TO_PRIMITIVE_SCRIPTS.template.md` (+ rendered `.md`) — parse_json rewrite + error-table row
- `guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md` (+ rendered `.ts.md` / `.swift.md`) — skipWhenSkipped (table row, verdict note, skipped def); cron not-active states; webhook events status; stringset delta ops; parse_json bullet fix
- `docs-sources.json` + `guides/latest/guides.json` — restamped to the new submodule tips (`builtAgainst` mirrored)
- `library_repos/js-bao-wss` — submodule fast-forwarded `1734ecbd` → `c7c199b4`

## Unresolved contradictions

None. Every fact written was verified against submodule source at the stamped tip; no doc claim was found that the sources contradict and that this pass could not resolve.

---
Review the doc changes and the disposition above, then merge into `next`. Publishing to `main` happens separately at a production release.

> Generated unattended by the Claude Code CLI. Verify facts against source before merging.