### PR TITLE
Point documents + data-modeling guides at the ios-design skill (#213)

### DIFF
--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATA_MODELING.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATA_MODELING.swift.md
@@ -266,3 +266,4 @@ Where the data should live instead: a record inside the database itself. Read it
 - [Documents guide](AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.md) — full document API, sharing, sync, patterns
 - [Databases guide](AGENT_GUIDE_TO_PRIMITIVE_DATABASES.md) — full database API, operations, triggers, subscriptions, pipelines
 - [Users and Groups guide](AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.md) — group membership, CEL functions, role-based access
+- **`ios-design` skill** — the iOS/SwiftUI UI-convention skill bundled in the Swift starter template (at `.claude/skills/ios-design/` in the scaffolded project). It governs the view layer the data-side rules here don't cover — platform gating, navigation, list affordances. It only activates once you're editing SwiftUI files inside the scaffolded project, so consult it explicitly before building any UI; architecture decisions made around scaffolding time can otherwise miss it.

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATA_MODELING.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATA_MODELING.template.md
@@ -219,3 +219,6 @@ Where the data should live instead: a record inside the database itself. Read it
 - [Documents guide](AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.md) — full document API, sharing, sync, patterns
 - [Databases guide](AGENT_GUIDE_TO_PRIMITIVE_DATABASES.md) — full database API, operations, triggers, subscriptions, pipelines
 - [Users and Groups guide](AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.md) — group membership, CEL functions, role-based access
+{{#lang swift}}
+- **`ios-design` skill** — the iOS/SwiftUI UI-convention skill bundled in the Swift starter template (at `.claude/skills/ios-design/` in the scaffolded project). It governs the view layer the data-side rules here don't cover — platform gating, navigation, list affordances. It only activates once you're editing SwiftUI files inside the scaffolded project, so consult it explicitly before building any UI; architecture decisions made around scaffolding time can otherwise miss it.
+{{/lang}}

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.swift.md
@@ -804,6 +804,8 @@ struct TodoListView: View {
 >     else { ProgressView() }
 > ```
 
+**Building the views themselves** — layout, navigation, platform gating, list affordances — is governed by the `ios-design` skill bundled in the Swift starter template (at `.claude/skills/ios-design/` in the scaffolded project). It triggers on SwiftUI edits inside the project, so consult it explicitly before writing views; UI decisions made around scaffolding time can otherwise miss it.
+
 ## Saving Data
 
 Writes go through record instances and are local-first — applied to the document store immediately and synced in the background (see [`models.toml` + codegen + the model facade](#modelstoml--codegen--the-model-facade) for the save/delete contract). `try record.save(in: documentId)` uses merge semantics: `nil` optional fields are not written, so fields you didn't set are preserved on update.

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.template.md
@@ -867,6 +867,8 @@ The view below is framework glue; the only Primitive calls in it are the `findAl
 >     if appState.hasReconciled { EmptyState() }
 >     else { ProgressView() }
 > ```
+
+**Building the views themselves** — layout, navigation, platform gating, list affordances — is governed by the `ios-design` skill bundled in the Swift starter template (at `.claude/skills/ios-design/` in the scaffolded project). It triggers on SwiftUI edits inside the project, so consult it explicitly before writing views; UI decisions made around scaffolding time can otherwise miss it.
 {{/lang}}
 
 ## Saving Data


### PR DESCRIPTION
## What the issue reported
iOS UI quality depends on the bundled `ios-design` project skill, but it only activates once an agent is editing SwiftUI files inside the already-scaffolded Swift app. An agent designing data architecture or building UI before/around scaffolding never triggers it. The ask: have the documents and data-modeling guides explicitly point at the skill so an agent knows to consult it before building UI.

## Verified against source
- The `ios-design` skill exists in the Swift starter template at `library_repos/swift-primitive-app-dev/primitive-app-template/.claude/skills/ios-design/SKILL.md`, and its trigger (per its own frontmatter) is "whenever a SwiftUI file is being edited inside a `swift-primitive-app`-based project" — confirming it can't fire before the project is scaffolded.
- `primitive init` (`cli/src/commands/init.ts`) installs the template into the project `targetDir`, so the skill lands at `.claude/skills/ios-design/` **in the scaffolded project**, not a fixed `app/` subdir. The issue's `app/.claude/skills/...` path reflects an environment where the app was scaffolded under `app/`; I phrased the pointer to be accurate regardless of where `init` was run, and noted it here.

## What changed
- `guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATA_MODELING.template.md` — a `{{#lang swift}}` bullet in *Further reading*.
- `guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.template.md` — a `{{#lang swift}}` note at the SwiftUI view-binding moment (`BaoDataLoader` section).
- Regenerated the `.swift.md` / `.ts.md` builds.

Both pointers are scoped to `{{#lang swift}}`, so they render only into the Swift builds — a JS agent never sees them (verified: no `ios-design` string in either `.ts.md`).

## Guide-sync note
This is agent-workflow guidance (consult a coding skill) with no human-doc analog — humans don't load skills — so there is intentionally no `docs/` mirror. The guide-sync rule is satisfied.

## Validation
- `pnpm check:examples` — pass.
- `npx vitepress build docs` — pass.

Fixes #213