### PR TITLE
docs-next-sync: js-bao-wss changes (automated)

### DIFF
--- a/docs-sources.json
+++ b/docs-sources.json
@@ -1,9 +1,9 @@
 {
   "channel": "next",
-  "stampedAt": "2026-06-27",
+  "stampedAt": "2026-06-28",
   "libraries": {
     "js-bao-wss": {
-      "commit": "4d7f34733301b779ef54e3a079666d452d0da9ea",
+      "commit": "cafa81e6e853413d2c4d53c26551d1e1e824d411",
       "npm": {
         "js-bao-wss-client": "2.0.4",
         "js-bao": "0.5.1",

--- a/docs/getting-started/primitive-cli.md
+++ b/docs/getting-started/primitive-cli.md
@@ -245,10 +245,22 @@ primitive guides get workflows
 primitive guides get authentication
 ```
 
+Guides come in TypeScript and Swift variants. By default you get the TypeScript guide; pass `--language swift` to fetch the Swift variant, or `--platform ios` (or `--platform macos`) to select the language that platform targets:
+
+```bash
+# Fetch the Swift variant of a guide
+primitive guides get documents --language swift
+
+# ...or let the platform choose the language (iOS and macOS target Swift)
+primitive guides get documents --platform ios
+```
+
+`primitive guides list` takes the same flags. An unknown `--language` or `--platform` value is rejected rather than silently served as TypeScript, so a typo surfaces immediately.
+
 Guides are cached locally at `~/.primitive/guides/`.
 
 :::tip For AI Agents
-When working with an AI coding assistant, point it to these guides before asking it to implement features. For example: "Read `primitive guides get workflows` and then create a workflow that sends a welcome email when a user signs up." The agent will fetch the guide, learn the patterns, and implement your request correctly.
+When working with an AI coding assistant, point it to these guides before asking it to implement features. For example: "Read `primitive guides get workflows` and then create a workflow that sends a welcome email when a user signs up." The agent will fetch the guide, learn the patterns, and implement your request correctly. Building for iOS or macOS? Tell the agent to pass `--platform ios` so it fetches the Swift guides instead of the TypeScript default.
 :::
 
 ## Configuration Sync

--- a/guides/latest/guides.json
+++ b/guides/latest/guides.json
@@ -15,7 +15,7 @@
     }
   },
   "builtAgainst": {
-    "stampedAt": "2026-06-27",
+    "stampedAt": "2026-06-28",
     "channel": "next",
     "packages": {
       "js-bao-wss-client": "2.0.4",


### PR DESCRIPTION
Automated `docs-next-sync` pass against the library main tips, triggered by the nightly release js-bao-wss#1290.

> **Rolling PR.** This PR is updated in place each night until it merges — every update is a complete, gate-green superset of everything new since the last merge (branched fresh from `next`, not stacked). Merge it to advance the baseline; the next nightly then starts fresh and small.

# docs-next-sync report — 2026-06-28

**Channel:** next · **Trigger:** js-bao-wss nightly (snapshot `cafa81e6`, source issue js-bao-wss#1290)
**Submodules trued to:** js-bao-wss `cafa81e6`, primitive-app-dev `fc60fa57` (no change), swift-primitive-app-dev `943ba1ab` (no change)
**Stamp moved:** 2026-06-27 → 2026-06-28 (`pnpm stamp:sources`, channel preserved as `next`)

## Per-commit disposition

11 js-bao-wss commits since the 2026-06-27 stamp = 4 squash-merged PRs (the rest are their merge commits / intermediate WIP commits).

| PR (issue) | Subject | Surface | Disposition |
|---|---|---|---|
| #1270 (#1034) | CLI: heal a 404 on a cache-derived guide file by refetching the manifest | `cli/src/commands/guides.ts` only | **internal — no change.** Transparent client-side cache-coherence fix for `primitive guides get`; no observable behavior or flag change. (Resilience for the `.md`→`.ts.md` rename; the heal is invisible to the user.) |
| #1259 (#1201) | swift-client: honor join-model order in `hasManyThrough` | Swift client codegen + runtime resolvers | **internal — no change.** Parity *fix*: Swift now returns target `id ASC` like JS. `hasManyThrough` / through-relationship ordering is undocumented in docs and guides (verified by grep), so no page stated the old behavior. Bug fix that makes the (implicit) parity claim true — nothing to write. |
| #1261 (#1219) | CLI: validate `guides --language/--platform` and infer language from platform | `cli/src/commands/guides.ts` only | **updated `docs/getting-started/primitive-cli.md`** (Accessing Guides). See below. |
| #1243 (#1228) | groups: add group members by email with strict membership check | `app-api/groups-controller.ts`, web-admin | **internal — no change.** See below. |

## Doc change made

**`docs/getting-started/primitive-cli.md` — "Accessing Guides" section (for #1261).**
The CLI's `primitive guides get`/`guides list` `--language` and `--platform` flags are now real and validated (and `guides.json` already carries the `platforms` block — primitive-docs#194 landed and is CLOSED — so validation + language inference are fully live against our served manifest). The doc previously documented only `guides list` / `guides get <topic>` with no mention of either flag, which is exactly the gap that produced js-bao-wss#1219's failure mode (an agent concluded "the Swift guides only return TypeScript" and reverse-engineered the Swift API from source).

Added, verified against `cli/src/commands/guides.ts` at `cafa81e6`:
- `--language swift` fetches the Swift variant; `--platform ios` / `--platform macos` select the language that platform targets (Swift); `web` → TypeScript; default is TypeScript.
- An unknown `--language`/`--platform` value is rejected rather than silently served as TypeScript.
- An "AI Agents" tip note: iOS/macOS builds should pass `--platform ios` to get the Swift guides.

No guide-template counterpart exists for the CLI page (there is no `AGENT_GUIDE_TO_PRIMITIVE_CLI`, and no guide template references `primitive guides get/list` — verified by grep), so the guide-sync rule requires no matching guide edit.

## Why #1243 needed no doc change

- **Client surface unchanged.** `client.groups.addMember(...)` already accepts `{ email }` in **both** the JS client (`api/groupsApi.ts`) and the Swift client (`GroupsTypes.swift`), and `users-and-groups.md` already documents adding members by email (lines 57–90, including the `added` / `pending_signup` discriminated-union result). #1243 added nothing to the client.
- **The new bits are not client-facing.** `requireExistingUser` is a backend-only strict-mode flag used by the web-admin console; it is not exposed in either client SDK. The web-admin "Add Member" dialog now accepts an email or a user ID — but `docs/getting-started/admin-console.md` documents Users & Groups at a high altitude ("Manage groups and group membership") and never enumerated a "user ID only" limitation, so there is no stale fact to correct.

## Issues

**Filed this pass:** none. No new one-language client capability or parity gap was introduced. #1259 is a parity *fix* (closes the Swift `hasManyThrough` ordering gap), not a new gap; #1243's strict-mode flag is backend-only.

**Open docs issues reviewed — none unblocked by this batch:**

| Issue | Status this pass |
|---|---|
| primitive-docs#207 — Workflows guide: `accessRule` inert on `runAs:system` workflows | **Not addressed / not gated on this batch.** A standing doc-accuracy improvement, independent of all 4 commits here (it cross-refs js-bao-wss#1232/#1233 only as an optional *platform* hardening, not as a blocker). Belongs to docs-issue-sweep, not this truing pass. Left open. |
| primitive-docs#199 — end-to-end subscription-entitlement recipe | **Still deferred.** Its blocker is "group-membership maintenance from a system webhook works end to end — today that path does not." This batch's #1243 is a console/endpoint email-add feature, not system-webhook membership maintenance, so the blocker is not in the stamped tips. Left open. |

## Whole-set audit (docs-set-audit)

Ran on this pass. Clean bill.
- **Mechanical sweeps:** no orphan pages (every `getting-started/*.md` is in the sidebar); `vitepress build` clean (no dead links); `guides.json` manifest references current (`sync-guides-json.mjs --check`); structure mirror intact.
- **Example parity inventory:** 6 lone-js, 4 lone-swift, 171 neutral — unchanged from the prior baseline; this pass added no inline code fences (the CLI doc edit is `bash` blocks, language-neutral) and introduced no new lone-language block.
- **Cross-page judgment:** the edit is confined to the CLI command reference, where `primitive guides` is documented in exactly one place (verified by grep). No duplication, inconsistency, or concept-boundary issue introduced.

## Gates — all green

- `pnpm check:examples` ✅ — corpus in sync; 159 TS examples compile against submodule source (Swift compile skipped: needs a macOS host, covered by macOS CI); 174 TOML blocks valid; **431 documented CLI invocations validated against `primitive-admin` submodule source** (includes the new `guides get --language swift` / `--platform ios` invocations); source stamp matches.
- `npx vitepress build docs` ✅ — no dead links.
- `node scripts/check-example-parity.mjs` ✅ · `node scripts/sync-guides-json.mjs --check` ✅

## Working tree left for the PR
```
 M docs-sources.json                       # restamp (cafa81e6 + 2026-06-28)
 M docs/getting-started/primitive-cli.md   # the doc change
 M guides/latest/guides.json               # restamp builtAgainst date
 M library_repos/js-bao-wss                # fast-forward to cafa81e6
```
No `git commit`/`push`/`merge` performed (unattended CI rules); the workflow opens the PR.

---
Review the doc changes and the disposition above, then merge into `next`. Publishing to `main` happens separately at a production release.

> Generated unattended by the Claude Code CLI. Verify facts against source before merging.