### PR TITLE
docs-next-sync: js-bao-wss changes (automated)

### DIFF
--- a/docs-sources.json
+++ b/docs-sources.json
@@ -1,13 +1,13 @@
 {
   "channel": "next",
-  "stampedAt": "2026-06-26",
+  "stampedAt": "2026-06-27",
   "libraries": {
     "js-bao-wss": {
-      "commit": "c7c199b4e47fdeaaabba702287a6e6516f57b226",
+      "commit": "4d7f34733301b779ef54e3a079666d452d0da9ea",
       "npm": {
-        "js-bao-wss-client": "2.0.2",
+        "js-bao-wss-client": "2.0.4",
         "js-bao": "0.5.1",
-        "primitive-admin": "1.0.51"
+        "primitive-admin": "1.0.53"
       }
     },
     "primitive-app-dev": {

--- a/docs/getting-started/blobs-and-files.md
+++ b/docs/getting-started/blobs-and-files.md
@@ -70,7 +70,7 @@ A bucket's **preset** decides who can use its blobs. App admins and owners alway
 
 | Preset | Access for everyone else | Use case |
 |---|---|---|
-| `public` | Anyone — including visitors with no account — can read and list. Only admins write. | Logos, brand images, assets served without auth |
+| `public` | Anyone — including visitors with no account — can read and list. Only admins and owners write. | Logos, brand images, assets served without auth |
 | `authenticated` | Any signed-in member can read, write, list, delete, and share | User avatars, app-wide shared assets |
 | `admin-only` | No one but admins and owners | Internal artifacts, workflow outputs you serve out selectively via signed URLs |
 | `personal-uploads` | Any member uploads; each member reads, deletes, and shares **only their own** blobs (the bucket isn't enumerable) | User file uploads where everyone keeps their own |

--- a/guides/latest/guides.json
+++ b/guides/latest/guides.json
@@ -15,12 +15,12 @@
     }
   },
   "builtAgainst": {
-    "stampedAt": "2026-06-26",
+    "stampedAt": "2026-06-27",
     "channel": "next",
     "packages": {
-      "js-bao-wss-client": "2.0.2",
+      "js-bao-wss-client": "2.0.4",
       "js-bao": "0.5.1",
-      "primitive-admin": "1.0.51",
+      "primitive-admin": "1.0.53",
       "primitive-app": "3.0.1"
     }
   },


### PR DESCRIPTION
Automated `docs-next-sync` pass against the library main tips, triggered by the nightly release js-bao-wss#1289.

> **Rolling PR.** This PR is updated in place each night until it merges — every update is a complete, gate-green superset of everything new since the last merge (branched fresh from `next`, not stacked). Merge it to advance the baseline; the next nightly then starts fresh and small.

# docs-next-sync disposition report — 2026-06-27 (next channel)

**Window:** js-bao-wss `c7c199b4..4d7f3473` (12 commits) · primitive-app-dev `fc60fa57` (0 new) · swift-primitive-app-dev `943ba1ab` (0 new)
**Stamp advanced:** `c7c199b4` → `4d7f3473` (channel preserved: `next`). Package mirrors: js-bao-wss-client `2.0.2`→`2.0.4`, primitive-admin `1.0.51`→`1.0.53`.

## Summary

This window carried **no developer-facing behavior changes** — every commit is internal (skills/CI/deploy markers/version bumps), a test, or a release-notes document. The triage produced no commit-driven doc edits.

The mandatory whole-set audit found **one source-verified accuracy fix** (unrelated to the batch), which is the only substantive content change in this PR. All gates are green.

> **Note on scope:** the release notes added this window (`releases/2026-06-26-4010121c.md`) describe the production window `e6a4ff41..4010121c` (102 commits: #1133 passkeys, #1203 handle-discovery steps, #1205 rhai arrays + `{ result, ok }` wrapper, #1213 `TYPE_HAS_INSTANCES`, #1221/#1226 not-active trigger disposition, #1244 schema-aware stringset writes, etc.). Those features are **ancestors of the prior baseline `c7c199b4`** and were trued in earlier passes — they are not re-documented here. Verified `#1205/#1182` is contained in `c7c199b4`, and our guides already describe the script-step `output.*` nesting with the `ok` envelope (consistent).

## Per-commit disposition

| Commit | PR | Subject | Surface | Disposition |
|---|---|---|---|---|
| 4d7f3473 | #1279 | Merge: require TOML+CLI+test for config change | `.claude/skills/` | internal — no change |
| 67ddbe73 | #1279 | chore(skills): require TOML+CLI+test | `.claude/skills/` | internal — no change |
| 914c6ef6 | #1271 | Merge: production deploy 2026-06-26 | deploy marker | internal — no change |
| c3fcb74c | #1273 | Merge: add #1244/#1242 to release notes | `releases/` | internal — no change |
| 27a94145 | #1273 | docs(release): add #1244/#1242 to prod notes | `releases/` | internal — no change |
| 0bd6a989 | #1241 | Merge: swift order-less hasMany id-ASC parity guard | swift test | internal (test) — no change |
| edc3c54a | — | chore: bump versions for production deploy | `*/package.json` | internal — mirrored into stamp/footer |
| 3142078b | #1268 | Merge: prod marker | deploy marker | internal — no change |
| c9173e70 | — | Production deploy 2026-06-26 | deploy marker | internal — no change |
| 4010121c | #1260 | Merge: script-step test for #1182 wrapper shape | server test | internal (test) — no change |
| e73f5aec | #1260 | fix(test): update #940 script-step test for #1182 wrapper | server test | internal (test) — no change; #1182 wrapper already trued (in baseline) |
| 57fdd843 | #1241 | test(swift-client): guard order-less hasMany id-ASC parity (#1160) | swift test | internal (test) — **confirms** existing JS/Swift id-ASC parity; "no production code change" |

## Whole-set audit (mandatory, always run)

**Mechanical sweeps — all clean:**
- Orphan pages: none (sidebar ↔ disk match exactly, 20 pages).
- Build + dead links: `npx vitepress build docs` ✅.
- Manifest integrity: `sync-guides-json.mjs --check` ✅ (no dangling `relatedGuides`/`prerequisites`).
- Example parity inventory: lone-language fences unchanged from prior passes (auth Swift-only passkey/deep-link, devtools JS-only, etc.) — previously judged-acceptable platform asymmetries; nothing new this batch.
- Structure mirror: every concept page has its guide counterpart (performance = known exception).

**Cross-page judgment passes:**
- **Duplication / boundary:** clean. CEL/access-control owned by `access-control.md`, config-as-code by `configuring-primitive-services.md`, test users by `primitive-cli.md`, step kinds by `workflows.md` — all collaborators link rather than re-teach.
- **Inconsistency:** **1 finding, fixed.**
  - `docs/getting-started/blobs-and-files.md:73` — the `public` blob-bucket preset row read "Only admins write," contradicting line 69 ("admins **and owners** always have full access") and the `admin-only` row ("admins and owners"). **Verified against source** (`js-bao-wss/src/app-api/resource-types/blob-bucket.ts:93-101`: `public` blob `write:"false"` for everyone-else, with the documented admin/owner bypass granting full access). Owners write too. **Fixed → "Only admins and owners write."** The agent guide (`AGENT_GUIDE_TO_PRIMITIVE_BLOB_BUCKETS.template.md:69`) was already precise ("no member `write`/`delete`/`share`") — no guide edit needed; render confirmed 0 guide changes.

## Open docs issues — triaged, none actionable from this batch

| Issue | Title | Disposition |
|---|---|---|
| #207 | Workflows guide: `accessRule` inert on `runAs:system` workflows | **Not unblocked by this batch.** Standing editorial correction (not upstream-keyed); its "stronger fix" refs js-bao-wss#1232/#1233 are unshipped and absent from the stamped tips. Belongs to `docs-issue-sweep`, not library truing. Left open. |
| #199 | Add end-to-end subscription-entitlement recipe | **Still deferred — blocked on platform capability.** The issue itself states group-membership maintenance from a system webhook "today does not [work]"; nothing in this batch enables it. Left open. |

## Issues filed this pass

**None.** No new one-language capabilities, parity gaps, or library bugs surfaced in this window. (57fdd843 *confirms* hasMany id-ASC parity holds on both clients — no gap to file.)

## Larger changes flagged for review

**None.** No new pages, restructures, or content removals. The single content edit is a one-cell accuracy fix.

## Gates

- `pnpm check:examples` — ✅ green (TS compile of full corpus against source; 429 CLI invocations validated against primitive-admin source; TOML 174 validated; guide render/registry current; source-stamp gate: "docs-sources.json matches submodules, installed packages, and guides.json"). Swift compile gate skipped here (needs macOS host; covered by macOS CI).
- `npx vitepress build docs` — ✅ no dead links.
- `node scripts/stamp-sources.mjs --changes` baseline reset to `4d7f3473`.

## Working-tree contents for the PR

- `docs/getting-started/blobs-and-files.md` — `public` preset write-access accuracy fix.
- `library_repos/js-bao-wss` — submodule pin advanced `c7c199b4` → `4d7f3473`.
- `docs-sources.json`, `guides/latest/guides.json` — restamp + `builtAgainst` version mirror (mechanical).

---
Review the doc changes and the disposition above, then merge into `next`. Publishing to `main` happens separately at a production release.

> Generated unattended by the Claude Code CLI. Verify facts against source before merging.