### PR TITLE
Configuration: env add starts logged-out; document login --token-stdin (#211)

### DIFF
--- a/docs/getting-started/primitive-cli.md
+++ b/docs/getting-started/primitive-cli.md
@@ -106,6 +106,8 @@ primitive env remove staging
 
 `--app-id` is optional. If you omit it, the environment pins only an `apiUrl` and the app is chosen per-session via `primitive use <appId>`.
 
+A freshly-added environment starts **logged-out**. `primitive env add` writes only the config entry — it seeds no credentials, and project mode does not borrow the global `~/.primitive/credentials.json`. So right after `env add`, project-scoped commands report "not logged in" even if `primitive whoami` works globally; run `primitive login` with that environment active to sign it in. For agents and CI, sign in without a browser by piping a refresh token — see [API Tokens for CI and Servers](#api-tokens-for-ci-and-servers).
+
 ### How the Active Environment Is Resolved
 
 Every command resolves an active environment in this order — the first match wins:
@@ -503,7 +505,15 @@ primitive token
 
 ### API Tokens for CI and Servers
 
-For headless environments where an interactive `primitive login` isn't possible — CI pipelines, deploy scripts, server-side jobs — create a long-lived API token instead:
+For headless environments where a browser-based `primitive login` isn't possible — CI pipelines, deploy scripts, server-side jobs — you have two non-interactive paths.
+
+To sign in as yourself, pipe a refresh token into `login --token-stdin`:
+
+```bash
+primitive token --refresh | primitive login -s <url> --token-stdin
+```
+
+Or create a long-lived API token, which isn't tied to a user session:
 
 ```bash
 primitive tokens create --name "CI deploys" --ttl 90d

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_CONFIGURATION.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_CONFIGURATION.md
@@ -62,6 +62,8 @@ Not in `app.toml` (see [What sync does NOT carry](#what-sync-does-not-carry)): `
 
 Every command resolves its target environment in order: `--env <name>` flag → `PRIMITIVE_ENV` env var → `defaultEnvironment` in `.primitive/config.json` → the only defined environment → error. Manage environments with `primitive env add|list|show|use|remove`. Tokens are stored per-environment in `.primitive/credentials.json` (gitignored); `.primitive/config.json` is committed.
 
+`primitive env add` writes only the environment entry into `.primitive/config.json` — it seeds no credentials, and project mode does **not** fall back to the global `~/.primitive/credentials.json`. A freshly-added environment therefore starts logged-out: project-scoped commands report "not logged in" until you run `primitive login` for that environment, even when a global `primitive whoami` succeeds. Agents and CI can log in without a browser by piping a refresh token — `primitive token --refresh | primitive login -s <url> --token-stdin` (see [Headless auth](#headless-auth-ci)).
+
 ## Previewing a push
 
 `primitive sync diff` lists entities that would be created, changed, or removed; `primitive sync push --dry-run` reports the full push without applying it. Both run the **same** validate-first gate as a real push — local TOML validation followed by the server-side checks via the validate-first pass — so the preview is faithful: what it reports is what the push applies. Schema-gate rejections surface identically in the preview and in a real push: an operation whose database type has no schema set, an unresolved `$params.X`/reference, or a schema change that would break an existing registered operation. A previewed or blocked entity records no content hash in sync state, so it stays pending on the next `sync diff` rather than reading "in sync" — a server-rejected change cannot silently disappear from the diff. `primitive sync diff --json` emits machine-readable output on stdout.
@@ -95,7 +97,7 @@ primitive secrets delete OPENAI_API_KEY
 
 ## Headless auth (CI)
 
-Interactive `primitive login` doesn't work in CI. Create a long-lived API token and target an environment explicitly:
+Browser-based `primitive login` doesn't work in CI. Either log in non-interactively by piping a refresh token — `primitive token --refresh | primitive login -s <url> --token-stdin` — or create a long-lived API token and target an environment explicitly:
 
 ```bash
 primitive tokens create --name "CI deploys" --ttl 90d    # m/h/d/w/mo/y units; omit for non-expiring

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_CONFIGURATION.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_CONFIGURATION.template.md
@@ -62,6 +62,8 @@ Not in `app.toml` (see [What sync does NOT carry](#what-sync-does-not-carry)): `
 
 Every command resolves its target environment in order: `--env <name>` flag → `PRIMITIVE_ENV` env var → `defaultEnvironment` in `.primitive/config.json` → the only defined environment → error. Manage environments with `primitive env add|list|show|use|remove`. Tokens are stored per-environment in `.primitive/credentials.json` (gitignored); `.primitive/config.json` is committed.
 
+`primitive env add` writes only the environment entry into `.primitive/config.json` — it seeds no credentials, and project mode does **not** fall back to the global `~/.primitive/credentials.json`. A freshly-added environment therefore starts logged-out: project-scoped commands report "not logged in" until you run `primitive login` for that environment, even when a global `primitive whoami` succeeds. Agents and CI can log in without a browser by piping a refresh token — `primitive token --refresh | primitive login -s <url> --token-stdin` (see [Headless auth](#headless-auth-ci)).
+
 ## Previewing a push
 
 `primitive sync diff` lists entities that would be created, changed, or removed; `primitive sync push --dry-run` reports the full push without applying it. Both run the **same** validate-first gate as a real push — local TOML validation followed by the server-side checks via the validate-first pass — so the preview is faithful: what it reports is what the push applies. Schema-gate rejections surface identically in the preview and in a real push: an operation whose database type has no schema set, an unresolved `$params.X`/reference, or a schema change that would break an existing registered operation. A previewed or blocked entity records no content hash in sync state, so it stays pending on the next `sync diff` rather than reading "in sync" — a server-rejected change cannot silently disappear from the diff. `primitive sync diff --json` emits machine-readable output on stdout.
@@ -95,7 +97,7 @@ primitive secrets delete OPENAI_API_KEY
 
 ## Headless auth (CI)
 
-Interactive `primitive login` doesn't work in CI. Create a long-lived API token and target an environment explicitly:
+Browser-based `primitive login` doesn't work in CI. Either log in non-interactively by piping a refresh token — `primitive token --refresh | primitive login -s <url> --token-stdin` — or create a long-lived API token and target an environment explicitly:
 
 ```bash
 primitive tokens create --name "CI deploys" --ttl 90d    # m/h/d/w/mo/y units; omit for non-expiring


### PR DESCRIPTION
## What the issue reported
Adding a project environment starts you logged-out even when a valid global session exists, and the docs don't say so or point at the non-interactive login path for agents/CI.

## Verified against source
Confirmed in the stamped `library_repos/js-bao-wss/cli` source:
- `env add` (`cli/src/commands/env.ts`) writes only the environment config (`apiUrl`, `appId`, …) via `writeProjectConfig()` — no credentials touched.
- `loadCredentialsStore()` (`cli/src/lib/credentials-store.ts`) in project mode reads `.primitive/credentials.json` keyed by env name and returns `null` when that env has no entry — **no** fallback to the global `~/.primitive/credentials.json` (the global fallback only applies in genuine legacy/no-project mode).
- `login` (`cli/src/commands/auth.ts`) supports `--token-stdin` ("Read a refresh token from stdin instead of browser OAuth"); the command's own error hint documents the invocation `primitive token --refresh | primitive login -s <url> --token-stdin`.

## What changed
- `guides/latest/AGENT_GUIDE_TO_PRIMITIVE_CONFIGURATION.template.md` — *Environment resolution* gains the env-add-starts-logged-out note; *Headless auth (CI)* now leads with the `login --token-stdin` path.
- `docs/getting-started/primitive-cli.md` — matching notes in *Named Environments* and *API Tokens for CI and Servers* (docs↔guide sync).
- Regenerated the rendered guide build.

## Validation
- `pnpm check:examples` — pass; the new `login --token-stdin` invocation validated against the `primitive-admin` help manifest (CLI count 431 → 432).
- `npx vitepress build docs` — pass (anchors resolve, no dead links).

Fixes #211