### PR TITLE
docs-next-sync: js-bao-wss changes (automated)

### DIFF
--- a/docs-sources.json
+++ b/docs-sources.json
@@ -1,9 +1,9 @@
 {
   "channel": "next",
-  "stampedAt": "2026-06-28",
+  "stampedAt": "2026-06-30",
   "libraries": {
     "js-bao-wss": {
-      "commit": "cafa81e6e853413d2c4d53c26551d1e1e824d411",
+      "commit": "577e6aa0debf20689f5be65274f101d1415a82f2",
       "npm": {
         "js-bao-wss-client": "2.0.4",
         "js-bao": "0.5.1",

--- a/docs/getting-started/workflows.md
+++ b/docs/getting-started/workflows.md
@@ -249,7 +249,7 @@ key = "stripe-payments"
 displayName = "Stripe Payments"
 workflowKey = "handle-payment"
 verificationScheme = "stripe"
-status = "active"
+status = "active"  # active | paused
 ```
 
 The receive endpoint is `POST /app/{appId}/webhook/{webhookKey}`. When an event arrives, the webhook verifies the signature and starts the configured workflow with the event payload as input. Supported verification schemes are `stripe`, `github`, `slack`, `custom`, and `none`. Use `inputMapping` to extract a nested path from the payload before passing it to the workflow (e.g. `"data.object"`).

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.swift.md
@@ -929,14 +929,14 @@ key = "stripe-payments"
 displayName = "Stripe Payments"
 workflowKey = "process-stripe"
 verificationScheme = "stripe"     # stripe | github | slack | custom | none
-status = "active"
+status = "active"                 # active | paused; create defaults to active
 # Optional: toleranceSeconds, deduplicationEnabled, deduplicationWindowMs,
 # secretGracePeriodMs, [webhook.allowedIps] cidrs, [webhook.inputMapping]
 ```
 
 Receive endpoint: `POST /app/{appId}/webhook/{webhookKey}`. The platform verifies the signature per `verificationScheme`, then starts `workflowKey` with the event payload as input; `inputMapping` (e.g. `"data.object"`) extracts a nested path first. A webhook-triggered workflow is `runAs: "system"`, so what stops a client from starting it directly with a crafted payload is the system-invocation gate (members get a 403) plus the signature verification — not `accessRule`, which a system workflow doesn't evaluate on the trigger (see [Access control](#access-control)).
 
-CLI: `primitive webhooks list | get | create | update | delete | rotate-secret | test | events <webhook-key>` — `events` lists recent deliveries (accepted / rejected / duplicate / `workflow_not_active`).
+CLI: `primitive webhooks list | get | create | update | delete | rotate-secret | test | events <webhook-key>` — `events` lists recent deliveries (accepted / rejected / duplicate / `workflow_not_active`). `active` and `paused` are the settable statuses (`create` and `update` reject anything else, and `create` defaults to `active`); `archived` is reserved for delete and only appears on read — `list --status` filters by `active`, `paused`, or `archived`.
 
 A `workflow_not_active` delivery means the bound workflow was draft or archived when the event arrived: the request is acked with HTTP 202 `{ received: true }` (so the sender doesn't retry) but the workflow is **not dispatched**. Activate the workflow and resend — these events are excluded from deduplication, so the resend isn't dropped as a duplicate. Binding a webhook to a not-yet-active workflow succeeds and returns a non-blocking `warning` carrying `WORKFLOW_NOT_ACTIVE`.
 
@@ -1210,7 +1210,9 @@ A workflow needs `status = "active"` AND one of (active configuration | publishe
 
 Setting `status = "active"` without an active config or revision returns: `Cannot activate workflow without a configuration`.
 
-`primitive sync push` creates a default configuration automatically when a workflow is first created and updates it on subsequent pushes. Each push of `[[steps]]` updates the active configuration's steps in place.
+`primitive workflows delete <id>` (the default) is a **soft delete**: it archives the workflow and keeps its `workflowKey` reserved, so recreating a workflow under the same key fails with `workflowKey already exists (held by an archived workflow <id>)`. Free the key for reuse with a hard delete — `primitive workflows delete <id> --hard` — which also cascades to the workflow's configurations, runs, step runs, and test cases.
+
+`primitive sync push` creates a default configuration automatically when a workflow is first created and updates it on subsequent pushes. Each push of `[[steps]]` updates the active configuration's steps in place. `primitive workflows update <id> --from-file <toml>` pushes a revised body (metadata + steps) to an existing workflow the same way without the full sync directory — it overwrites the active configuration in place and is live immediately; explicit `update` flags override the TOML's metadata.
 
 ### Configurations vs revisions
 
@@ -1232,8 +1234,9 @@ primitive workflows list [--status active] [--json]
 primitive workflows get <workflow-id>
 primitive workflows create --from-file workflow.toml [--requires-client-apply false]
 primitive workflows update <workflow-id> --status active
-primitive workflows delete <workflow-id>           # archive
-primitive workflows delete <workflow-id> --hard --yes
+primitive workflows update <workflow-id> --from-file workflow.toml   # push a revised body (metadata + steps) in place, live immediately; explicit flags above override TOML values
+primitive workflows delete <workflow-id>           # archive (soft delete; the workflowKey stays reserved)
+primitive workflows delete <workflow-id> --hard --yes   # also frees the workflowKey for reuse
 
 # Expand fragment includes (for debugging)
 primitive workflows expand <workflow.toml>
@@ -1281,6 +1284,8 @@ primitive workflows analytics top --days 7
 ```
 
 All inspection commands take `--json`.
+
+A run that aborts during **setup** — before any step executes (resolving its config/revision, loading steps, or validating `input` against `inputSchema`) — is still marked `failed` with the real error message, and records one synthetic step with id `__setup__` and kind `setup`. So `runs steps` is never empty and `runs error` always names the failure, even when no author-defined step ran.
 
 ### Reusable step fragments
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md
@@ -929,14 +929,14 @@ key = "stripe-payments"
 displayName = "Stripe Payments"
 workflowKey = "process-stripe"
 verificationScheme = "stripe"     # stripe | github | slack | custom | none
-status = "active"
+status = "active"                 # active | paused; create defaults to active
 # Optional: toleranceSeconds, deduplicationEnabled, deduplicationWindowMs,
 # secretGracePeriodMs, [webhook.allowedIps] cidrs, [webhook.inputMapping]
 ```
 
 Receive endpoint: `POST /app/{appId}/webhook/{webhookKey}`. The platform verifies the signature per `verificationScheme`, then starts `workflowKey` with the event payload as input; `inputMapping` (e.g. `"data.object"`) extracts a nested path first. A webhook-triggered workflow is `runAs: "system"`, so what stops a client from starting it directly with a crafted payload is the system-invocation gate (members get a 403) plus the signature verification — not `accessRule`, which a system workflow doesn't evaluate on the trigger (see [Access control](#access-control)).
 
-CLI: `primitive webhooks list | get | create | update | delete | rotate-secret | test | events <webhook-key>` — `events` lists recent deliveries (accepted / rejected / duplicate / `workflow_not_active`).
+CLI: `primitive webhooks list | get | create | update | delete | rotate-secret | test | events <webhook-key>` — `events` lists recent deliveries (accepted / rejected / duplicate / `workflow_not_active`). `active` and `paused` are the settable statuses (`create` and `update` reject anything else, and `create` defaults to `active`); `archived` is reserved for delete and only appears on read — `list --status` filters by `active`, `paused`, or `archived`.
 
 A `workflow_not_active` delivery means the bound workflow was draft or archived when the event arrived: the request is acked with HTTP 202 `{ received: true }` (so the sender doesn't retry) but the workflow is **not dispatched**. Activate the workflow and resend — these events are excluded from deduplication, so the resend isn't dropped as a duplicate. Binding a webhook to a not-yet-active workflow succeeds and returns a non-blocking `warning` carrying `WORKFLOW_NOT_ACTIVE`.
 
@@ -1178,7 +1178,9 @@ A workflow needs `status = "active"` AND one of (active configuration | publishe
 
 Setting `status = "active"` without an active config or revision returns: `Cannot activate workflow without a configuration`.
 
-`primitive sync push` creates a default configuration automatically when a workflow is first created and updates it on subsequent pushes. Each push of `[[steps]]` updates the active configuration's steps in place.
+`primitive workflows delete <id>` (the default) is a **soft delete**: it archives the workflow and keeps its `workflowKey` reserved, so recreating a workflow under the same key fails with `workflowKey already exists (held by an archived workflow <id>)`. Free the key for reuse with a hard delete — `primitive workflows delete <id> --hard` — which also cascades to the workflow's configurations, runs, step runs, and test cases.
+
+`primitive sync push` creates a default configuration automatically when a workflow is first created and updates it on subsequent pushes. Each push of `[[steps]]` updates the active configuration's steps in place. `primitive workflows update <id> --from-file <toml>` pushes a revised body (metadata + steps) to an existing workflow the same way without the full sync directory — it overwrites the active configuration in place and is live immediately; explicit `update` flags override the TOML's metadata.
 
 ### Configurations vs revisions
 
@@ -1200,8 +1202,9 @@ primitive workflows list [--status active] [--json]
 primitive workflows get <workflow-id>
 primitive workflows create --from-file workflow.toml [--requires-client-apply false]
 primitive workflows update <workflow-id> --status active
-primitive workflows delete <workflow-id>           # archive
-primitive workflows delete <workflow-id> --hard --yes
+primitive workflows update <workflow-id> --from-file workflow.toml   # push a revised body (metadata + steps) in place, live immediately; explicit flags above override TOML values
+primitive workflows delete <workflow-id>           # archive (soft delete; the workflowKey stays reserved)
+primitive workflows delete <workflow-id> --hard --yes   # also frees the workflowKey for reuse
 
 # Expand fragment includes (for debugging)
 primitive workflows expand <workflow.toml>
@@ -1249,6 +1252,8 @@ primitive workflows analytics top --days 7
 ```
 
 All inspection commands take `--json`.
+
+A run that aborts during **setup** — before any step executes (resolving its config/revision, loading steps, or validating `input` against `inputSchema`) — is still marked `failed` with the real error message, and records one synthetic step with id `__setup__` and kind `setup`. So `runs steps` is never empty and `runs error` always names the failure, even when no author-defined step ran.
 
 ### Reusable step fragments
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.ts.md
@@ -929,14 +929,14 @@ key = "stripe-payments"
 displayName = "Stripe Payments"
 workflowKey = "process-stripe"
 verificationScheme = "stripe"     # stripe | github | slack | custom | none
-status = "active"
+status = "active"                 # active | paused; create defaults to active
 # Optional: toleranceSeconds, deduplicationEnabled, deduplicationWindowMs,
 # secretGracePeriodMs, [webhook.allowedIps] cidrs, [webhook.inputMapping]
 ```
 
 Receive endpoint: `POST /app/{appId}/webhook/{webhookKey}`. The platform verifies the signature per `verificationScheme`, then starts `workflowKey` with the event payload as input; `inputMapping` (e.g. `"data.object"`) extracts a nested path first. A webhook-triggered workflow is `runAs: "system"`, so what stops a client from starting it directly with a crafted payload is the system-invocation gate (members get a 403) plus the signature verification — not `accessRule`, which a system workflow doesn't evaluate on the trigger (see [Access control](#access-control)).
 
-CLI: `primitive webhooks list | get | create | update | delete | rotate-secret | test | events <webhook-key>` — `events` lists recent deliveries (accepted / rejected / duplicate / `workflow_not_active`).
+CLI: `primitive webhooks list | get | create | update | delete | rotate-secret | test | events <webhook-key>` — `events` lists recent deliveries (accepted / rejected / duplicate / `workflow_not_active`). `active` and `paused` are the settable statuses (`create` and `update` reject anything else, and `create` defaults to `active`); `archived` is reserved for delete and only appears on read — `list --status` filters by `active`, `paused`, or `archived`.
 
 A `workflow_not_active` delivery means the bound workflow was draft or archived when the event arrived: the request is acked with HTTP 202 `{ received: true }` (so the sender doesn't retry) but the workflow is **not dispatched**. Activate the workflow and resend — these events are excluded from deduplication, so the resend isn't dropped as a duplicate. Binding a webhook to a not-yet-active workflow succeeds and returns a non-blocking `warning` carrying `WORKFLOW_NOT_ACTIVE`.
 
@@ -1216,7 +1216,9 @@ A workflow needs `status = "active"` AND one of (active configuration | publishe
 
 Setting `status = "active"` without an active config or revision returns: `Cannot activate workflow without a configuration`.
 
-`primitive sync push` creates a default configuration automatically when a workflow is first created and updates it on subsequent pushes. Each push of `[[steps]]` updates the active configuration's steps in place.
+`primitive workflows delete <id>` (the default) is a **soft delete**: it archives the workflow and keeps its `workflowKey` reserved, so recreating a workflow under the same key fails with `workflowKey already exists (held by an archived workflow <id>)`. Free the key for reuse with a hard delete — `primitive workflows delete <id> --hard` — which also cascades to the workflow's configurations, runs, step runs, and test cases.
+
+`primitive sync push` creates a default configuration automatically when a workflow is first created and updates it on subsequent pushes. Each push of `[[steps]]` updates the active configuration's steps in place. `primitive workflows update <id> --from-file <toml>` pushes a revised body (metadata + steps) to an existing workflow the same way without the full sync directory — it overwrites the active configuration in place and is live immediately; explicit `update` flags override the TOML's metadata.
 
 ### Configurations vs revisions
 
@@ -1238,8 +1240,9 @@ primitive workflows list [--status active] [--json]
 primitive workflows get <workflow-id>
 primitive workflows create --from-file workflow.toml [--requires-client-apply false]
 primitive workflows update <workflow-id> --status active
-primitive workflows delete <workflow-id>           # archive
-primitive workflows delete <workflow-id> --hard --yes
+primitive workflows update <workflow-id> --from-file workflow.toml   # push a revised body (metadata + steps) in place, live immediately; explicit flags above override TOML values
+primitive workflows delete <workflow-id>           # archive (soft delete; the workflowKey stays reserved)
+primitive workflows delete <workflow-id> --hard --yes   # also frees the workflowKey for reuse
 
 # Expand fragment includes (for debugging)
 primitive workflows expand <workflow.toml>
@@ -1287,6 +1290,8 @@ primitive workflows analytics top --days 7
 ```
 
 All inspection commands take `--json`.
+
+A run that aborts during **setup** — before any step executes (resolving its config/revision, loading steps, or validating `input` against `inputSchema`) — is still marked `failed` with the real error message, and records one synthetic step with id `__setup__` and kind `setup`. So `runs steps` is never empty and `runs error` always names the failure, even when no author-defined step ran.
 
 ### Reusable step fragments
 

--- a/guides/latest/guides.json
+++ b/guides/latest/guides.json
@@ -15,7 +15,7 @@
     }
   },
   "builtAgainst": {
-    "stampedAt": "2026-06-28",
+    "stampedAt": "2026-06-30",
     "channel": "next",
     "packages": {
       "js-bao-wss-client": "2.0.4",


### PR DESCRIPTION
Automated `docs-next-sync` pass against the library main tips, triggered by the nightly release js-bao-wss#1298.

> **Rolling PR.** This PR is updated in place each night until it merges — every update is a complete, gate-green superset of everything new since the last merge (branched fresh from `next`, not stacked). Merge it to advance the baseline; the next nightly then starts fresh and small.

# docs-next-sync disposition report — 2026-06-30 (next channel)

Trued the `next` docs against the library `main` tips. Baseline stamp: 2026-06-28
(`cafa81e6`). New js-bao-wss tip: **`577e6aa0`**. Other submodules unchanged
(`primitive-app-dev` `fc60fa57`, `swift-primitive-app-dev` `943ba1ab` — 0 commits each).

All facts below were verified against the submodule source at `577e6aa0`
(diffs in `library_repos/js-bao-wss/{src,cli}`), not the PR/release summaries.
**No client-API surface changed** (`src/client/**` untouched), so no example
callsite ripple and no JS/Swift parity gaps to file — every change is CLI- or
server-behavior, documented in language-agnostic prose/TOML/CLI blocks.

## Per-commit disposition

| Commit(s) | PR / issue | Surface | Disposition |
|---|---|---|---|
| `cab6bfb1`, `a1737ac3`, `315d9841` | #1234 | `cli/src/commands/webhooks.ts`, `src/admin-api.ts` | **updated** workflows guide (Inbound webhooks) + `docs/getting-started/workflows.md` webhook TOML — webhook status vocabulary: `active`/`paused` are the settable values (`create`/`update` reject others; `create` defaults to `active`), `archived` is reserved for delete and read-only (sync round-trips it); `list --status` filters `active`/`paused`/`archived`. The old `disabled` value never appeared in the docs, so nothing stale to remove. |
| `408a880f`, `e741ef7d`, `aea69a3b` | #1238 | `src/admin-api.ts` (hard-delete cascade + archived-key conflict), `cli/src/commands/workflows.ts` | **updated** workflows guide lifecycle — soft delete (`workflows delete <id>`) archives and keeps the `workflowKey` reserved (recreate under the same key fails `workflowKey already exists (held by an archived workflow <id>)`); `--hard` frees the key and cascades to configs/runs/step-runs/test-cases. The cascade itself is internal server cleanup (no doc surface); only the developer-observable key-reservation + remedy is documented. |
| `3ee548e3`, `b2c7ee82` | #1240 | `src/workflows/app-workflow.ts`, `src/workflows/setup-failure-step.ts` (new) | **updated** workflows guide run-inspection — a run aborting during *setup* (config/revision resolution, step load, `inputSchema` validation) is now marked `failed` with the real message and records one synthetic step `id=__setup__`, `kind=setup`, so `runs steps` is never empty and `runs error` always names the failure. |
| `5f954525`, `03d514fc`, `78418cc1` | #1249 | `cli/src/commands/workflows.ts`, `cli/src/lib/workflow-apply.ts`, `cli/src/commands/sync.ts` | **updated** workflows guide CLI reference + lifecycle — new `primitive workflows update <id> --from-file <toml>`: pushes a revised body (metadata + steps) to an existing workflow in place, live immediately (overwrites the active config), symmetric with `create --from-file`; explicit `update` flags override the TOML's metadata. Expands `include` fragments like `sync push`. |
| `142d250f`, `e083a172`, `577e6aa0` | #1239 | `cli/src/lib/toml-params-validator.ts` | **internal — no change.** Removes a *false-positive* "declared but not referenced" soft warning in `sync push` for a database-op param used only in an `access` CEL rule. The warning itself is undocumented; the blocking `$params` error path (which the guide *does* document) is unchanged. Makes existing behavior match the docs — no edit needed. |
| `3bdafda4`, `ae6719ca`, `790f1fb0` | #1274 | `.claude/skills/**` (deploy-window PR enumeration) | **internal — no change.** Library-repo skills/tooling, not developer-facing. |

## Files changed this pass

- `guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md` (+ rendered `.ts.md` / `.swift.md` — all edits are agnostic prose, rendered identically into both builds)
- `docs/getting-started/workflows.md` (webhook TOML status comment)
- `docs-sources.json`, `guides/latest/guides.json` (restamp to `577e6aa0`)
- `library_repos/js-bao-wss` (submodule pointer → `577e6aa0`)

### Altitude note (no human-doc duplication of reference detail)
#1238 / #1240 / #1249 landed in the agent guide only. The tutorial human page
(`workflows.md`) documents body-push via `sync push` and does not enumerate the
`workflows create/update --from-file` CLI surface, `workflows delete`, or run
internals — so the new reference-grade detail stays guide-side, consistent with
how `create --from-file` is already handled. The one human-doc touch (#1234) is a
single at-altitude TOML comment. No contradiction between the two surfaces.

## Issues touched

No open `primitive-docs` issue was unblocked by this batch (none is upstream-keyed
to these commits). All remain **deferred**:

- **#222** (docs-editorial skill: rule against internal type names) — not gated on any library commit. Deferred.
- **#221** (`AppGroup` internal type in generated reference + users-and-groups guide) — blocker is an upstream `js-bao-wss-client` TSDoc fix, not present in this batch. Deferred.
- **#210** (auth guide: Apple provider rows / Swift `[auth]` / enable surface) — not gated on this batch. Deferred.
- **#199** (end-to-end subscription-entitlement recipe) — explicitly blocked on "group-membership maintenance from a system webhook works end to end"; the #1234 webhook change is create-status defaulting only and does **not** deliver that path. Still blocked. Deferred.

**Filed this pass:** none — no JS/Swift parity gap or library bug surfaced (no client API changed).

## Whole-set audit (docs-set-audit)

- **Mechanical:** no orphan pages (all `getting-started/*.md` are in the sidebar); `vitepress build` clean (no dead links); example-parity inventory unchanged — this pass added **no** new lone-language fences (all edits agnostic); `guides.json` manifest references current.
- **Cross-page judgment:** webhook status and workflow lifecycle/delete are owned solely by the workflows pages — no duplication. The new `--hard`/soft-delete language harmonizes with the established pattern already used in the integrations and prompts guides ("soft sets `archived`; `--hard` permanently removes"). No inconsistency, boundary violation, or set-ramp issue introduced.
- **Findings applied:** none required — clean bill for this pass.

## Gates (all GREEN)

- `pnpm check:examples` — ✅ corpus/guide sync, 159 TS examples compile against submodule source, 174 TOML blocks valid, **433 CLI invocations validated against `primitive-admin` source (incl. the new `workflows update --from-file`)**, `docs-sources.json` matches submodules + package versions. (Swift compile gate skipped here — needs a macOS host; covered by the macOS CI job.)
- `npx vitepress build docs` — ✅ build complete, no dead links.

## Larger changes flagged for review

None. All edits are routine in-section updates to the existing workflows guide and
one TOML comment on the workflows page — no new pages, restructures, or content removals.

## Unresolved source/doc contradictions

None.

---
Review the doc changes and the disposition above, then merge into `next`. Publishing to `main` happens separately at a production release.

> Generated unattended by the Claude Code CLI. Verify facts against source before merging.