### PR TITLE
Workflows: accessRule is inert on system workflows; fix webhook guidance (#207)

### DIFF
--- a/docs/getting-started/workflows.md
+++ b/docs/getting-started/workflows.md
@@ -254,17 +254,17 @@ status = "active"
 
 The receive endpoint is `POST /app/{appId}/webhook/{webhookKey}`. When an event arrives, the webhook verifies the signature and starts the configured workflow with the event payload as input. Supported verification schemes are `stripe`, `github`, `slack`, `custom`, and `none`. Use `inputMapping` to extract a nested path from the payload before passing it to the workflow (e.g. `"data.object"`).
 
-**Securing webhook workflows:** add an `accessRule` so clients can't bypass signature verification by starting the workflow directly with a crafted payload:
+**Securing webhook workflows:** a webhook-triggered workflow must run as the system identity (`runAs = "system"` — webhooks can only fire [system workflows](#system-workflows)):
 
 ```toml
 [workflow]
 key = "handle-payment"
 name = "Handle Payment"
 status = "active"
-accessRule = "hasRole('owner')"  # Only webhook triggers can start this — clients are blocked
+runAs = "system"  # required — webhooks can only fire system workflows
 ```
 
-The `accessRule` is evaluated on `client.workflows.start()` calls but **not** on webhook triggers (which have their own signature verification), so `hasRole('owner')` restricts direct starts while webhooks flow normally.
+That identity *is* the security boundary: members can't start a system workflow — a direct `client.workflows.start()` from a member is refused with a `403` — so, together with the webhook's signature verification, a client can't invoke the workflow with a crafted payload. An `accessRule` adds nothing here: it isn't evaluated on webhook triggers, and admins and owners bypass it, so `hasRole('owner')`, `"false"`, and omitting it behave identically. Reserve `accessRule` for [caller workflows](#controlling-access-to-workflows), where it gates who may start a run.
 
 Inspect webhooks and their recent deliveries (accepted, rejected, duplicate) from the CLI:
 
@@ -285,7 +285,7 @@ name = "Generate Report"
 accessRule = "hasRole('admin') || isMemberOf('team', 'ops')"
 ```
 
-With no rule, any signed-in member of the app can start the workflow; admins and owners always pass regardless of the rule. The rule is evaluated on every client invocation — asynchronous or synchronous — and when another workflow invokes this one through a `workflow.call` step. Cron triggers and inbound webhooks have their own controls and skip it; that's what makes the [webhook lock-down pattern](#via-inbound-webhooks) work.
+With no rule, any signed-in member of the app can start the workflow; admins and owners always pass regardless of the rule. The rule is evaluated on every client invocation — asynchronous or synchronous — and when another workflow invokes this one through a `workflow.call` step. Cron triggers and inbound webhooks skip it entirely (they have their own controls). Because those triggers run [system workflows](#system-workflows) — which members can't start at all — `accessRule` is effectively inert on a system workflow; it genuinely gates only **caller** workflows, deciding who may start a run.
 
 Push the rule with `primitive sync push` like any other workflow config, or change it in place with `primitive workflows update <id> --access-rule "<CEL>"`. For the rule language and the identity context available to it (`hasRole`, `isMemberOf`, `memberGroups`), see [Access Control](./access-control.md).
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.swift.md
@@ -839,7 +839,7 @@ When a step reads `steps.<upstream>.output.*` and that upstream can be skipped, 
 - A client calls `workflows.start()`.
 - A `workflow.call` step invokes the workflow from another workflow.
 
-NOT evaluated for inbound webhook triggers (those handle their own auth — e.g., Stripe signature). For webhook-triggered workflows, set `accessRule = "hasRole('owner')"` to prevent direct client invocation.
+NOT evaluated for inbound webhook or cron triggers (those bypass it entirely — a webhook handles its own auth, e.g. a Stripe signature). A webhook- or cron-triggered workflow must be `runAs: "system"` (see [Execution identity](#execution-identity-runas-system-workflows)), and on a system workflow `accessRule` is **inert**: it isn't evaluated on the trigger, members are already blocked by the system-invocation gate (403), and admin/owner bypass it — so `hasRole('owner')`, `"false"`, and omitting it behave identically. What prevents direct client invocation of a webhook workflow is the system-invocation gate plus the webhook's signature verification, not `accessRule`. Reserve `accessRule` for `runAs: "caller"` workflows, where it genuinely gates who may start a run.
 
 Behavior:
 - No rule → any authenticated app member can start.
@@ -934,7 +934,7 @@ status = "active"
 # secretGracePeriodMs, [webhook.allowedIps] cidrs, [webhook.inputMapping]
 ```
 
-Receive endpoint: `POST /app/{appId}/webhook/{webhookKey}`. The platform verifies the signature per `verificationScheme`, then starts `workflowKey` with the event payload as input; `inputMapping` (e.g. `"data.object"`) extracts a nested path first. Always pair a webhook-triggered workflow with `accessRule = "hasRole('owner')"` (see Access control above) so clients can't start it directly with a crafted payload.
+Receive endpoint: `POST /app/{appId}/webhook/{webhookKey}`. The platform verifies the signature per `verificationScheme`, then starts `workflowKey` with the event payload as input; `inputMapping` (e.g. `"data.object"`) extracts a nested path first. A webhook-triggered workflow is `runAs: "system"`, so what stops a client from starting it directly with a crafted payload is the system-invocation gate (members get a 403) plus the signature verification — not `accessRule`, which a system workflow doesn't evaluate on the trigger (see [Access control](#access-control)).
 
 CLI: `primitive webhooks list | get | create | update | delete | rotate-secret | test | events <webhook-key>` — `events` lists recent deliveries (accepted / rejected / duplicate / `workflow_not_active`).
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md
@@ -839,7 +839,7 @@ When a step reads `steps.<upstream>.output.*` and that upstream can be skipped, 
 - A client calls `workflows.start()`.
 - A `workflow.call` step invokes the workflow from another workflow.
 
-NOT evaluated for inbound webhook triggers (those handle their own auth — e.g., Stripe signature). For webhook-triggered workflows, set `accessRule = "hasRole('owner')"` to prevent direct client invocation.
+NOT evaluated for inbound webhook or cron triggers (those bypass it entirely — a webhook handles its own auth, e.g. a Stripe signature). A webhook- or cron-triggered workflow must be `runAs: "system"` (see [Execution identity](#execution-identity-runas-system-workflows)), and on a system workflow `accessRule` is **inert**: it isn't evaluated on the trigger, members are already blocked by the system-invocation gate (403), and admin/owner bypass it — so `hasRole('owner')`, `"false"`, and omitting it behave identically. What prevents direct client invocation of a webhook workflow is the system-invocation gate plus the webhook's signature verification, not `accessRule`. Reserve `accessRule` for `runAs: "caller"` workflows, where it genuinely gates who may start a run.
 
 Behavior:
 - No rule → any authenticated app member can start.
@@ -934,7 +934,7 @@ status = "active"
 # secretGracePeriodMs, [webhook.allowedIps] cidrs, [webhook.inputMapping]
 ```
 
-Receive endpoint: `POST /app/{appId}/webhook/{webhookKey}`. The platform verifies the signature per `verificationScheme`, then starts `workflowKey` with the event payload as input; `inputMapping` (e.g. `"data.object"`) extracts a nested path first. Always pair a webhook-triggered workflow with `accessRule = "hasRole('owner')"` (see Access control above) so clients can't start it directly with a crafted payload.
+Receive endpoint: `POST /app/{appId}/webhook/{webhookKey}`. The platform verifies the signature per `verificationScheme`, then starts `workflowKey` with the event payload as input; `inputMapping` (e.g. `"data.object"`) extracts a nested path first. A webhook-triggered workflow is `runAs: "system"`, so what stops a client from starting it directly with a crafted payload is the system-invocation gate (members get a 403) plus the signature verification — not `accessRule`, which a system workflow doesn't evaluate on the trigger (see [Access control](#access-control)).
 
 CLI: `primitive webhooks list | get | create | update | delete | rotate-secret | test | events <webhook-key>` — `events` lists recent deliveries (accepted / rejected / duplicate / `workflow_not_active`).
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.ts.md
@@ -839,7 +839,7 @@ When a step reads `steps.<upstream>.output.*` and that upstream can be skipped, 
 - A client calls `workflows.start()`.
 - A `workflow.call` step invokes the workflow from another workflow.
 
-NOT evaluated for inbound webhook triggers (those handle their own auth — e.g., Stripe signature). For webhook-triggered workflows, set `accessRule = "hasRole('owner')"` to prevent direct client invocation.
+NOT evaluated for inbound webhook or cron triggers (those bypass it entirely — a webhook handles its own auth, e.g. a Stripe signature). A webhook- or cron-triggered workflow must be `runAs: "system"` (see [Execution identity](#execution-identity-runas-system-workflows)), and on a system workflow `accessRule` is **inert**: it isn't evaluated on the trigger, members are already blocked by the system-invocation gate (403), and admin/owner bypass it — so `hasRole('owner')`, `"false"`, and omitting it behave identically. What prevents direct client invocation of a webhook workflow is the system-invocation gate plus the webhook's signature verification, not `accessRule`. Reserve `accessRule` for `runAs: "caller"` workflows, where it genuinely gates who may start a run.
 
 Behavior:
 - No rule → any authenticated app member can start.
@@ -934,7 +934,7 @@ status = "active"
 # secretGracePeriodMs, [webhook.allowedIps] cidrs, [webhook.inputMapping]
 ```
 
-Receive endpoint: `POST /app/{appId}/webhook/{webhookKey}`. The platform verifies the signature per `verificationScheme`, then starts `workflowKey` with the event payload as input; `inputMapping` (e.g. `"data.object"`) extracts a nested path first. Always pair a webhook-triggered workflow with `accessRule = "hasRole('owner')"` (see Access control above) so clients can't start it directly with a crafted payload.
+Receive endpoint: `POST /app/{appId}/webhook/{webhookKey}`. The platform verifies the signature per `verificationScheme`, then starts `workflowKey` with the event payload as input; `inputMapping` (e.g. `"data.object"`) extracts a nested path first. A webhook-triggered workflow is `runAs: "system"`, so what stops a client from starting it directly with a crafted payload is the system-invocation gate (members get a 403) plus the signature verification — not `accessRule`, which a system workflow doesn't evaluate on the trigger (see [Access control](#access-control)).
 
 CLI: `primitive webhooks list | get | create | update | delete | rotate-secret | test | events <webhook-key>` — `events` lists recent deliveries (accepted / rejected / duplicate / `workflow_not_active`).
 


### PR DESCRIPTION
## What the issue reported
The workflows guide recommends, for webhook-triggered workflows, `accessRule = "hasRole('owner')"` to prevent direct client invocation. On a `runAs:"system"` workflow — which a webhook-triggered workflow must be — `accessRule` is inert, so the recommendation reads as if it were the security boundary when it adds nothing.

## Verified against source
Confirmed all three sub-claims against the stamped `library_repos/js-bao-wss` source:
- **Not evaluated on webhook/cron triggers.** `evaluateWorkflowAccessRule` is called only on caller-mode HTTP `start`/`runSync` (`app-api/controllers/workflows-controller.ts`, gated `runAs === "caller"`) and non-system `workflow.call` (`workflows/steps/workflow-call-step.ts`). The webhook receiver and cron-trigger paths never reference `accessRule`.
- **System-invocation gate is the real control.** `resolveSystemIdentity` (`workflows/runner/execution-identity.ts`) returns `403 "Members cannot run system workflows"` for a member, before any accessRule evaluation.
- **admin/owner bypass.** `workflows/workflow-access.ts` returns `{ allowed: true }` for admin/owner unconditionally.

Net: on a system workflow, `hasRole('owner')`, `"false"`, and omitting `accessRule` are functionally identical. The guide's own Execution-identity section already says role-only rules are "inert but accepted" on system workflows — the webhook recommendation contradicted it.

## What changed
- `guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md` — *Access control* (`accessRule` evaluation) and *Inbound webhooks* sections rewritten: the boundary for a webhook workflow is the system-invocation gate + signature verification; `accessRule` is scoped to `runAs:"caller"`.
- `docs/getting-started/workflows.md` — the webhook-securing note now shows `runAs = "system"` (not an `accessRule`) and explains the real boundary; the *Controlling Access* section scopes `accessRule` to caller workflows and drops a now-defunct link to the removed "webhook lock-down pattern".
- Regenerated the rendered guide builds.

## Validation
- `pnpm check:examples` — pass.
- `npx vitepress build docs` — pass (all internal anchors resolve; the dead `#via-inbound-webhooks` link is gone).
- Editorial + sync + link-integrity review — pass.

## Related (platform, not actioned here)
The issue also suggests surfacing this footgun at the source (warn/reject a non-trivial `accessRule` on a `runAs:"system"` workflow). That's a js-bao-wss change, out of scope for this doc fix; it cross-references js-bao-wss#1232 and #1233.

Fixes #207