### PR TITLE
Access control: entitlement-as-group, external-id trust, owner/admin testing note (#200, #201, #202)

### DIFF
--- a/docs/getting-started/access-control.md
+++ b/docs/getting-started/access-control.md
@@ -34,6 +34,18 @@ Group membership is the workhorse: model teams, roles, and relationships as [gro
 
 Each place a rule appears adds its own context on top — operation `params.*`, the `database.*` being accessed, the `record.*` being written. The feature pages document their specific variables.
 
+### A Rule Sees Identity, Not Stored Data
+
+Every function above answers a question about the *caller* — their role, their group memberships, the operation's params. A rule has no way to read a database record. So an entitlement you want the server to enforce — a paid feature, a role gate — can't live as a flag on a row: storing `isSubscribed = true` and checking it in a rule doesn't work, because the rule can't read the row, and a flag no rule can check isn't enforced server-side (a client can call the operation regardless).
+
+Model the entitlement as **group membership** instead, which a rule *can* check:
+
+```toml novalidate
+access = "isMemberOf('subscription', 'trialing') || isMemberOf('subscription', 'active')"
+```
+
+Maintain that membership from your billing source — add a member when a subscription starts, remove them when it lapses — and every rule that gates a paid feature becomes a one-line membership check.
+
 ## Where Rules Appear
 
 | Surface | What the rule gates | Details |
@@ -78,6 +90,28 @@ primitive rule-sets debug --user <userId> --group-type team --category member --
 ```
 
 The same is available from the client as `client.ruleSets.test()` and `client.ruleSets.debug()`. For database operations, the fastest loop is running the operation as different test users — see [Test Users for Automated Testing](./primitive-cli.md#test-users-for-automated-testing).
+
+**Test gated states as a plain member.** App owners and admins bypass access rules and rule sets — they pass every gate — so you can't exercise a locked or entitlement-gated state while signed in as one. A paywalled feature reads as open to an admin even when the gate is correct. Verify that a gate actually denies using a `member` test user.
+
+## Trusting External Identifiers
+
+When the server later acts on an identifier — opening a billing portal from a payment `customer_id`, calling a provider API on a user's behalf — it must not trust a value the client supplied. A user-writable document holding `customerId` is unsafe: a caller could substitute someone else's id and act on their account.
+
+Keep the authoritative user-to-external-id mapping in a store only the server writes, with reads scoped to the owning user:
+
+- **Writes come from server-side automation only.** Gate the write operation to the workflow that maintains the mapping — `access = "fromWorkflow('billing-webhook')"` — so no client can set it.
+- **Reads return only the caller's own row.** Filter the read on `$user.userId`, so a caller can never name another user's id:
+
+```toml
+[[operations]]
+name = "my-billing-profile"
+type = "query"
+modelName = "billingProfile"
+access = "user.userId != ''"
+definition = '{"filter":{"userId":"$user.userId"}}'
+```
+
+When a server action needs the external id, resolve it from the authenticated user through this operation — never accept it as a parameter from the client.
 
 ## Patterns That Hold Up
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_ACCESS_CONTROL.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_ACCESS_CONTROL.md
@@ -15,6 +15,8 @@ Guidelines for AI agents writing access rules. Server-evaluated authorization ac
 
 Prefer membership checks over user-ID comparisons: `isMemberOf('team', params.teamId)`, `params.teamId in memberGroups('team')`.
 
+A rule reads caller identity and operation params only — it cannot read a database record. So a server-enforced entitlement (paid feature, role gate) can't be a flag on a row (`isSubscribed = true`): no rule can check it, so it isn't enforced. Model the entitlement as group membership, which a rule can check — `isMemberOf('subscription', 'active')` — and maintain that membership from your billing source.
+
 ## Surfaces and their extra context
 
 | Surface | Field(s) | Extra context | Notes |
@@ -54,7 +56,7 @@ primitive rule-sets debug --user <userId> --group-type <type> --category <group|
 primitive rule-sets schema                                   # available context variables/functions
 ```
 
-Client equivalents: `client.ruleSets.test()`, `client.ruleSets.debug()`, `client.ruleSets.schema()`. For end-to-end checks of operation rules, sign in as `+primitivetest` derived users with different roles/memberships and execute the operation.
+Client equivalents: `client.ruleSets.test()`, `client.ruleSets.debug()`, `client.ruleSets.schema()`. For end-to-end checks of operation rules, sign in as `+primitivetest` derived users with different roles/memberships and execute the operation. Owners and admins bypass every rule, so a gated or entitlement-gated state reads as open to them even when the gate is correct — test that a gate actually denies as a plain `member`.
 
 ## Patterns
 
@@ -70,3 +72,4 @@ access = "fromWorkflow('refresh-prices')"                      # only the named 
 - Default-deny, widen deliberately. Missing rules deny (database ops) or allow any member (workflows) — know which surface you're on.
 - One group type per concept (`team`, `org`, `team-admin`); group-level "admin" is modeled as its own group type, not a built-in.
 - Parameterize the resource (`params.teamId`) so one operation serves every team.
+- External identifiers: never trust a client-supplied provider id (a payment `customer_id`) for a server-side action — a caller could substitute another user's id. Keep the user→external-id mapping in a system-write store (write op gated `access = "fromWorkflow('key')"`) with reads scoped to the caller (`definition` filter on `$user.userId`), and resolve the id server-side from the authenticated user.

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_ACCESS_CONTROL.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_ACCESS_CONTROL.template.md
@@ -15,6 +15,8 @@ Guidelines for AI agents writing access rules. Server-evaluated authorization ac
 
 Prefer membership checks over user-ID comparisons: `isMemberOf('team', params.teamId)`, `params.teamId in memberGroups('team')`.
 
+A rule reads caller identity and operation params only — it cannot read a database record. So a server-enforced entitlement (paid feature, role gate) can't be a flag on a row (`isSubscribed = true`): no rule can check it, so it isn't enforced. Model the entitlement as group membership, which a rule can check — `isMemberOf('subscription', 'active')` — and maintain that membership from your billing source.
+
 ## Surfaces and their extra context
 
 | Surface | Field(s) | Extra context | Notes |
@@ -54,7 +56,7 @@ primitive rule-sets debug --user <userId> --group-type <type> --category <group|
 primitive rule-sets schema                                   # available context variables/functions
 ```
 
-Client equivalents: `client.ruleSets.test()`, `client.ruleSets.debug()`, `client.ruleSets.schema()`. For end-to-end checks of operation rules, sign in as `+primitivetest` derived users with different roles/memberships and execute the operation.
+Client equivalents: `client.ruleSets.test()`, `client.ruleSets.debug()`, `client.ruleSets.schema()`. For end-to-end checks of operation rules, sign in as `+primitivetest` derived users with different roles/memberships and execute the operation. Owners and admins bypass every rule, so a gated or entitlement-gated state reads as open to them even when the gate is correct — test that a gate actually denies as a plain `member`.
 
 ## Patterns
 
@@ -70,3 +72,4 @@ access = "fromWorkflow('refresh-prices')"                      # only the named 
 - Default-deny, widen deliberately. Missing rules deny (database ops) or allow any member (workflows) — know which surface you're on.
 - One group type per concept (`team`, `org`, `team-admin`); group-level "admin" is modeled as its own group type, not a built-in.
 - Parameterize the resource (`params.teamId`) so one operation serves every team.
+- External identifiers: never trust a client-supplied provider id (a payment `customer_id`) for a server-side action — a caller could substitute another user's id. Keep the user→external-id mapping in a system-write store (write op gated `access = "fromWorkflow('key')"`) with reads scoped to the caller (`definition` filter on `$user.userId`), and resolve the id server-side from the authenticated user.


### PR DESCRIPTION
Combined fix for three related access-control documentation issues. All three land on `docs/getting-started/access-control.md` and its agent guide.

## #200 — access rules can't read DB rows, so entitlement must be a group
**Reported:** a natural gate is a flag on a record (`isSubscribed = true`) checked in an access rule, but that can't be enforced server-side.
**Verified against source:** operation `access`, subscription `accessRule`/`filter`, and workflow `accessRule` all evaluate with no row-lookup function wired (`database-operations-controller.ts:780`, `websocket-notifier.ts:1276` pass no `lookupFn`; `lookup()` → `null`). A `lookup(model, id)` CEL function exists but is only wired in the database-DO trigger/server-stamped-field context — never on an access-rule surface. So the claim holds for every access rule.
**Changed:** new "A Rule Sees Identity, Not Stored Data" subsection; entitlement modeled as group membership with the `isMemberOf('subscription', …)` pattern.

## #201 — store and trust third-party identifiers safely
**Reported:** no guidance on where to keep a provider `customer_id`; a user-writable copy is unsafe if the server later trusts it.
**Verified against source:** `$user.userId` resolves to the authenticated caller in operation definitions (`database-operations-controller.ts:2730`), so a read filtered on `$user.userId` is genuinely owner-scoped.
**Changed:** new "Trusting External Identifiers" section — system-write store (write op gated `fromWorkflow('billing-webhook')`), owner-scoped reads filtered on `$user.userId`, id resolved server-side.

## #202 — owner/admin bypass when testing gated states
**Reported:** the documented owner/admin bypass has an untold testing consequence — you can't exercise a locked state as an owner/admin.
**Changed:** a note in "Testing Rules" (and the guide's testing section): verify a gate denies using a plain `member` test user.

## Validation
- `pnpm check:examples` — passes (parity, TOML, CLI, stamp gate all green)
- `npx vitepress build docs` — no dead links
- `node scripts/render-guides.mjs --check` / `sync-guides-json.mjs --check` — builds and guides.json current
- docs↔guide sync verified: all three facts mirrored at appropriate altitude

Fixes #200
Fixes #201
Fixes #202