### PR TITLE
Move the repo and CI to pnpm 10

### DIFF
--- a/AUTOMATION.md
+++ b/AUTOMATION.md
@@ -16,7 +16,10 @@ skills they invoke must be reflected here (CLAUDE.md enforces this rule).
 The unattended posture for each skill lives in that skill's **"Unattended
 mode (CI)"** section (`.claude/skills/*/SKILL.md`) — the single source of
 truth; workflow prompts only restate the hard boundaries. The Claude Code CLI
-version is pinned in each workflow — bump deliberately.
+version is pinned in each workflow — bump deliberately. All CI jobs take their
+pnpm from `package.json`'s `packageManager` field (pnpm 10; settings live in
+`pnpm-workspace.yaml`), and the js-bao-wss workspace builds run under that
+submodule's own pinned pnpm via corepack.
 
 ## Non-agent plumbing
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "primitive-docs",
   "private": true,
-  "packageManager": "pnpm@9.0.0",
+  "packageManager": "pnpm@10.28.2+sha512.41872f037ad22f7348e3b1debbaf7e867cfd448f2726d9cf74c08f19507c31d2c8e7a11525b983febc2df640b5438dee6023ebb1f84ed43cc2d654d2bc326264",
   "engines": {
     "node": ">=22"
   },

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+# Not a workspace — this file carries pnpm settings (their home since pnpm 10;
+# the package.json `pnpm` field is no longer read).
+onlyBuiltDependencies:
+  - better-sqlite3
+  - esbuild


### PR DESCRIPTION
Aligns the docs repo with the pnpm version the library repos pin (`pnpm@10.28.2`), so the CI/local split that caused this morning's gate failure can't recur in either direction.

- `packageManager` → `pnpm@10.28.2` (same integrity-pinned string as js-bao-wss). `pnpm/action-setup` in every workflow reads this field, so all CI jobs move automatically — no workflow edits needed.
- **pnpm 10 doesn't run dependency build scripts by default**: `better-sqlite3` and `esbuild` are allowlisted via `onlyBuiltDependencies` in a new `pnpm-workspace.yaml` (settings-only — not a workspace; pnpm 10 no longer reads the `package.json` `pnpm` field). Both verified built and loadable locally.
- Lockfile unchanged — pnpm 9/10 share lockfileVersion 9.0 and this repo has no overrides.
- `build-source-packages.mjs` keeps its corepack indirection: the js-bao-wss workspace builds under that submodule's own pin regardless of this repo's pnpm.
- AUTOMATION.md notes where CI pnpm comes from.

This PR's own Checks run **is** the validation: action-setup installs pnpm 10 from the new pin and runs the full gates (frozen install, source-package builds, compiles, site build) on both Linux and macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)