### PR TITLE
Make the inbound webhook trigger discoverable from the integration docs (#198)

### DIFF
--- a/docs/getting-started/api-integrations.md
+++ b/docs/getting-started/api-integrations.md
@@ -115,7 +115,11 @@ primitive integrations test my-api       # Test the integration
 primitive integrations logs my-api       # View recent call logs
 ```
 
+## The Inbound Half: Webhooks
+
+An integration is the **outbound** half — your app calling a third-party API. Most real integrations also need the **inbound** half: a webhook the provider calls when something happens on their side (a payment succeeds, a repo is pushed), which triggers a workflow. The two are configured separately — the outbound call here, the inbound webhook as a [webhook trigger](./workflows.md#via-inbound-webhooks) on a workflow, with signature verification. Integrating a service like Stripe or GitHub usually means setting up both.
+
 ## Next Steps
 
-- **[Workflows](./workflows.md)** — Call integrations from a pipeline with the `integration.call` step
+- **[Workflows](./workflows.md)** — Call integrations from a pipeline with the `integration.call` step, and trigger workflows from [inbound webhooks](./workflows.md#via-inbound-webhooks)
 - **[Primitive CLI](./primitive-cli.md)** — Full CLI command reference

--- a/docs/getting-started/workflows.md
+++ b/docs/getting-started/workflows.md
@@ -240,7 +240,7 @@ Cron-fired runs are persistent workflow runs like any other — `meta.triggerId`
 
 ### Via Inbound Webhooks
 
-Inbound webhooks let external services (Stripe, GitHub, Slack, etc.) trigger workflows automatically. Each webhook has a public URL, signature verification, and automatic workflow triggering. Define them in your sync directory:
+Inbound webhooks let external services (Stripe, GitHub, Slack, etc.) trigger workflows automatically. Each webhook has a public URL, signature verification, and automatic workflow triggering. This is the **inbound** half of a third-party integration; the **outbound** half — your app calling the provider's API — is a configured [integration](./api-integrations.md). Most integrations use both. Define webhooks in your sync directory:
 
 ```toml
 # config/webhooks/stripe-payments.toml

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_INTEGRATIONS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_INTEGRATIONS.swift.md
@@ -2,6 +2,8 @@
 
 Integrations let tenant apps call third-party APIs through a server-side proxy without exposing credentials to clients. The proxy enforces an allowlist of methods and paths, injects credentials from App Secrets, and returns the upstream response to the caller.
 
+This is the **outbound** half of a third-party integration. The **inbound** half — a webhook the provider calls to trigger a workflow, configured with a verification scheme — is in the Workflows guide ("Inbound webhooks"). Most third-party integrations need both: outbound calls plus an inbound webhook that triggers a workflow.
+
 ## Call an integration
 
 ```swift

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_INTEGRATIONS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_INTEGRATIONS.template.md
@@ -2,6 +2,8 @@
 
 Integrations let tenant apps call third-party APIs through a server-side proxy without exposing credentials to clients. The proxy enforces an allowlist of methods and paths, injects credentials from App Secrets, and returns the upstream response to the caller.
 
+This is the **outbound** half of a third-party integration. The **inbound** half — a webhook the provider calls to trigger a workflow, configured with a verification scheme — is in the Workflows guide ("Inbound webhooks"). Most third-party integrations need both: outbound calls plus an inbound webhook that triggers a workflow.
+
 ## Call an integration
 
 {{ example: integrations/integration-call }}

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_INTEGRATIONS.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_INTEGRATIONS.ts.md
@@ -2,6 +2,8 @@
 
 Integrations let tenant apps call third-party APIs through a server-side proxy without exposing credentials to clients. The proxy enforces an allowlist of methods and paths, injects credentials from App Secrets, and returns the upstream response to the caller.
 
+This is the **outbound** half of a third-party integration. The **inbound** half — a webhook the provider calls to trigger a workflow, configured with a verification scheme — is in the Workflows guide ("Inbound webhooks"). Most third-party integrations need both: outbound calls plus an inbound webhook that triggers a workflow.
+
 ## Call an integration
 
 ```typescript

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.swift.md
@@ -920,7 +920,7 @@ Once a subject method returns a concrete `documentId`, the app-privileged `docum
 
 ## Inbound webhooks
 
-External services trigger workflows via inbound webhooks. Define them as `webhooks/*.toml` in the sync directory and push with `primitive sync push`:
+External services trigger workflows via inbound webhooks. This is the **inbound** half of a third-party integration; the **outbound** half — calling the provider's API — is a configured integration (see the Integrations guide). Most integrations need both. Define webhooks as `webhooks/*.toml` in the sync directory and push with `primitive sync push`:
 
 ```toml
 # config/webhooks/stripe-payments.toml

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md
@@ -920,7 +920,7 @@ Once a subject method returns a concrete `documentId`, the app-privileged `docum
 
 ## Inbound webhooks
 
-External services trigger workflows via inbound webhooks. Define them as `webhooks/*.toml` in the sync directory and push with `primitive sync push`:
+External services trigger workflows via inbound webhooks. This is the **inbound** half of a third-party integration; the **outbound** half — calling the provider's API — is a configured integration (see the Integrations guide). Most integrations need both. Define webhooks as `webhooks/*.toml` in the sync directory and push with `primitive sync push`:
 
 ```toml
 # config/webhooks/stripe-payments.toml

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.ts.md
@@ -920,7 +920,7 @@ Once a subject method returns a concrete `documentId`, the app-privileged `docum
 
 ## Inbound webhooks
 
-External services trigger workflows via inbound webhooks. Define them as `webhooks/*.toml` in the sync directory and push with `primitive sync push`:
+External services trigger workflows via inbound webhooks. This is the **inbound** half of a third-party integration; the **outbound** half — calling the provider's API — is a configured integration (see the Integrations guide). Most integrations need both. Define webhooks as `webhooks/*.toml` in the sync directory and push with `primitive sync push`:
 
 ```toml
 # config/webhooks/stripe-payments.toml


### PR DESCRIPTION
## What the issue reported
Calling a third-party API has two halves that live far apart in the docs: the outbound half (an integration the workflow calls) in the integrations guide, and the inbound half (a webhook that triggers a workflow) in the workflows guide. Someone starting from "how do I call Stripe" lands on the integration docs with no signal that the webhook half exists or where to find it.

## What changed
Reciprocal cross-links plus a one-line "most integrations use both halves" note:

- **`docs/getting-started/api-integrations.md`** — new "The Inbound Half: Webhooks" section linking to the workflows webhook-trigger section, plus a pointer in Next Steps.
- **`docs/getting-started/workflows.md`** — the "Via Inbound Webhooks" intro now names the outbound integration half and links to it.
- **Integrations guide** (`..._INTEGRATIONS.template.md`) — intro names the inbound webhook half (Workflows guide).
- **Workflows guide** (`..._WORKFLOWS.template.md`) — "Inbound webhooks" names the outbound integration half.

Guide-to-guide references are prose-by-name (not URLs), consistent with the rest of the guides.

## Validation
- `pnpm check:examples` — passes
- `npx vitepress build docs` — no dead links (both new anchors resolve)
- Guides re-rendered; docs↔guide facts mirrored on both pairs

Fixes #198