### PR TITLE
Workflows: a registered operation's access rule is enforced even for system runs (#197)

### DIFF
--- a/docs/getting-started/workflows.md
+++ b/docs/getting-started/workflows.md
@@ -309,6 +309,12 @@ A system run executes with the app's own privileges — which is what lets a sch
 
 Runs are attributed to the app's system principal, and every system run records who set it off — the admin who started it, or the trigger that fired it — for the audit trail.
 
+**A registered operation's `access` rule still applies.** The app-privileged baseline covers *raw* reads and writes — the documents and records a run touches directly, skipping the per-caller permission checks a [caller run](#system-workflows) is bound by. It does **not** override a registered [database operation](./working-with-databases.md#access-control-with-cel)'s own `access` rule: a `database.query` or `database.mutate` step evaluates that operation's CEL whether the run is `caller` or `system`, and an operation whose `access` is `"false"` fails with `403 Access denied` even from a system workflow. To reserve an operation for server-side automation, authorize it by workflow identity rather than disabling access:
+
+```toml novalidate
+access = "fromWorkflow('billing-webhook')"   # not "false"
+```
+
 ### Sensitive capabilities
 
 A system run can always read and write the app's documents and data. Anything beyond that baseline is **opt-in**: declare it in `capabilities` so a privileged workflow does only what you intend.

--- a/docs/getting-started/working-with-databases.md
+++ b/docs/getting-started/working-with-databases.md
@@ -221,7 +221,7 @@ access = "params.createdBy == user.userId"
 | `hasRole(role)` | Check if the user has a specific app role |
 | `fromWorkflow()` / `fromWorkflow(workflowKey)` | True when the call originated from a workflow (optionally a specific one) |
 
-Use `fromWorkflow(...)` to gate an operation so only a specific workflow can invoke it — useful for cron-fired refreshes that no user, including admins, should call directly. The workflow identity is injected only by the internal workflow runner; clients cannot spoof it.
+Use `fromWorkflow(...)` to gate an operation so only a specific workflow can invoke it — useful for cron-fired refreshes that no user, including admins, should call directly. The workflow identity is injected only by the internal workflow runner; clients cannot spoof it. An operation's `access` rule is evaluated on every call, including from [system workflow](./workflows.md#system-workflows) runs — `runAs = "system"` doesn't bypass it. So reserve a workflow-only operation with `fromWorkflow('key')` rather than setting `access = "false"` and expecting a system run to reach it.
 
 ### Per-Parameter Access
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.swift.md
@@ -489,6 +489,8 @@ access = "fromWorkflow('refresh-security-prices')"
 
 This is the cleanest expression of "only the named cron-fired workflow can call this — no user, not even an admin, can call it directly with a hand-crafted request." The workflow identity is only injected when the caller is the internal workflow step runner; external HTTP clients cannot spoof it.
 
+An operation's `access` rule is evaluated on every call, including from a `runAs = "system"` workflow run — system runs are app-privileged on the raw document/record baseline but do **not** bypass a registered operation's own `access` CEL. So a workflow-only op must be `access = "fromWorkflow('key')"`; setting `access = "false"` denies the system run too (`403`).
+
 For group-based access patterns, per-parameter access, and detailed CEL examples, see the [Users and Groups guide](AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.md).
 
 ### Parameters

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.template.md
@@ -469,6 +469,8 @@ access = "fromWorkflow('refresh-security-prices')"
 
 This is the cleanest expression of "only the named cron-fired workflow can call this — no user, not even an admin, can call it directly with a hand-crafted request." The workflow identity is only injected when the caller is the internal workflow step runner; external HTTP clients cannot spoof it.
 
+An operation's `access` rule is evaluated on every call, including from a `runAs = "system"` workflow run — system runs are app-privileged on the raw document/record baseline but do **not** bypass a registered operation's own `access` CEL. So a workflow-only op must be `access = "fromWorkflow('key')"`; setting `access = "false"` denies the system run too (`403`).
+
 For group-based access patterns, per-parameter access, and detailed CEL examples, see the [Users and Groups guide](AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.md).
 
 ### Parameters

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.ts.md
@@ -493,6 +493,8 @@ access = "fromWorkflow('refresh-security-prices')"
 
 This is the cleanest expression of "only the named cron-fired workflow can call this — no user, not even an admin, can call it directly with a hand-crafted request." The workflow identity is only injected when the caller is the internal workflow step runner; external HTTP clients cannot spoof it.
 
+An operation's `access` rule is evaluated on every call, including from a `runAs = "system"` workflow run — system runs are app-privileged on the raw document/record baseline but do **not** bypass a registered operation's own `access` CEL. So a workflow-only op must be `access = "fromWorkflow('key')"`; setting `access = "false"` denies the system run too (`403`).
+
 For group-based access patterns, per-parameter access, and detailed CEL examples, see the [Users and Groups guide](AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.md).
 
 ### Parameters

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.swift.md
@@ -853,7 +853,7 @@ Set `accessRule` once in the `[workflow]` TOML block and it sticks: `primitive s
 `runAs` declares the principal a run executes as — `caller` (default) or `system`. It's a top-level `[workflow]` field.
 
 - `runAs = "caller"` (default) — the run executes as the invoking user. Every step acts with that member's permissions: `document.*` steps enforce the caller's per-document ACL, group/data ops are checked against their roles. `accessRule` gates who may start it.
-- `runAs = "system"` — the run executes as the app's synthetic per-app principal (`sys:<appId>`, also the `WorkflowRun` partition key). App-privileged: the data baseline (document/database read/write/delete/manage) is unconditional.
+- `runAs = "system"` — the run executes as the app's synthetic per-app principal (`sys:<appId>`, also the `WorkflowRun` partition key). App-privileged on the **raw** data baseline: direct document/record read/write/delete/manage skips the per-caller ACL. It does **not** bypass a registered database operation's own `access` CEL — a `database.*` step evaluates that rule on every call, system run included (`access = "false"` → `403`; reserve a workflow-only op with `fromWorkflow('key')`, not `"false"`).
 
 The invocation gate is enforced once at top-level start (HTTP start/run-sync, cron, webhook, admin test) — never silently downgraded:
 
@@ -866,7 +866,7 @@ The invocation gate is enforced once at top-level start (HTTP start/run-sync, cr
 
 Nested/child runs (`workflow.call`, durable `forEach` batches) never re-resolve identity — they inherit the parent's verbatim. Every system run records attribution (`initiatedByUserId` + `initiatorKind` of `admin`/`cron`/`webhook`/`test`) for audit; it is not a security control.
 
-**Sensitive capabilities.** A system run gets the data baseline unconditionally. Sensitive operations are opt-in via `capabilities` (StringSet, allowlist-validated at save time):
+**Sensitive capabilities.** A system run gets the raw data baseline unconditionally (registered-operation `access` rules still evaluate — above). Sensitive operations are opt-in via `capabilities` (StringSet, allowlist-validated at save time):
 
 ```toml
 [workflow]

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md
@@ -853,7 +853,7 @@ Set `accessRule` once in the `[workflow]` TOML block and it sticks: `primitive s
 `runAs` declares the principal a run executes as — `caller` (default) or `system`. It's a top-level `[workflow]` field.
 
 - `runAs = "caller"` (default) — the run executes as the invoking user. Every step acts with that member's permissions: `document.*` steps enforce the caller's per-document ACL, group/data ops are checked against their roles. `accessRule` gates who may start it.
-- `runAs = "system"` — the run executes as the app's synthetic per-app principal (`sys:<appId>`, also the `WorkflowRun` partition key). App-privileged: the data baseline (document/database read/write/delete/manage) is unconditional.
+- `runAs = "system"` — the run executes as the app's synthetic per-app principal (`sys:<appId>`, also the `WorkflowRun` partition key). App-privileged on the **raw** data baseline: direct document/record read/write/delete/manage skips the per-caller ACL. It does **not** bypass a registered database operation's own `access` CEL — a `database.*` step evaluates that rule on every call, system run included (`access = "false"` → `403`; reserve a workflow-only op with `fromWorkflow('key')`, not `"false"`).
 
 The invocation gate is enforced once at top-level start (HTTP start/run-sync, cron, webhook, admin test) — never silently downgraded:
 
@@ -866,7 +866,7 @@ The invocation gate is enforced once at top-level start (HTTP start/run-sync, cr
 
 Nested/child runs (`workflow.call`, durable `forEach` batches) never re-resolve identity — they inherit the parent's verbatim. Every system run records attribution (`initiatedByUserId` + `initiatorKind` of `admin`/`cron`/`webhook`/`test`) for audit; it is not a security control.
 
-**Sensitive capabilities.** A system run gets the data baseline unconditionally. Sensitive operations are opt-in via `capabilities` (StringSet, allowlist-validated at save time):
+**Sensitive capabilities.** A system run gets the raw data baseline unconditionally (registered-operation `access` rules still evaluate — above). Sensitive operations are opt-in via `capabilities` (StringSet, allowlist-validated at save time):
 
 ```toml
 [workflow]

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.ts.md
@@ -853,7 +853,7 @@ Set `accessRule` once in the `[workflow]` TOML block and it sticks: `primitive s
 `runAs` declares the principal a run executes as — `caller` (default) or `system`. It's a top-level `[workflow]` field.
 
 - `runAs = "caller"` (default) — the run executes as the invoking user. Every step acts with that member's permissions: `document.*` steps enforce the caller's per-document ACL, group/data ops are checked against their roles. `accessRule` gates who may start it.
-- `runAs = "system"` — the run executes as the app's synthetic per-app principal (`sys:<appId>`, also the `WorkflowRun` partition key). App-privileged: the data baseline (document/database read/write/delete/manage) is unconditional.
+- `runAs = "system"` — the run executes as the app's synthetic per-app principal (`sys:<appId>`, also the `WorkflowRun` partition key). App-privileged on the **raw** data baseline: direct document/record read/write/delete/manage skips the per-caller ACL. It does **not** bypass a registered database operation's own `access` CEL — a `database.*` step evaluates that rule on every call, system run included (`access = "false"` → `403`; reserve a workflow-only op with `fromWorkflow('key')`, not `"false"`).
 
 The invocation gate is enforced once at top-level start (HTTP start/run-sync, cron, webhook, admin test) — never silently downgraded:
 
@@ -866,7 +866,7 @@ The invocation gate is enforced once at top-level start (HTTP start/run-sync, cr
 
 Nested/child runs (`workflow.call`, durable `forEach` batches) never re-resolve identity — they inherit the parent's verbatim. Every system run records attribution (`initiatedByUserId` + `initiatorKind` of `admin`/`cron`/`webhook`/`test`) for audit; it is not a security control.
 
-**Sensitive capabilities.** A system run gets the data baseline unconditionally. Sensitive operations are opt-in via `capabilities` (StringSet, allowlist-validated at save time):
+**Sensitive capabilities.** A system run gets the raw data baseline unconditionally (registered-operation `access` rules still evaluate — above). Sensitive operations are opt-in via `capabilities` (StringSet, allowlist-validated at save time):
 
 ```toml
 [workflow]


### PR DESCRIPTION
## What the issue reported
The guides describe a `runAs = "system"` workflow as "app-privileged" with the "data baseline unconditional," which reads as if a system run can call any registered database operation regardless of that operation's own `access` rule. It can't: a `database.query` step in a system run against an operation whose `access` is `"false"` fails at runtime with `403 Access denied`. A system run bypasses only the **raw** document/record baseline — not a registered operation's CEL.

## Verified against source
- A workflow `database.*` step routes through `DatabaseOperationsController.execute` (`workflows/steps/database-step.ts:167`), which evaluates the operation's `access` CEL on every call (`database-operations-controller.ts:823`) with **no** system/internal bypass — the workflow context only sets `celContext.workflow` so `fromWorkflow()` can match.
- The unconditional baseline is the *document* layer: a system workflow skips the per-caller document ACL (`workflows.md` caller-mode note), not registered-operation access.

So the issue's claim holds, and the behavior is correct and secure — this is a wording fix.

## What changed
- **`docs/getting-started/workflows.md`** — new paragraph in "System Workflows": the app-privileged baseline is *raw* reads/writes; a registered operation's `access` rule still evaluates, system run included; reserve workflow-only ops with `fromWorkflow('billing-webhook')`, not `"false"`.
- **`docs/getting-started/working-with-databases.md`** — `fromWorkflow` note clarifies the rule is enforced for `runAs = "system"` runs too.
- **Workflows guide** (`..._WORKFLOWS.template.md`) — corrected the "Execution identity" / "Sensitive capabilities" lines: raw baseline unconditional, registered-operation `access` not bypassed.
- **Databases guide** (`..._DATABASES.template.md`) — mirrored note on the `fromWorkflow` lock-down.

## Validation
- `pnpm check:examples` — passes (parity, TOML, CLI, stamp gate)
- `npx vitepress build docs` — no dead links
- Guides re-rendered; docs↔guide facts mirrored on both pairs

Fixes #197