### PR TITLE
Use public-surface phrasing for contextId in users-and-groups guide (#221)

### DIFF
--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.swift.md
@@ -693,7 +693,7 @@ Per-op fallback applies — configured ops always win, missing ops resolve again
 | `user.role` | yes | App role (`"owner"` / `"admin"` / `"member"`) |
 | `collection.collectionType` | yes | Collection's type (matches the `CollectionTypeConfig` this rule set is bound to) |
 | `collection.collectionId` | yes (after create) | Collection's ID |
-| `collection.contextId` | yes | Per-instance identifier — parallels `AppGroup.groupId`. Set at create time and immutable. `null` for collections with no context. Use it to express "caller belongs to the group this collection represents." |
+| `collection.contextId` | yes | Per-instance identifier — parallels a group's `groupId`. Set at create time and immutable. `null` for collections with no context. Use it to express "caller belongs to the group this collection represents." |
 | `collection.name` | yes | Display name |
 | `collection.createdBy` | yes (after create) | userId of the collection's creator |
 | `target.userId` | only `category: "member"`, ops `add` / `remove` | The user being added or removed. Absent for `member.list`. |

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.template.md
@@ -498,7 +498,7 @@ Per-op fallback applies — configured ops always win, missing ops resolve again
 | `user.role` | yes | App role (`"owner"` / `"admin"` / `"member"`) |
 | `collection.collectionType` | yes | Collection's type (matches the `CollectionTypeConfig` this rule set is bound to) |
 | `collection.collectionId` | yes (after create) | Collection's ID |
-| `collection.contextId` | yes | Per-instance identifier — parallels `AppGroup.groupId`. Set at create time and immutable. `null` for collections with no context. Use it to express "caller belongs to the group this collection represents." |
+| `collection.contextId` | yes | Per-instance identifier — parallels a group's `groupId`. Set at create time and immutable. `null` for collections with no context. Use it to express "caller belongs to the group this collection represents." |
 | `collection.name` | yes | Display name |
 | `collection.createdBy` | yes (after create) | userId of the collection's creator |
 | `target.userId` | only `category: "member"`, ops `add` / `remove` | The user being added or removed. Absent for `member.list`. |

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.ts.md
@@ -674,7 +674,7 @@ Per-op fallback applies — configured ops always win, missing ops resolve again
 | `user.role` | yes | App role (`"owner"` / `"admin"` / `"member"`) |
 | `collection.collectionType` | yes | Collection's type (matches the `CollectionTypeConfig` this rule set is bound to) |
 | `collection.collectionId` | yes (after create) | Collection's ID |
-| `collection.contextId` | yes | Per-instance identifier — parallels `AppGroup.groupId`. Set at create time and immutable. `null` for collections with no context. Use it to express "caller belongs to the group this collection represents." |
+| `collection.contextId` | yes | Per-instance identifier — parallels a group's `groupId`. Set at create time and immutable. `null` for collections with no context. Use it to express "caller belongs to the group this collection represents." |
 | `collection.name` | yes | Display name |
 | `collection.createdBy` | yes (after create) | userId of the collection's creator |
 | `target.userId` | only `category: "member"`, ops `add` / `remove` | The user being added or removed. Absent for `member.list`. |


### PR DESCRIPTION
## What the issue reported
Public docs reference the platform-internal type **`AppGroup`**, which is not on the public client surface (groups are exposed as `GroupInfo` / `CreateGroupParams`, fields `groupType` / `groupId`). A developer reading the `contextId` description asked "what is `AppGroup.groupId`?" — a dead reference for anyone working from the public client.

## Verified against source
Three live references confirmed. Two are **generated** reference pages whose text comes verbatim from upstream client TSDoc (`src/client/api/collectionsApi.ts`, `src/client/api/groupsApi.ts`) — editing the generated `.md` is overwritten on the next `gen:reference`, so those are fixed at the source in **js-bao-wss#1299**. The third, the users-and-groups agent guide, is authored in-repo and fixed here.

## What changed
`guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.template.md` (+ rendered `.ts.md` / `.swift.md` via `pnpm render:guides`): `collection.contextId` now reads "parallels a group's `groupId`" instead of "parallels `AppGroup.groupId`". Meaning preserved — `contextId` is a caller-supplied per-instance key analogous to a group's `groupId`.

`AppGroup` appears nowhere in `docs/` (only the template + the two generated pages), so the docs↔guides pair stays in sync.

## Validation
- `pnpm check:examples` — pass (parity, compile, TOML, CLI, stamp gate)
- `npx vitepress build docs` — pass (no dead links)

Companion: editorial-rule change in #222; upstream source fix in js-bao-wss#1299.

Fixes #221