### PR TITLE
docs-next-sync: js-bao-wss changes (automated, 2026-07-04)

### DIFF
--- a/docs-sources.json
+++ b/docs-sources.json
@@ -1,9 +1,9 @@
 {
   "channel": "next",
-  "stampedAt": "2026-07-03",
+  "stampedAt": "2026-07-04",
   "libraries": {
     "js-bao-wss": {
-      "commit": "e72da39d1ae91ad83fe6e0dfae00a622db221525",
+      "commit": "20de84bffcfdc3d496116cfe3cbc8ae86f4db8c4",
       "npm": {
         "js-bao-wss-client": "2.0.4",
         "js-bao": "0.5.1",

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -372,6 +372,7 @@ export default defineConfig({
           { text: 'Authentication', link: '/getting-started/authentication' },
           { text: 'Users and Groups', link: '/getting-started/users-and-groups' },
           { text: 'Access Control', link: '/getting-started/access-control' },
+          { text: 'Resource Metadata', link: '/getting-started/resource-metadata' },
           { text: 'Invitations', link: '/getting-started/invitations' },
         ],
         collapsed: false,

--- a/docs/getting-started/access-control.md
+++ b/docs/getting-started/access-control.md
@@ -32,7 +32,7 @@ Every CEL evaluation sees the authenticated caller:
 
 Group membership is the workhorse: model teams, roles, and relationships as [groups](./users-and-groups.md), then write rules against membership instead of hard-coding user IDs. `isMemberOf('team', params.teamId)` stays correct as people join and leave; `userId == '01ABC...'` doesn't.
 
-Each place a rule appears adds its own context on top — operation `params.*`, the `database.*` being accessed, the `record.*` being written. The feature pages document their specific variables.
+Each place a rule appears adds its own context on top — operation `params.*`, the `database.*` being accessed, the `record.*` being written. The feature pages document their specific variables. A rule at a site with a declared metadata manifest also gains `md.self.*` (and, where declared, `md.<path>.*` / `md.caller.*`) — see [Resource Metadata](./resource-metadata.md).
 
 ### A Rule Sees Identity, Not Stored Data
 
@@ -56,6 +56,7 @@ Maintain that membership from your billing source — add a member when a subscr
 | Server-stamped fields (trigger `when` conditions) | Whether a computed field applies to this write | [Server-Stamped Fields](./working-with-databases.md#server-stamped-fields) |
 | Blob buckets (`ruleSetId`) | Member-level access to a bucket's blobs, per operation | [Blobs and Files](./blobs-and-files.md#access-presets) |
 | Rule sets | Who can perform **management operations** on groups and collections | below |
+| Metadata categories (`readRule` + `writeRule`) | Who can read or write one category of a resource's metadata | [Resource Metadata](./resource-metadata.md) |
 
 ## Rule Sets: Governing Management Operations
 

--- a/docs/getting-started/configuring-primitive-services.md
+++ b/docs/getting-started/configuring-primitive-services.md
@@ -57,9 +57,10 @@ config/
   rule-sets/*.toml                # Access rule sets
   group-type-configs/*.toml       # Group type configuration
   collection-type-configs/*.toml  # Collection type configuration
+  metadata-category-configs/*.toml # Resource metadata category configs
 ```
 
-Every feature page in these docs that shows a TOML block — [Workflows](./workflows.md), [Prompts](./prompts.md), [API Integrations](./api-integrations.md), [Working with Databases](./working-with-databases.md), [Blobs and Files](./blobs-and-files.md) — is describing one of these files. Define the entity in TOML, `primitive sync push`, and it's live.
+Every feature page in these docs that shows a TOML block — [Workflows](./workflows.md), [Prompts](./prompts.md), [API Integrations](./api-integrations.md), [Working with Databases](./working-with-databases.md), [Blobs and Files](./blobs-and-files.md), [Resource Metadata](./resource-metadata.md) — is describing one of these files. Define the entity in TOML, `primitive sync push`, and it's live.
 
 `app.toml` holds the app-level settings, and pushing it is the preferred way to change them — the imperative `primitive apps update --flag` calls mutate the server directly and drift from the checked-in TOML, so a later `sync push` reverts them. The TOML-syncable settings are:
 

--- a/docs/getting-started/primitive-cli.md
+++ b/docs/getting-started/primitive-cli.md
@@ -328,6 +328,16 @@ primitive secrets list
 primitive secrets delete OPENAI_API_KEY
 ```
 
+### Resource Metadata
+
+Read and write [resource metadata](./resource-metadata.md) category values — category definitions (schema, `readRule`, `writeRule`) are managed through `primitive sync`, not this command:
+
+```bash
+primitive metadata set user 01HXY... profile --data '{"tier":"pro"}'
+primitive metadata get user 01HXY... profile --json
+primitive metadata get-batch --resource user:01HXY...:profile,billing
+```
+
 ### Integrations
 
 Configure external API connections:

--- a/docs/getting-started/resource-metadata.md
+++ b/docs/getting-started/resource-metadata.md
@@ -1,0 +1,195 @@
+# Resource Metadata
+
+Resource metadata is typed, server-stored key/value data you attach to any resource — a user, a group, a collection, a database, or a workflow's subject. Metadata is grouped into named **categories**, and each category carries its own schema and its own CEL read/write rules, so different pieces of data about the same resource can have completely different access rules: a user's `profile` category might be self-editable, while a `billing` category is written only by a server-side workflow.
+
+## Categories and Schemas
+
+A category is defined once per resource type — `(resourceType, category)` — with a schema of typed fields, plus an optional `readRule` and `writeRule`:
+
+```toml
+# config/metadata-category-configs/user.profile.toml
+[metadataCategoryConfig]
+resourceType = "user"
+category = "profile"
+readRule = "user.userId == resource.resourceId"
+writeRule = "user.userId == resource.resourceId"
+description = "Per-user profile metadata"
+
+[metadataCategoryConfig.schema.fields.tier]
+type = "string"
+required = true
+enum = ["free", "pro", "enterprise"]
+
+[metadataCategoryConfig.schema.fields.displayName]
+type = "string"
+maxLength = 120
+```
+
+Push it like any other synced config:
+
+```bash
+primitive sync push
+```
+
+Field types are `string`, `number`, `boolean`, `date`, `id`, and `stringset`; `enum` is valid only on a `string` field. A category holds up to 100 keys and 16 KB of data, and writes are validated against the schema before they're stored.
+
+`readRule` and `writeRule` are CEL expressions evaluated against `user.*` (the caller) and `resource.*` (`resourceType`, `resourceId`, `category`) — app owners and admins bypass both. `writeRule` gates the write API; `readRule` gates the read API. Omit either and it defaults to deny.
+
+## Reading and Writing Metadata
+
+Read and write a category's data with the client or the CLI. `get`/`set` take the resource type, resource id, and category as arguments, and `set` fully replaces the category's data:
+
+```typescript
+await client.resourceMetadata.set("user", userId, "profile", {
+  tier: "pro",
+  displayName: "Ada",
+});
+
+const profile = await client.resourceMetadata.get("user", userId, "profile");
+// { resourceType, resourceId, category, data: { tier: "pro", displayName: "Ada" }, schemaVersion, exists }
+```
+
+```bash
+primitive metadata set user 01HXY... profile --data '{"tier":"pro","displayName":"Ada"}'
+primitive metadata get user 01HXY... profile --json
+```
+
+### Batch Reads
+
+Read several resources' categories in one call — useful for a listing view that would otherwise issue one request per row. The call always succeeds; per-resource and per-category problems (a missing category, a denied `readRule`) show up inside the results instead of failing the whole batch:
+
+```typescript
+const { results } = await client.resourceMetadata.getBatch({
+  requests: [
+    { resourceType: "user", resourceId: userA, categories: ["profile", "billing"] },
+    { resourceType: "user", resourceId: userB, categories: ["profile"] },
+  ],
+});
+// results[i] = { resourceType, resourceId, ok: true,
+//   categories: { profile: { ok: true, exists, data, schemaVersion }, billing: { ok: false, status: 403, code: "FORBIDDEN", message } } }
+```
+
+```bash
+primitive metadata get-batch --resource user:01HXY...:profile,billing --resource user:01HZQ...:profile
+```
+
+A batch call covers up to 50 resources and 200 resource/category pairs total.
+
+## Using Metadata in Access Rules
+
+A rule can read the metadata of the resource it's evaluating as `md.self.<category>.<key>` — but every category it reads must be declared ahead of time on the config that owns the rule (a group type, collection type, database type, or workflow definition). Declaring a category is what authorizes a rule to use it; the metadata read API's `readRule` plays no part here — a rule author is trusted to declare only what they intend the rule to use:
+
+```toml
+# config/group-type-configs/team.toml
+[groupTypeConfig]
+groupType = "team"
+ruleSetName = "team-rules"
+
+[metadata.self]
+categories = ["config"]
+```
+
+```toml novalidate
+# in the attached rule set
+member.create = "md.self.config.tier == \"pro\""
+```
+
+Groups and collections also expose a reserved, read-only `attrs` category projected from the resource's own fields — no schema, nothing to write, just declare it like any other category:
+
+| Resource type | `md.self.attrs.*` |
+|---|---|
+| `group` | `groupType`, `groupId`, `name`, `createdBy` |
+| `collection` | `collectionId`, `collectionType`, `contextId`, `name`, `createdBy` |
+
+```toml novalidate
+group.get = "md.self.attrs.createdBy == user.userId"
+```
+
+Database operations can also substitute a declared category's value directly into an operation's `filter` or `data` — see [Working with Databases](./working-with-databases.md#access-control-with-cel).
+
+### Reading a Related Resource's Metadata
+
+Beyond the subject's own metadata, a manifest can declare a **path** to another resource reached through a metadata key that holds its id, chaining up to 3 hops:
+
+```toml
+[metadata.self]
+categories = ["system"]
+
+[metadata.paths.school]
+from = "self"
+via = "system.schoolId"
+type = "school"
+categories = ["system"]
+```
+
+```toml novalidate
+# now usable in the rule:
+md.school.system.tier == "pro"
+```
+
+## The Caller's Own Metadata
+
+A rule can also read the **calling user's** own metadata, independent of whose resource is being evaluated, by declaring a path rooted at `user.userId` — the one server-authenticated root (every other path root — `input.*`, `record.*`, `params.*` — is a caller-supplied, static context value, not an authenticated identity):
+
+```toml
+[metadata.paths.caller]
+rootFrom = "user.userId"
+type = "user"
+categories = ["billing"]
+```
+
+```toml novalidate
+access = "md.caller.billing.status in ['trialing', 'active', 'past_due']"
+```
+
+This is available to database operation access rules and workflow `accessRule`s. When there's no authenticated caller — an anonymous request, or a system-run workflow — `md.caller` binds `null`, and a rule that dereferences it denies rather than erroring.
+
+## Writing Metadata from Workflows
+
+A workflow can write or read a category directly with the `metadata.write` / `metadata.read` steps, which go through the same read/write path — and the same `readRule`/`writeRule` gate — as the client and CLI:
+
+```toml
+[[steps]]
+id = "record-billing"
+kind = "metadata.write"
+resourceType = "user"
+resourceId = "{{ input.userId }}"
+category = "billing"
+[steps.data]
+stripeCustomerId = "{{ input.customerId }}"
+status = "active"
+```
+
+Gate a category so only that workflow can write it with `fromWorkflow('key')` in the category's `writeRule` — a call from anywhere else, including the REST API or a different workflow, is denied:
+
+```toml
+# config/metadata-category-configs/user.billing.toml
+[metadataCategoryConfig]
+resourceType = "user"
+category = "billing"
+writeRule = "fromWorkflow('process-stripe')"
+readRule = "true"
+
+[metadataCategoryConfig.schema.fields.stripeCustomerId]
+type = "string"
+required = true
+
+[metadataCategoryConfig.schema.fields.status]
+type = "string"
+```
+
+## Metadata Lifecycle
+
+Writing metadata doesn't check that the target resource exists — a write for a not-yet-created or already-deleted resource succeeds, and deleting a resource doesn't delete its metadata. This keeps writes cheap (no extra lookup) and lets a provisioning workflow write metadata immediately after — or interleaved with — creating the resource it belongs to.
+
+Two patterns keep metadata consistent with the resources it describes:
+
+- **Gate writes with `writeRule`.** Restricting who (or which workflow) can write a category limits who can create metadata for a resource that doesn't exist.
+- **Clean up metadata wherever you delete the resource.** Whatever flow deletes a resource should also delete its metadata categories.
+
+## Next Steps
+
+- **[Access Control](./access-control.md)** — The CEL identity context every rule shares
+- **[Users and Groups](./users-and-groups.md)** — Group and collection categories, and the projected `attrs` category
+- **[Working with Databases](./working-with-databases.md)** — Substituting metadata into operation filters and writes
+- **[Workflows](./workflows.md)** — The `metadata.write` / `metadata.read` steps in full

--- a/docs/getting-started/users-and-groups.md
+++ b/docs/getting-started/users-and-groups.md
@@ -48,9 +48,11 @@ Groups let you organize users into teams, roles, departments, or any relationshi
 # Create a group type config (defines a category of groups)
 primitive group-type-configs create --group-type team
 
-# Create a group
+# Create a group — omit --id and the server assigns one
 primitive groups create --type team --id engineering --name "Engineering Team"
 ```
+
+`--id` (`groupId` on the client) is optional — omit it and the server assigns a ULID, returned in the response, the same way documents and databases get their ids.
 
 ### Managing Members
 
@@ -120,6 +122,8 @@ access = "isMemberOf('org', params.orgId) || isMemberOf('team', params.teamId)"
 
 Who can *manage* groups themselves — create groups of a type, add or remove members — is governed by **rule sets** bound to the group type. See [Access Control](./access-control.md#rule-sets-governing-management-operations).
 
+A group type (or collection type) can also declare [resource metadata](./resource-metadata.md) categories, making `md.self.<category>.<key>` available in that type's rule set — along with a reserved `attrs` category projecting the group's own `groupType`, `groupId`, `name`, and `createdBy` (a collection's `attrs` also includes `contextId`).
+
 ## Best Practices
 
 1. **Use groups for access control.** Groups integrate natively with documents (group permissions) and databases (CEL membership checks). They're the primary mechanism for authorization in Primitive.
@@ -131,6 +135,7 @@ Who can *manage* groups themselves — create groups of a type, add or remove me
 ## Next Steps
 
 - **[Access Control](./access-control.md)** — The CEL rules your groups plug into
+- **[Resource Metadata](./resource-metadata.md)** — Attach schema'd, access-controlled data to a group or collection
 - **[Invitations](./invitations.md)** — App membership and deferred grants for not-yet-users
 - **[Working with Documents](./working-with-documents.md)** — Share documents with groups
 - **[Authentication](./authentication.md)** — How users get authenticated

--- a/docs/getting-started/workflows.md
+++ b/docs/getting-started/workflows.md
@@ -456,6 +456,7 @@ Every step has an `id` (unique within the workflow) and a `kind` (the step type)
 | `document.query` / `queryOne` / `count` / `save` / `patch` / `delete` | Read and write records in a document's models |
 | `document.resolveAlias` | Resolve a document alias to its id (or null) for conditional branching |
 | `group.addMember` / `removeMember` / `removeAll` / `checkMembership` / `listMembers` / `listUserMemberships` | Group membership operations |
+| `metadata.write` / `metadata.read` | Write or read a [resource metadata](./resource-metadata.md) category |
 | `collect` | Auto-paginate any step that returns `{ items, cursor }` |
 | `workflow.call` | Run a child workflow synchronously, inline (use `forEach` to fan out) |
 | `block.call` | Invoke a prompt, integration, script, or workflow block selected by `blockType` — a unified wrapper over the four steps above |
@@ -826,6 +827,25 @@ It takes a `groupType` and a `userId` (no `groupId` — it removes the user from
 
 Group steps evaluate the group type's rule sets like any other caller; rules can match workflow-issued operations with `fromWorkflow("workflowKey")` — see [Access Control](./access-control.md). In a [system run](#system-workflows), `addMember` and `removeMember` record the app's system principal as the member's `addedBy` — not the admin or trigger that started the run.
 
+### Metadata Steps
+
+`metadata.write` and `metadata.read` read and write a [resource metadata](./resource-metadata.md) category, going through the same category `writeRule` / `readRule` gate as the client and CLI:
+
+```toml
+[[steps]]
+id = "record-billing"
+kind = "metadata.write"
+resourceType = "user"
+resourceId = "{{ input.userId }}"
+category = "billing"
+saveAs = "output"
+[steps.data]
+stripeCustomerId = "{{ input.customerId }}"
+status = "active"
+```
+
+`metadata.write` fully replaces the category and returns `{ data, schemaVersion, size }`; `metadata.read` returns `{ data, schemaVersion, exists }` (`saveAs` puts either under `outputs.<name>`). A category's `writeRule`/`readRule` can name `fromWorkflow('workflowKey')` to authorize only that workflow's step — a REST call or a different workflow to the same category is denied.
+
 ### `collect`
 
 Auto-paginates any step that returns `{ items, cursor }` (or `{ data, nextCursor }`), merging all pages into one result:
@@ -1037,6 +1057,7 @@ In interpolation mode an unresolved path renders as `<missing: steps.x.y>`, so t
 ## Next Steps
 
 - **[Prompts](./prompts.md)** — Versioned, testable LLM prompt templates
+- **[Resource Metadata](./resource-metadata.md)** — Write metadata a workflow alone is authorized to change
 - **[Working with Databases](./working-with-databases.md)** — Server-side structured storage
 - **[Blobs and Files](./blobs-and-files.md)** — General-purpose file storage
 - **[Primitive CLI](./primitive-cli.md)** — Full CLI command reference

--- a/docs/getting-started/working-with-databases.md
+++ b/docs/getting-started/working-with-databases.md
@@ -220,6 +220,14 @@ access = "params.createdBy == user.userId"
 
 Use `fromWorkflow(...)` to gate an operation so only a specific workflow can invoke it — useful for cron-fired refreshes that no user, including admins, should call directly. An operation's `access` rule is evaluated on every call, including from [system workflow](./workflows.md#system-workflows) runs — `runAs = "system"` doesn't bypass it. So reserve a workflow-only operation with `fromWorkflow('key')` rather than setting `access = "false"` and expecting a system run to reach it.
 
+An operation's `definition` can also substitute a declared [resource metadata](./resource-metadata.md#using-metadata-in-access-rules) value alongside `$params.*` and `$user.userId`:
+
+```toml novalidate
+definition = '{"filter":{"tier":"$md.self.profile.tier"}}'
+```
+
+`$md.self.<category>.<key>` resolves to `null` (not the literal string) when the category isn't declared on the database type's manifest or the key is missing.
+
 ### Per-Parameter Access
 
 Restrict who can set specific parameters by adding an `access` rule to the parameter itself:
@@ -541,5 +549,6 @@ Pass `timing: true` to `executeOperation` and the response includes a `_timing` 
 
 - **[Choosing Your Data Model](./choosing-your-data-model.md)** — When to use databases vs. documents
 - **[Users and Groups](./users-and-groups.md)** — Set up groups for database access control
+- **[Resource Metadata](./resource-metadata.md)** — Declare a category to read it from `access` and `definition`
 - **[Workflows](./workflows.md)** — Multi-step server-side automation
 - **[Primitive CLI](./primitive-cli.md)** — Full CLI reference for database management

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_ACCESS_CONTROL.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_ACCESS_CONTROL.md
@@ -26,6 +26,9 @@ A rule reads caller identity and operation params only — it cannot read a data
 | Workflow | `accessRule` on `[workflow]` | identity context only | Evaluated on `workflows.start()` and `workflow.call`; NOT on webhook triggers. admin/owner bypass. No rule → any authenticated member can start. |
 | Server-stamped fields / triggers | trigger `when` conditions; `autoPopulatedFields` values | `record.*`, `database.*`, `now()` | CEL produces values (`user.userId`, `now()`) as well as conditions. |
 | Rule sets | per-op rules on a named rule set | resource objects (e.g. `group.groupType`, `group.groupId`, `group.createdBy`) | Governs **management operations** (create/edit/delete groups & collections, member management) — see below. |
+| Metadata category | `readRule` (read API) / `writeRule` (write API) on the category config | `user.userId`, `user.role`, `resource.resourceType`/`resourceId`/`category`; `workflow.workflowKey` when called from a `metadata.write`/`read` step | Gates the metadata read/write API only — a *different* rule's `md.self`/`md.caller` use is authorized by declaration, not this rule. See the Resource Metadata guide. |
+
+Any eval site with a declared metadata manifest also gains `md.self.*` (and, where declared, `md.<path>.*` / `md.caller.*`) in its CEL context — see the [Resource Metadata guide](AGENT_GUIDE_TO_PRIMITIVE_RESOURCE_METADATA.md).
 
 ## Rule sets (management operations)
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_ACCESS_CONTROL.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_ACCESS_CONTROL.template.md
@@ -26,6 +26,9 @@ A rule reads caller identity and operation params only — it cannot read a data
 | Workflow | `accessRule` on `[workflow]` | identity context only | Evaluated on `workflows.start()` and `workflow.call`; NOT on webhook triggers. admin/owner bypass. No rule → any authenticated member can start. |
 | Server-stamped fields / triggers | trigger `when` conditions; `autoPopulatedFields` values | `record.*`, `database.*`, `now()` | CEL produces values (`user.userId`, `now()`) as well as conditions. |
 | Rule sets | per-op rules on a named rule set | resource objects (e.g. `group.groupType`, `group.groupId`, `group.createdBy`) | Governs **management operations** (create/edit/delete groups & collections, member management) — see below. |
+| Metadata category | `readRule` (read API) / `writeRule` (write API) on the category config | `user.userId`, `user.role`, `resource.resourceType`/`resourceId`/`category`; `workflow.workflowKey` when called from a `metadata.write`/`read` step | Gates the metadata read/write API only — a *different* rule's `md.self`/`md.caller` use is authorized by declaration, not this rule. See the Resource Metadata guide. |
+
+Any eval site with a declared metadata manifest also gains `md.self.*` (and, where declared, `md.<path>.*` / `md.caller.*`) in its CEL context — see the [Resource Metadata guide](AGENT_GUIDE_TO_PRIMITIVE_RESOURCE_METADATA.md).
 
 ## Rule sets (management operations)
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_CONFIGURATION.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_CONFIGURATION.md
@@ -46,6 +46,7 @@ config/
   rule-sets/*.toml                # Access rule sets
   group-type-configs/*.toml       # Group type configs
   collection-type-configs/*.toml  # Collection type configs
+  metadata-category-configs/*.toml # Resource metadata category configs (schema + readRule/writeRule)
 ```
 
 ## App settings (`app.toml`)

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_CONFIGURATION.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_CONFIGURATION.template.md
@@ -46,6 +46,7 @@ config/
   rule-sets/*.toml                # Access rule sets
   group-type-configs/*.toml       # Group type configs
   collection-type-configs/*.toml  # Collection type configs
+  metadata-category-configs/*.toml # Resource metadata category configs (schema + readRule/writeRule)
 ```
 
 ## App settings (`app.toml`)

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.swift.md
@@ -342,6 +342,8 @@ Triggers are computed fields that run server-side before a record is saved. Conf
 
 **Don't confuse trigger CEL with operation substitutions.** Triggers use bare CEL — `user.userId`, `now()`. Operation `definition` and `params` use `$user.userId`, `$now`, `$params.x`, `$database.celContext.x` substitutions, which are deep string-replacement on the JSON template, NOT CEL. (`$database.metadata.x` is accepted as an alternate alias for the same value.)
 
+A declared [resource metadata](AGENT_GUIDE_TO_PRIMITIVE_RESOURCE_METADATA.md) category value is also substitutable this way: `$md.self.<category>.<key>` in `filter`/`data`, resolving to `null` (not the literal string) when the category isn't declared on the database type's manifest or the key is missing. Access rules (`access`, `defaultAccess`) can likewise reference `md.self.<category>.<key>` and, where declared, `md.caller.<category>.<key>` (the caller's own metadata, rooted at `user.userId`) — see the Resource Metadata guide for declaring the manifest.
+
 ### Timestamps
 
 The `timestamps` knob on the `[type]` config stamps `createdAt` and/or `modifiedAt` fields automatically on every write, removing the need for per-model trigger boilerplate. Field names are caller-configurable.

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.template.md
@@ -322,6 +322,8 @@ Triggers are computed fields that run server-side before a record is saved. Conf
 
 **Don't confuse trigger CEL with operation substitutions.** Triggers use bare CEL — `user.userId`, `now()`. Operation `definition` and `params` use `$user.userId`, `$now`, `$params.x`, `$database.celContext.x` substitutions, which are deep string-replacement on the JSON template, NOT CEL. (`$database.metadata.x` is accepted as an alternate alias for the same value.)
 
+A declared [resource metadata](AGENT_GUIDE_TO_PRIMITIVE_RESOURCE_METADATA.md) category value is also substitutable this way: `$md.self.<category>.<key>` in `filter`/`data`, resolving to `null` (not the literal string) when the category isn't declared on the database type's manifest or the key is missing. Access rules (`access`, `defaultAccess`) can likewise reference `md.self.<category>.<key>` and, where declared, `md.caller.<category>.<key>` (the caller's own metadata, rooted at `user.userId`) — see the Resource Metadata guide for declaring the manifest.
+
 ### Timestamps
 
 The `timestamps` knob on the `[type]` config stamps `createdAt` and/or `modifiedAt` fields automatically on every write, removing the need for per-model trigger boilerplate. Field names are caller-configurable.

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.ts.md
@@ -346,6 +346,8 @@ Triggers are computed fields that run server-side before a record is saved. Conf
 
 **Don't confuse trigger CEL with operation substitutions.** Triggers use bare CEL — `user.userId`, `now()`. Operation `definition` and `params` use `$user.userId`, `$now`, `$params.x`, `$database.celContext.x` substitutions, which are deep string-replacement on the JSON template, NOT CEL. (`$database.metadata.x` is accepted as an alternate alias for the same value.)
 
+A declared [resource metadata](AGENT_GUIDE_TO_PRIMITIVE_RESOURCE_METADATA.md) category value is also substitutable this way: `$md.self.<category>.<key>` in `filter`/`data`, resolving to `null` (not the literal string) when the category isn't declared on the database type's manifest or the key is missing. Access rules (`access`, `defaultAccess`) can likewise reference `md.self.<category>.<key>` and, where declared, `md.caller.<category>.<key>` (the caller's own metadata, rooted at `user.userId`) — see the Resource Metadata guide for declaring the manifest.
+
 ### Timestamps
 
 The `timestamps` knob on the `[type]` config stamps `createdAt` and/or `modifiedAt` fields automatically on every write, removing the need for per-model trigger boilerplate. Field names are caller-configurable.

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_RESOURCE_METADATA.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_RESOURCE_METADATA.swift.md
@@ -1,0 +1,184 @@
+# Agent Guide to Primitive Resource Metadata
+
+Guidelines for AI agents attaching typed, access-controlled metadata to a resource — a user, a group, a collection, a database, or a workflow's subject. Metadata is grouped into named **categories**; each category has its own schema and its own CEL `readRule`/`writeRule`, so different data about the same resource can carry different rules (a self-editable `profile` category vs. a workflow-only `billing` category).
+
+## Category configs
+
+A category is defined once per `(resourceType, category)` — schema plus optional `readRule`/`writeRule` — and synced like any other config, one file per category:
+
+```toml
+# config/metadata-category-configs/user.profile.toml
+[metadataCategoryConfig]
+resourceType = "user"
+category = "profile"
+readRule = "user.userId == resource.resourceId"
+writeRule = "user.userId == resource.resourceId"
+description = "Per-user profile metadata"
+
+[metadataCategoryConfig.schema.fields.tier]
+type = "string"
+required = true
+enum = ["free", "pro", "enterprise"]
+
+[metadataCategoryConfig.schema.fields.displayName]
+type = "string"
+maxLength = 120
+```
+
+```bash
+primitive sync push
+```
+
+- **Field types:** `string`, `number`, `boolean`, `date`, `id`, `stringset`. `enum` (string array) is valid only on a `string` field; other supported constraints are `required`, `maxLength`, `maxCount`.
+- **Category name `attrs` is reserved** — it's the read-only projected category (see **`md.self.attrs`** below), not a category you define.
+- **Limits:** up to 100 keys per category, 16 KB per category item.
+- **`readRule`/`writeRule` context:** `user.userId`, `user.role` (the caller), `resource.resourceType`, `resource.resourceId`, `resource.category` — plus `workflow.workflowKey` when the call originates from a `metadata.write`/`metadata.read` step (so `fromWorkflow('key')` works). Owner/admin always bypass both rules. Omitting either rule defaults to deny.
+- **Category authoring is admin-scoped** — define and update categories via TOML sync, or directly through the admin-gated `metadata-categories` REST route. `client.resourceMetadata` covers values only (`get`/`set`/`getBatch`).
+
+## Values: read, write, batch read
+
+`get`/`set` take `(resourceType, resourceId, category)` positionally; `set` is a **full replace**, not a merge.
+
+
+```bash
+primitive metadata set user 01HXY... profile --data '{"tier":"pro","displayName":"Ada"}'
+primitive metadata set user 01HXY... profile --data-file ./profile.json
+primitive metadata get user 01HXY... profile --json
+primitive metadata get-batch --resource user:01HXY...:profile,billing --resource user:01HZQ...:profile
+primitive metadata get-batch --requests '[{"resourceType":"user","resourceId":"01HXY...","categories":["profile"]}]'
+```
+
+- Batch: up to 50 resources, 200 expanded resource/category pairs per call — over either limit fails the **whole** call with `400 BATCH_TOO_LARGE` (checked before any read). Within limits the call is always `200`; per-item problems (missing category → `404 NOT_FOUND`, denied `readRule` → `403 FORBIDDEN`) surface inside `results[].categories[cat]`, never as a call-level failure.
+- Errors on single read/write: `404 NOT_FOUND` (no such category on that resource type), `403 FORBIDDEN` (`readRule`/`writeRule` denied), `400` (schema validation failure, or writing the reserved `attrs` category → `RESERVED_CATEGORY`).
+- All CLI text output (`keyValue`/`success`/`info`) goes to **stderr** — only `--json` output goes to stdout. A `primitive metadata get ... > out.txt` without `--json` produces an empty file.
+- `set --data` and `--data-file` are mutually available; `--data-file` wins if both are passed. The payload must be a JSON object.
+
+## Declaring metadata for CEL rules
+
+A rule reads a resource's own metadata as `md.self.<category>.<key>` — but every category it reads must be **declared** on the owning config (a group type, collection type, database type, or workflow definition). Declaring is the authorization: a category's own `readRule` gates the read API only, not a rule author's use of it (trusted-author model).
+
+```toml
+# on the owning config (group-type-config shown; same shape for collection/database type configs and workflow definitions)
+[metadata.self]
+categories = ["config", "attrs"]
+```
+
+```toml novalidate
+member.create = "md.self.config.tier == \"pro\""
+```
+
+### `md.self.attrs` — the projected category
+
+Groups and collections expose a reserved, read-only `attrs` category with no schema — declare it like any other category and it's populated from the resource's own fields, no write path:
+
+| Resource type | `md.self.attrs.*` |
+|---|---|
+| `group` | `groupType`, `groupId`, `name`, `createdBy` |
+| `collection` | `collectionId`, `collectionType`, `contextId`, `name`, `createdBy` |
+
+```toml novalidate
+group.get = "md.self.attrs.createdBy == user.userId"
+```
+
+### Declared paths — a related resource's metadata
+
+A manifest can chain to another resource (up to 3 hops) via a metadata key holding its id:
+
+```toml
+[metadata.self]
+categories = ["system"]
+
+[metadata.paths.school]
+from = "self"          # "self" or another already-declared path name
+via = "system.schoolId" # "<category>.<key>" on the source; that category must be declared there
+type = "school"         # the target's resourceType
+categories = ["system"]
+```
+
+```toml novalidate
+md.school.system.tier == "pro"
+```
+
+### `md.caller` — the calling user's own metadata
+
+One path root is server-authenticated rather than caller-supplied: `rootFrom = "user.userId"` (requires `type = "user"`; any other `user.*` root is rejected at save time). Every other root (`input.*`, `record.*`, `params.*`) is a static, caller-declared context path, not an identity binding.
+
+```toml
+[metadata.paths.caller]
+rootFrom = "user.userId"
+type = "user"
+categories = ["billing"]
+```
+
+```toml novalidate
+access = "md.caller.billing.status in ['trialing', 'active', 'past_due']"
+```
+
+`md.caller` is bindable in **database operation `access`** (including per-param access and batch), the database's own `metadataAccess` rule, DO-trigger `when`/`set`, and **workflow `accessRule`** (`start` and `workflow.call`). With no authenticated caller (anonymous request, or a `runAs:"system"` workflow), `md.caller` binds `null` — a rule that dereferences it denies rather than erroring; guard explicitly (`md.caller != null && ...`) on a strict evaluation path where errors surface instead of denying.
+
+### Database operation substitution
+
+Beyond CEL `access` rules, an operation's `definition` (`filter`/`data`) can substitute a declared category value directly, alongside `$params.*` / `$user.userId` / `$now` / `$steps.*`:
+
+```toml novalidate
+definition = '{"filter":{"tier":"$md.self.profile.tier"}}'
+```
+
+`$md.self.<category>.<key>` resolves to `null` (not the literal string) when the category isn't declared on that database type's manifest, or the key is missing — same fail-closed convention as `$database.metadata.<key>`.
+
+## Workflow steps: `metadata.write` / `metadata.read`
+
+Both route through the exact same read/write path (and the same `readRule`/`writeRule` gate) as the client and CLI — no parallel authorization logic.
+
+```toml
+[[steps]]
+id = "record-billing"
+kind = "metadata.write"
+resourceType = "user"
+resourceId = "{{ input.userId }}"
+category = "billing"
+saveAs = "output"
+[steps.data]
+stripeCustomerId = "{{ input.customerId }}"
+status = "active"
+# Output: { ok, resourceType, resourceId, category, data, schemaVersion, size }
+
+[[steps]]
+id = "load-billing"
+kind = "metadata.read"
+resourceType = "user"
+resourceId = "{{ input.userId }}"
+category = "billing"
+saveAs = "output"
+# Output: { ok, resourceType, resourceId, category, data, schemaVersion, exists }
+```
+
+- `resourceType`/`resourceId`/`category`/`data` are all templated like any other step's params.
+- `metadata.write` is a **full replace** of the category, matching the REST `PUT` semantics.
+- Gate a category to exactly one workflow with `fromWorkflow('workflowKey')` in its `writeRule`/`readRule` — a REST call or a different workflow gets `403`. The workflow identity here is a privileged, call-local value the step runner passes in-process; it is never derived from a request header (an `X-Workflow-Context` header on a REST call has no effect).
+- Error behavior mirrors `database.*` steps: a 4xx (schema validation, rule denial, reserved category, bad segment) is **non-retryable**; a 429 or 5xx is retryable.
+- A `runAs:"system"` run's metadata calls carry no `user.*` context (empty `{}`) and get no owner/admin bypass — only `fromWorkflow('key')` can authorize a system-run write/read. A `runAs:"caller"` run's calls still get the owner/admin bypass.
+
+## Metadata lifecycle
+
+A write never checks that the target resource exists — a write for a not-yet-created or already-deleted resource succeeds silently, and deleting a resource does not delete its metadata (no cascade). This is deliberate: it keeps a write to a single cheap put, and doesn't race provisioning flows that write metadata immediately after — or interleaved with — creating the resource itself.
+
+**Consequences an implementation should account for:**
+- Gate writes with a category `writeRule` (owner-only, or `fromWorkflow('key')`) to limit who can create dangling metadata in the first place.
+- Whatever flow deletes a resource must also delete that resource's metadata categories — the platform doesn't do it for you.
+
+## Anti-patterns
+
+- Reading `md.self.<category>` in a rule without declaring `categories` for it in the config's `[metadata.self]` — the reference fails to save (400), not silently returns null.
+- Expecting a category's own `readRule` to restrict what a *different* rule can read via `md.self`/`md.caller` — it only gates the read API; declaration is the authorization for CEL use (trusted-author model).
+- Assuming `md.caller` works inside a group or collection rule set — it isn't bound there; it's for database operations and workflow `accessRule`.
+- Relying on resource deletion to clean up its metadata — there's no cascade; delete metadata explicitly in the same flow.
+- Trying to create or list category configs from the client SDK — that surface is TOML-sync/admin-REST only.
+- Treating `set()` as a merge — it's a full replace of the category's data.
+
+## Related guides
+
+- **access-control** — the shared CEL identity context every rule builds on
+- **users-and-groups** — group/collection `metadataManifest` and the projected `attrs` category
+- **databases** — `md.self`/`md.caller` in operation `access` and `$md.self.*` substitution
+- **workflows** — the `metadata.write`/`metadata.read` step shapes and `fromWorkflow()`

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_RESOURCE_METADATA.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_RESOURCE_METADATA.template.md
@@ -1,0 +1,205 @@
+# Agent Guide to Primitive Resource Metadata
+
+Guidelines for AI agents attaching typed, access-controlled metadata to a resource — a user, a group, a collection, a database, or a workflow's subject. Metadata is grouped into named **categories**; each category has its own schema and its own CEL `readRule`/`writeRule`, so different data about the same resource can carry different rules (a self-editable `profile` category vs. a workflow-only `billing` category).
+
+## Category configs
+
+A category is defined once per `(resourceType, category)` — schema plus optional `readRule`/`writeRule` — and synced like any other config, one file per category:
+
+```toml
+# config/metadata-category-configs/user.profile.toml
+[metadataCategoryConfig]
+resourceType = "user"
+category = "profile"
+readRule = "user.userId == resource.resourceId"
+writeRule = "user.userId == resource.resourceId"
+description = "Per-user profile metadata"
+
+[metadataCategoryConfig.schema.fields.tier]
+type = "string"
+required = true
+enum = ["free", "pro", "enterprise"]
+
+[metadataCategoryConfig.schema.fields.displayName]
+type = "string"
+maxLength = 120
+```
+
+```bash
+primitive sync push
+```
+
+- **Field types:** `string`, `number`, `boolean`, `date`, `id`, `stringset`. `enum` (string array) is valid only on a `string` field; other supported constraints are `required`, `maxLength`, `maxCount`.
+- **Category name `attrs` is reserved** — it's the read-only projected category (see **`md.self.attrs`** below), not a category you define.
+- **Limits:** up to 100 keys per category, 16 KB per category item.
+- **`readRule`/`writeRule` context:** `user.userId`, `user.role` (the caller), `resource.resourceType`, `resource.resourceId`, `resource.category` — plus `workflow.workflowKey` when the call originates from a `metadata.write`/`metadata.read` step (so `fromWorkflow('key')` works). Owner/admin always bypass both rules. Omitting either rule defaults to deny.
+- **Category authoring is admin-scoped** — define and update categories via TOML sync, or directly through the admin-gated `metadata-categories` REST route. `client.resourceMetadata` covers values only (`get`/`set`/`getBatch`).
+
+## Values: read, write, batch read
+
+`get`/`set` take `(resourceType, resourceId, category)` positionally; `set` is a **full replace**, not a merge.
+
+{{#lang ts}}
+```typescript
+await client.resourceMetadata.set("user", userId, "profile", { tier: "pro", displayName: "Ada" });
+// -> { resourceType, resourceId, category, data, schemaVersion, size }
+
+const profile = await client.resourceMetadata.get("user", userId, "profile");
+// -> { resourceType, resourceId, category, data, schemaVersion, exists }
+
+const { results } = await client.resourceMetadata.getBatch({
+  requests: [
+    { resourceType: "user", resourceId: userA, categories: ["profile", "billing"] },
+    { resourceType: "user", resourceId: userB, categories: ["profile"] },
+  ],
+});
+// results[i] = { resourceType, resourceId, ok: true,
+//   categories: { <category>: { ok: true, exists, data, schemaVersion }
+//               | { ok: false, status, code, message } } }
+// A whole-resource failure (e.g. a malformed id) instead returns
+// { resourceType, resourceId, ok: false, status, code, message } with no `categories`.
+```
+{{/lang}}
+
+```bash
+primitive metadata set user 01HXY... profile --data '{"tier":"pro","displayName":"Ada"}'
+primitive metadata set user 01HXY... profile --data-file ./profile.json
+primitive metadata get user 01HXY... profile --json
+primitive metadata get-batch --resource user:01HXY...:profile,billing --resource user:01HZQ...:profile
+primitive metadata get-batch --requests '[{"resourceType":"user","resourceId":"01HXY...","categories":["profile"]}]'
+```
+
+- Batch: up to 50 resources, 200 expanded resource/category pairs per call — over either limit fails the **whole** call with `400 BATCH_TOO_LARGE` (checked before any read). Within limits the call is always `200`; per-item problems (missing category → `404 NOT_FOUND`, denied `readRule` → `403 FORBIDDEN`) surface inside `results[].categories[cat]`, never as a call-level failure.
+- Errors on single read/write: `404 NOT_FOUND` (no such category on that resource type), `403 FORBIDDEN` (`readRule`/`writeRule` denied), `400` (schema validation failure, or writing the reserved `attrs` category → `RESERVED_CATEGORY`).
+- All CLI text output (`keyValue`/`success`/`info`) goes to **stderr** — only `--json` output goes to stdout. A `primitive metadata get ... > out.txt` without `--json` produces an empty file.
+- `set --data` and `--data-file` are mutually available; `--data-file` wins if both are passed. The payload must be a JSON object.
+
+## Declaring metadata for CEL rules
+
+A rule reads a resource's own metadata as `md.self.<category>.<key>` — but every category it reads must be **declared** on the owning config (a group type, collection type, database type, or workflow definition). Declaring is the authorization: a category's own `readRule` gates the read API only, not a rule author's use of it (trusted-author model).
+
+```toml
+# on the owning config (group-type-config shown; same shape for collection/database type configs and workflow definitions)
+[metadata.self]
+categories = ["config", "attrs"]
+```
+
+```toml novalidate
+member.create = "md.self.config.tier == \"pro\""
+```
+
+### `md.self.attrs` — the projected category
+
+Groups and collections expose a reserved, read-only `attrs` category with no schema — declare it like any other category and it's populated from the resource's own fields, no write path:
+
+| Resource type | `md.self.attrs.*` |
+|---|---|
+| `group` | `groupType`, `groupId`, `name`, `createdBy` |
+| `collection` | `collectionId`, `collectionType`, `contextId`, `name`, `createdBy` |
+
+```toml novalidate
+group.get = "md.self.attrs.createdBy == user.userId"
+```
+
+### Declared paths — a related resource's metadata
+
+A manifest can chain to another resource (up to 3 hops) via a metadata key holding its id:
+
+```toml
+[metadata.self]
+categories = ["system"]
+
+[metadata.paths.school]
+from = "self"          # "self" or another already-declared path name
+via = "system.schoolId" # "<category>.<key>" on the source; that category must be declared there
+type = "school"         # the target's resourceType
+categories = ["system"]
+```
+
+```toml novalidate
+md.school.system.tier == "pro"
+```
+
+### `md.caller` — the calling user's own metadata
+
+One path root is server-authenticated rather than caller-supplied: `rootFrom = "user.userId"` (requires `type = "user"`; any other `user.*` root is rejected at save time). Every other root (`input.*`, `record.*`, `params.*`) is a static, caller-declared context path, not an identity binding.
+
+```toml
+[metadata.paths.caller]
+rootFrom = "user.userId"
+type = "user"
+categories = ["billing"]
+```
+
+```toml novalidate
+access = "md.caller.billing.status in ['trialing', 'active', 'past_due']"
+```
+
+`md.caller` is bindable in **database operation `access`** (including per-param access and batch), the database's own `metadataAccess` rule, DO-trigger `when`/`set`, and **workflow `accessRule`** (`start` and `workflow.call`). With no authenticated caller (anonymous request, or a `runAs:"system"` workflow), `md.caller` binds `null` — a rule that dereferences it denies rather than erroring; guard explicitly (`md.caller != null && ...`) on a strict evaluation path where errors surface instead of denying.
+
+### Database operation substitution
+
+Beyond CEL `access` rules, an operation's `definition` (`filter`/`data`) can substitute a declared category value directly, alongside `$params.*` / `$user.userId` / `$now` / `$steps.*`:
+
+```toml novalidate
+definition = '{"filter":{"tier":"$md.self.profile.tier"}}'
+```
+
+`$md.self.<category>.<key>` resolves to `null` (not the literal string) when the category isn't declared on that database type's manifest, or the key is missing — same fail-closed convention as `$database.metadata.<key>`.
+
+## Workflow steps: `metadata.write` / `metadata.read`
+
+Both route through the exact same read/write path (and the same `readRule`/`writeRule` gate) as the client and CLI — no parallel authorization logic.
+
+```toml
+[[steps]]
+id = "record-billing"
+kind = "metadata.write"
+resourceType = "user"
+resourceId = "{{ input.userId }}"
+category = "billing"
+saveAs = "output"
+[steps.data]
+stripeCustomerId = "{{ input.customerId }}"
+status = "active"
+# Output: { ok, resourceType, resourceId, category, data, schemaVersion, size }
+
+[[steps]]
+id = "load-billing"
+kind = "metadata.read"
+resourceType = "user"
+resourceId = "{{ input.userId }}"
+category = "billing"
+saveAs = "output"
+# Output: { ok, resourceType, resourceId, category, data, schemaVersion, exists }
+```
+
+- `resourceType`/`resourceId`/`category`/`data` are all templated like any other step's params.
+- `metadata.write` is a **full replace** of the category, matching the REST `PUT` semantics.
+- Gate a category to exactly one workflow with `fromWorkflow('workflowKey')` in its `writeRule`/`readRule` — a REST call or a different workflow gets `403`. The workflow identity here is a privileged, call-local value the step runner passes in-process; it is never derived from a request header (an `X-Workflow-Context` header on a REST call has no effect).
+- Error behavior mirrors `database.*` steps: a 4xx (schema validation, rule denial, reserved category, bad segment) is **non-retryable**; a 429 or 5xx is retryable.
+- A `runAs:"system"` run's metadata calls carry no `user.*` context (empty `{}`) and get no owner/admin bypass — only `fromWorkflow('key')` can authorize a system-run write/read. A `runAs:"caller"` run's calls still get the owner/admin bypass.
+
+## Metadata lifecycle
+
+A write never checks that the target resource exists — a write for a not-yet-created or already-deleted resource succeeds silently, and deleting a resource does not delete its metadata (no cascade). This is deliberate: it keeps a write to a single cheap put, and doesn't race provisioning flows that write metadata immediately after — or interleaved with — creating the resource itself.
+
+**Consequences an implementation should account for:**
+- Gate writes with a category `writeRule` (owner-only, or `fromWorkflow('key')`) to limit who can create dangling metadata in the first place.
+- Whatever flow deletes a resource must also delete that resource's metadata categories — the platform doesn't do it for you.
+
+## Anti-patterns
+
+- Reading `md.self.<category>` in a rule without declaring `categories` for it in the config's `[metadata.self]` — the reference fails to save (400), not silently returns null.
+- Expecting a category's own `readRule` to restrict what a *different* rule can read via `md.self`/`md.caller` — it only gates the read API; declaration is the authorization for CEL use (trusted-author model).
+- Assuming `md.caller` works inside a group or collection rule set — it isn't bound there; it's for database operations and workflow `accessRule`.
+- Relying on resource deletion to clean up its metadata — there's no cascade; delete metadata explicitly in the same flow.
+- Trying to create or list category configs from the client SDK — that surface is TOML-sync/admin-REST only.
+- Treating `set()` as a merge — it's a full replace of the category's data.
+
+## Related guides
+
+- **access-control** — the shared CEL identity context every rule builds on
+- **users-and-groups** — group/collection `metadataManifest` and the projected `attrs` category
+- **databases** — `md.self`/`md.caller` in operation `access` and `$md.self.*` substitution
+- **workflows** — the `metadata.write`/`metadata.read` step shapes and `fromWorkflow()`

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_RESOURCE_METADATA.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_RESOURCE_METADATA.ts.md
@@ -1,0 +1,203 @@
+# Agent Guide to Primitive Resource Metadata
+
+Guidelines for AI agents attaching typed, access-controlled metadata to a resource — a user, a group, a collection, a database, or a workflow's subject. Metadata is grouped into named **categories**; each category has its own schema and its own CEL `readRule`/`writeRule`, so different data about the same resource can carry different rules (a self-editable `profile` category vs. a workflow-only `billing` category).
+
+## Category configs
+
+A category is defined once per `(resourceType, category)` — schema plus optional `readRule`/`writeRule` — and synced like any other config, one file per category:
+
+```toml
+# config/metadata-category-configs/user.profile.toml
+[metadataCategoryConfig]
+resourceType = "user"
+category = "profile"
+readRule = "user.userId == resource.resourceId"
+writeRule = "user.userId == resource.resourceId"
+description = "Per-user profile metadata"
+
+[metadataCategoryConfig.schema.fields.tier]
+type = "string"
+required = true
+enum = ["free", "pro", "enterprise"]
+
+[metadataCategoryConfig.schema.fields.displayName]
+type = "string"
+maxLength = 120
+```
+
+```bash
+primitive sync push
+```
+
+- **Field types:** `string`, `number`, `boolean`, `date`, `id`, `stringset`. `enum` (string array) is valid only on a `string` field; other supported constraints are `required`, `maxLength`, `maxCount`.
+- **Category name `attrs` is reserved** — it's the read-only projected category (see **`md.self.attrs`** below), not a category you define.
+- **Limits:** up to 100 keys per category, 16 KB per category item.
+- **`readRule`/`writeRule` context:** `user.userId`, `user.role` (the caller), `resource.resourceType`, `resource.resourceId`, `resource.category` — plus `workflow.workflowKey` when the call originates from a `metadata.write`/`metadata.read` step (so `fromWorkflow('key')` works). Owner/admin always bypass both rules. Omitting either rule defaults to deny.
+- **Category authoring is admin-scoped** — define and update categories via TOML sync, or directly through the admin-gated `metadata-categories` REST route. `client.resourceMetadata` covers values only (`get`/`set`/`getBatch`).
+
+## Values: read, write, batch read
+
+`get`/`set` take `(resourceType, resourceId, category)` positionally; `set` is a **full replace**, not a merge.
+
+```typescript
+await client.resourceMetadata.set("user", userId, "profile", { tier: "pro", displayName: "Ada" });
+// -> { resourceType, resourceId, category, data, schemaVersion, size }
+
+const profile = await client.resourceMetadata.get("user", userId, "profile");
+// -> { resourceType, resourceId, category, data, schemaVersion, exists }
+
+const { results } = await client.resourceMetadata.getBatch({
+  requests: [
+    { resourceType: "user", resourceId: userA, categories: ["profile", "billing"] },
+    { resourceType: "user", resourceId: userB, categories: ["profile"] },
+  ],
+});
+// results[i] = { resourceType, resourceId, ok: true,
+//   categories: { <category>: { ok: true, exists, data, schemaVersion }
+//               | { ok: false, status, code, message } } }
+// A whole-resource failure (e.g. a malformed id) instead returns
+// { resourceType, resourceId, ok: false, status, code, message } with no `categories`.
+```
+
+```bash
+primitive metadata set user 01HXY... profile --data '{"tier":"pro","displayName":"Ada"}'
+primitive metadata set user 01HXY... profile --data-file ./profile.json
+primitive metadata get user 01HXY... profile --json
+primitive metadata get-batch --resource user:01HXY...:profile,billing --resource user:01HZQ...:profile
+primitive metadata get-batch --requests '[{"resourceType":"user","resourceId":"01HXY...","categories":["profile"]}]'
+```
+
+- Batch: up to 50 resources, 200 expanded resource/category pairs per call — over either limit fails the **whole** call with `400 BATCH_TOO_LARGE` (checked before any read). Within limits the call is always `200`; per-item problems (missing category → `404 NOT_FOUND`, denied `readRule` → `403 FORBIDDEN`) surface inside `results[].categories[cat]`, never as a call-level failure.
+- Errors on single read/write: `404 NOT_FOUND` (no such category on that resource type), `403 FORBIDDEN` (`readRule`/`writeRule` denied), `400` (schema validation failure, or writing the reserved `attrs` category → `RESERVED_CATEGORY`).
+- All CLI text output (`keyValue`/`success`/`info`) goes to **stderr** — only `--json` output goes to stdout. A `primitive metadata get ... > out.txt` without `--json` produces an empty file.
+- `set --data` and `--data-file` are mutually available; `--data-file` wins if both are passed. The payload must be a JSON object.
+
+## Declaring metadata for CEL rules
+
+A rule reads a resource's own metadata as `md.self.<category>.<key>` — but every category it reads must be **declared** on the owning config (a group type, collection type, database type, or workflow definition). Declaring is the authorization: a category's own `readRule` gates the read API only, not a rule author's use of it (trusted-author model).
+
+```toml
+# on the owning config (group-type-config shown; same shape for collection/database type configs and workflow definitions)
+[metadata.self]
+categories = ["config", "attrs"]
+```
+
+```toml novalidate
+member.create = "md.self.config.tier == \"pro\""
+```
+
+### `md.self.attrs` — the projected category
+
+Groups and collections expose a reserved, read-only `attrs` category with no schema — declare it like any other category and it's populated from the resource's own fields, no write path:
+
+| Resource type | `md.self.attrs.*` |
+|---|---|
+| `group` | `groupType`, `groupId`, `name`, `createdBy` |
+| `collection` | `collectionId`, `collectionType`, `contextId`, `name`, `createdBy` |
+
+```toml novalidate
+group.get = "md.self.attrs.createdBy == user.userId"
+```
+
+### Declared paths — a related resource's metadata
+
+A manifest can chain to another resource (up to 3 hops) via a metadata key holding its id:
+
+```toml
+[metadata.self]
+categories = ["system"]
+
+[metadata.paths.school]
+from = "self"          # "self" or another already-declared path name
+via = "system.schoolId" # "<category>.<key>" on the source; that category must be declared there
+type = "school"         # the target's resourceType
+categories = ["system"]
+```
+
+```toml novalidate
+md.school.system.tier == "pro"
+```
+
+### `md.caller` — the calling user's own metadata
+
+One path root is server-authenticated rather than caller-supplied: `rootFrom = "user.userId"` (requires `type = "user"`; any other `user.*` root is rejected at save time). Every other root (`input.*`, `record.*`, `params.*`) is a static, caller-declared context path, not an identity binding.
+
+```toml
+[metadata.paths.caller]
+rootFrom = "user.userId"
+type = "user"
+categories = ["billing"]
+```
+
+```toml novalidate
+access = "md.caller.billing.status in ['trialing', 'active', 'past_due']"
+```
+
+`md.caller` is bindable in **database operation `access`** (including per-param access and batch), the database's own `metadataAccess` rule, DO-trigger `when`/`set`, and **workflow `accessRule`** (`start` and `workflow.call`). With no authenticated caller (anonymous request, or a `runAs:"system"` workflow), `md.caller` binds `null` — a rule that dereferences it denies rather than erroring; guard explicitly (`md.caller != null && ...`) on a strict evaluation path where errors surface instead of denying.
+
+### Database operation substitution
+
+Beyond CEL `access` rules, an operation's `definition` (`filter`/`data`) can substitute a declared category value directly, alongside `$params.*` / `$user.userId` / `$now` / `$steps.*`:
+
+```toml novalidate
+definition = '{"filter":{"tier":"$md.self.profile.tier"}}'
+```
+
+`$md.self.<category>.<key>` resolves to `null` (not the literal string) when the category isn't declared on that database type's manifest, or the key is missing — same fail-closed convention as `$database.metadata.<key>`.
+
+## Workflow steps: `metadata.write` / `metadata.read`
+
+Both route through the exact same read/write path (and the same `readRule`/`writeRule` gate) as the client and CLI — no parallel authorization logic.
+
+```toml
+[[steps]]
+id = "record-billing"
+kind = "metadata.write"
+resourceType = "user"
+resourceId = "{{ input.userId }}"
+category = "billing"
+saveAs = "output"
+[steps.data]
+stripeCustomerId = "{{ input.customerId }}"
+status = "active"
+# Output: { ok, resourceType, resourceId, category, data, schemaVersion, size }
+
+[[steps]]
+id = "load-billing"
+kind = "metadata.read"
+resourceType = "user"
+resourceId = "{{ input.userId }}"
+category = "billing"
+saveAs = "output"
+# Output: { ok, resourceType, resourceId, category, data, schemaVersion, exists }
+```
+
+- `resourceType`/`resourceId`/`category`/`data` are all templated like any other step's params.
+- `metadata.write` is a **full replace** of the category, matching the REST `PUT` semantics.
+- Gate a category to exactly one workflow with `fromWorkflow('workflowKey')` in its `writeRule`/`readRule` — a REST call or a different workflow gets `403`. The workflow identity here is a privileged, call-local value the step runner passes in-process; it is never derived from a request header (an `X-Workflow-Context` header on a REST call has no effect).
+- Error behavior mirrors `database.*` steps: a 4xx (schema validation, rule denial, reserved category, bad segment) is **non-retryable**; a 429 or 5xx is retryable.
+- A `runAs:"system"` run's metadata calls carry no `user.*` context (empty `{}`) and get no owner/admin bypass — only `fromWorkflow('key')` can authorize a system-run write/read. A `runAs:"caller"` run's calls still get the owner/admin bypass.
+
+## Metadata lifecycle
+
+A write never checks that the target resource exists — a write for a not-yet-created or already-deleted resource succeeds silently, and deleting a resource does not delete its metadata (no cascade). This is deliberate: it keeps a write to a single cheap put, and doesn't race provisioning flows that write metadata immediately after — or interleaved with — creating the resource itself.
+
+**Consequences an implementation should account for:**
+- Gate writes with a category `writeRule` (owner-only, or `fromWorkflow('key')`) to limit who can create dangling metadata in the first place.
+- Whatever flow deletes a resource must also delete that resource's metadata categories — the platform doesn't do it for you.
+
+## Anti-patterns
+
+- Reading `md.self.<category>` in a rule without declaring `categories` for it in the config's `[metadata.self]` — the reference fails to save (400), not silently returns null.
+- Expecting a category's own `readRule` to restrict what a *different* rule can read via `md.self`/`md.caller` — it only gates the read API; declaration is the authorization for CEL use (trusted-author model).
+- Assuming `md.caller` works inside a group or collection rule set — it isn't bound there; it's for database operations and workflow `accessRule`.
+- Relying on resource deletion to clean up its metadata — there's no cascade; delete metadata explicitly in the same flow.
+- Trying to create or list category configs from the client SDK — that surface is TOML-sync/admin-REST only.
+- Treating `set()` as a merge — it's a full replace of the category's data.
+
+## Related guides
+
+- **access-control** — the shared CEL identity context every rule builds on
+- **users-and-groups** — group/collection `metadataManifest` and the projected `attrs` category
+- **databases** — `md.self`/`md.caller` in operation `access` and `$md.self.*` substitution
+- **workflows** — the `metadata.write`/`metadata.read` step shapes and `fromWorkflow()`

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.swift.md
@@ -229,7 +229,7 @@ Groups are identified by a `(groupType, groupId)` pair, allowing multiple taxono
 
 ### Quick start
 
-1. Create a group with `client.groups.create({ groupType, groupId, name })`.
+1. Create a group with `client.groups.create({ groupType, groupId, name })` — `groupId` is optional; omit it (or pass `null`) and the server assigns a ULID, returned in the response.
 2. Add members with `client.groups.addMember(...)` (by `userId` or `email`).
 3. Grant group access to a document with `client.documents.grantGroupPermission(...)`.
 4. Gate database operations in CEL: `access: "isMemberOf('team', database.metadata.teamId)"`.
@@ -270,6 +270,8 @@ The full create/list/get/update/delete surface is in [Managing Groups](#managing
 ```
 
 If the group type has `autoAddCreator: true` (default), the creator is automatically added as a member.
+
+`groupId` on create is optional — a supplied id keeps its existing validation (`#` banned, no `_`-prefixed reserved type, `409` on a duplicate); a non-string supplied value is rejected with `400 "groupId must be a string"`, an empty string with `400 "groupId cannot be empty"`. Omit it (or send `null`) to have the server assign a ULID, returned as `groupId` in the response — the same pattern documents, databases, and collections use for server-assigned ids.
 
 `groups.list()` returns a paginated `{ items: GroupInfo[], cursor? }`. `ListGroupsOptions` supports `type`, `limit`, `cursor`, and `includeSystem: true` to include platform-managed internal groups whose `groupType` is prefixed with `_` (e.g. `_col-reader`/`_col-writer` backing collection sharing). These are filtered out by default — only set `includeSystem` for admin tooling.
 
@@ -379,7 +381,13 @@ Group types are configured via TOML config files and the `primitive sync` comman
 groupType = "team"
 ruleSetName = "team-rules"     # optional — name of an attached rule set
 autoAddCreator = true          # auto-add creator as member when the config exists (default: true)
+
+[metadata.self]
+categories = ["config"]        # optional — declares which metadata categories this
+                                # group type's rule set may read as md.self.config.*
 ```
+
+A group type config can also declare a metadata manifest (`[metadata.self]`/`[metadata.paths.*]`/top-level `secrets`), making `md.self.<category>.<key>` — plus a reserved, schema-less `attrs` category (`groupType`, `groupId`, `name`, `createdBy`) — available in that type's rule set. Collection type configs take the identical `[metadata]` block (collection `attrs` adds `contextId`). See the [Resource Metadata guide](AGENT_GUIDE_TO_PRIMITIVE_RESOURCE_METADATA.md).
 
 Push to the server:
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.template.md
@@ -152,7 +152,7 @@ Groups are identified by a `(groupType, groupId)` pair, allowing multiple taxono
 
 ### Quick start
 
-1. Create a group with `client.groups.create({ groupType, groupId, name })`.
+1. Create a group with `client.groups.create({ groupType, groupId, name })` — `groupId` is optional; omit it (or pass `null`) and the server assigns a ULID, returned in the response.
 2. Add members with `client.groups.addMember(...)` (by `userId` or `email`).
 3. Grant group access to a document with `client.documents.grantGroupPermission(...)`.
 4. Gate database operations in CEL: `access: "isMemberOf('team', database.metadata.teamId)"`.
@@ -166,6 +166,8 @@ The full create/list/get/update/delete surface is in [Managing Groups](#managing
 {{ example: users-and-groups/group-crud }}
 
 If the group type has `autoAddCreator: true` (default), the creator is automatically added as a member.
+
+`groupId` on create is optional — a supplied id keeps its existing validation (`#` banned, no `_`-prefixed reserved type, `409` on a duplicate); a non-string supplied value is rejected with `400 "groupId must be a string"`, an empty string with `400 "groupId cannot be empty"`. Omit it (or send `null`) to have the server assign a ULID, returned as `groupId` in the response — the same pattern documents, databases, and collections use for server-assigned ids.
 
 `groups.list()` returns a paginated `{ items: GroupInfo[], cursor? }`. `ListGroupsOptions` supports `type`, `limit`, `cursor`, and `includeSystem: true` to include platform-managed internal groups whose `groupType` is prefixed with `_` (e.g. `_col-reader`/`_col-writer` backing collection sharing). These are filtered out by default — only set `includeSystem` for admin tooling.
 
@@ -229,7 +231,13 @@ Group types are configured via TOML config files and the `primitive sync` comman
 groupType = "team"
 ruleSetName = "team-rules"     # optional — name of an attached rule set
 autoAddCreator = true          # auto-add creator as member when the config exists (default: true)
+
+[metadata.self]
+categories = ["config"]        # optional — declares which metadata categories this
+                                # group type's rule set may read as md.self.config.*
 ```
+
+A group type config can also declare a metadata manifest (`[metadata.self]`/`[metadata.paths.*]`/top-level `secrets`), making `md.self.<category>.<key>` — plus a reserved, schema-less `attrs` category (`groupType`, `groupId`, `name`, `createdBy`) — available in that type's rule set. Collection type configs take the identical `[metadata]` block (collection `attrs` adds `contextId`). See the [Resource Metadata guide](AGENT_GUIDE_TO_PRIMITIVE_RESOURCE_METADATA.md).
 
 Push to the server:
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.ts.md
@@ -221,7 +221,7 @@ Groups are identified by a `(groupType, groupId)` pair, allowing multiple taxono
 
 ### Quick start
 
-1. Create a group with `client.groups.create({ groupType, groupId, name })`.
+1. Create a group with `client.groups.create({ groupType, groupId, name })` — `groupId` is optional; omit it (or pass `null`) and the server assigns a ULID, returned in the response.
 2. Add members with `client.groups.addMember(...)` (by `userId` or `email`).
 3. Grant group access to a document with `client.documents.grantGroupPermission(...)`.
 4. Gate database operations in CEL: `access: "isMemberOf('team', database.metadata.teamId)"`.
@@ -264,6 +264,8 @@ The full create/list/get/update/delete surface is in [Managing Groups](#managing
 ```
 
 If the group type has `autoAddCreator: true` (default), the creator is automatically added as a member.
+
+`groupId` on create is optional — a supplied id keeps its existing validation (`#` banned, no `_`-prefixed reserved type, `409` on a duplicate); a non-string supplied value is rejected with `400 "groupId must be a string"`, an empty string with `400 "groupId cannot be empty"`. Omit it (or send `null`) to have the server assign a ULID, returned as `groupId` in the response — the same pattern documents, databases, and collections use for server-assigned ids.
 
 `groups.list()` returns a paginated `{ items: GroupInfo[], cursor? }`. `ListGroupsOptions` supports `type`, `limit`, `cursor`, and `includeSystem: true` to include platform-managed internal groups whose `groupType` is prefixed with `_` (e.g. `_col-reader`/`_col-writer` backing collection sharing). These are filtered out by default — only set `includeSystem` for admin tooling.
 
@@ -364,7 +366,13 @@ Group types are configured via TOML config files and the `primitive sync` comman
 groupType = "team"
 ruleSetName = "team-rules"     # optional — name of an attached rule set
 autoAddCreator = true          # auto-add creator as member when the config exists (default: true)
+
+[metadata.self]
+categories = ["config"]        # optional — declares which metadata categories this
+                                # group type's rule set may read as md.self.config.*
 ```
+
+A group type config can also declare a metadata manifest (`[metadata.self]`/`[metadata.paths.*]`/top-level `secrets`), making `md.self.<category>.<key>` — plus a reserved, schema-less `attrs` category (`groupType`, `groupId`, `name`, `createdBy`) — available in that type's rule set. Collection type configs take the identical `[metadata]` block (collection `attrs` adds `contextId`). See the [Resource Metadata guide](AGENT_GUIDE_TO_PRIMITIVE_RESOURCE_METADATA.md).
 
 Push to the server:
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.swift.md
@@ -369,6 +369,33 @@ userId = "{{ input.userId }}"   # OR email = "...", not both
 
 Group operations evaluate the group type's CEL rules. For workflow-issued operations, rules can match `fromWorkflow("workflowKey")`. In a system run, `addMember`/`removeMember` record `sys:<appId>` as the membership's `addedBy` (not the admin/cron/webhook that initiated the run).
 
+### `metadata.write` / `metadata.read`
+
+```toml
+[[steps]]
+id = "record-billing"
+kind = "metadata.write"
+resourceType = "user"
+resourceId = "{{ input.userId }}"
+category = "billing"
+saveAs = "output"
+[steps.data]
+stripeCustomerId = "{{ input.customerId }}"
+status = "active"
+# Output: { ok, resourceType, resourceId, category, data, schemaVersion, size }
+
+[[steps]]
+id = "load-billing"
+kind = "metadata.read"
+resourceType = "user"
+resourceId = "{{ input.userId }}"
+category = "billing"
+saveAs = "output"
+# Output: { ok, resourceType, resourceId, category, data, schemaVersion, exists }
+```
+
+Both route through the same read/write path (and the same category `readRule`/`writeRule` gate) as the client and CLI — `resourceType`/`resourceId`/`category`/`data` are all templated. `metadata.write` is a full replace, not a merge. Gate a category to exactly this workflow with `fromWorkflow('workflowKey')` in its `writeRule`/`readRule`; the workflow identity is a privileged, call-local value the step runner passes in-process, never derived from a request header. A `runAs:"system"` run gets no owner/admin bypass here — only `fromWorkflow('key')` authorizes it; a `runAs:"caller"` run keeps the bypass. Errors follow the `database.*` step convention: 4xx (validation, rule denial, reserved category) is non-retryable, 429/5xx is retryable. See the [Resource Metadata guide](AGENT_GUIDE_TO_PRIMITIVE_RESOURCE_METADATA.md).
+
 ### `collect`
 
 Auto-paginate through any step that returns `{ items|data: [...], cursor|nextCursor }`.

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md
@@ -369,6 +369,33 @@ userId = "{{ input.userId }}"   # OR email = "...", not both
 
 Group operations evaluate the group type's CEL rules. For workflow-issued operations, rules can match `fromWorkflow("workflowKey")`. In a system run, `addMember`/`removeMember` record `sys:<appId>` as the membership's `addedBy` (not the admin/cron/webhook that initiated the run).
 
+### `metadata.write` / `metadata.read`
+
+```toml
+[[steps]]
+id = "record-billing"
+kind = "metadata.write"
+resourceType = "user"
+resourceId = "{{ input.userId }}"
+category = "billing"
+saveAs = "output"
+[steps.data]
+stripeCustomerId = "{{ input.customerId }}"
+status = "active"
+# Output: { ok, resourceType, resourceId, category, data, schemaVersion, size }
+
+[[steps]]
+id = "load-billing"
+kind = "metadata.read"
+resourceType = "user"
+resourceId = "{{ input.userId }}"
+category = "billing"
+saveAs = "output"
+# Output: { ok, resourceType, resourceId, category, data, schemaVersion, exists }
+```
+
+Both route through the same read/write path (and the same category `readRule`/`writeRule` gate) as the client and CLI — `resourceType`/`resourceId`/`category`/`data` are all templated. `metadata.write` is a full replace, not a merge. Gate a category to exactly this workflow with `fromWorkflow('workflowKey')` in its `writeRule`/`readRule`; the workflow identity is a privileged, call-local value the step runner passes in-process, never derived from a request header. A `runAs:"system"` run gets no owner/admin bypass here — only `fromWorkflow('key')` authorizes it; a `runAs:"caller"` run keeps the bypass. Errors follow the `database.*` step convention: 4xx (validation, rule denial, reserved category) is non-retryable, 429/5xx is retryable. See the [Resource Metadata guide](AGENT_GUIDE_TO_PRIMITIVE_RESOURCE_METADATA.md).
+
 ### `collect`
 
 Auto-paginate through any step that returns `{ items|data: [...], cursor|nextCursor }`.

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.ts.md
@@ -369,6 +369,33 @@ userId = "{{ input.userId }}"   # OR email = "...", not both
 
 Group operations evaluate the group type's CEL rules. For workflow-issued operations, rules can match `fromWorkflow("workflowKey")`. In a system run, `addMember`/`removeMember` record `sys:<appId>` as the membership's `addedBy` (not the admin/cron/webhook that initiated the run).
 
+### `metadata.write` / `metadata.read`
+
+```toml
+[[steps]]
+id = "record-billing"
+kind = "metadata.write"
+resourceType = "user"
+resourceId = "{{ input.userId }}"
+category = "billing"
+saveAs = "output"
+[steps.data]
+stripeCustomerId = "{{ input.customerId }}"
+status = "active"
+# Output: { ok, resourceType, resourceId, category, data, schemaVersion, size }
+
+[[steps]]
+id = "load-billing"
+kind = "metadata.read"
+resourceType = "user"
+resourceId = "{{ input.userId }}"
+category = "billing"
+saveAs = "output"
+# Output: { ok, resourceType, resourceId, category, data, schemaVersion, exists }
+```
+
+Both route through the same read/write path (and the same category `readRule`/`writeRule` gate) as the client and CLI — `resourceType`/`resourceId`/`category`/`data` are all templated. `metadata.write` is a full replace, not a merge. Gate a category to exactly this workflow with `fromWorkflow('workflowKey')` in its `writeRule`/`readRule`; the workflow identity is a privileged, call-local value the step runner passes in-process, never derived from a request header. A `runAs:"system"` run gets no owner/admin bypass here — only `fromWorkflow('key')` authorizes it; a `runAs:"caller"` run keeps the bypass. Errors follow the `database.*` step convention: 4xx (validation, rule denial, reserved category) is non-retryable, 429/5xx is retryable. See the [Resource Metadata guide](AGENT_GUIDE_TO_PRIMITIVE_RESOURCE_METADATA.md).
+
 ### `collect`
 
 Auto-paginate through any step that returns `{ items|data: [...], cursor|nextCursor }`.

--- a/guides/latest/guides.json
+++ b/guides/latest/guides.json
@@ -15,7 +15,7 @@
     }
   },
   "builtAgainst": {
-    "stampedAt": "2026-07-03",
+    "stampedAt": "2026-07-04",
     "channel": "next",
     "packages": {
       "js-bao-wss-client": "2.0.4",
@@ -237,7 +237,8 @@
         "documents",
         "data-modeling",
         "authentication",
-        "invitations"
+        "invitations",
+        "resource-metadata"
       ],
       "variants": [
         {
@@ -328,7 +329,8 @@
         "documents",
         "data-modeling",
         "users-and-groups",
-        "workflows"
+        "workflows",
+        "resource-metadata"
       ],
       "variants": [
         {
@@ -496,7 +498,8 @@
         "databases",
         "blobs",
         "analytics",
-        "app-secrets"
+        "app-secrets",
+        "resource-metadata"
       ],
       "variants": [
         {
@@ -927,6 +930,63 @@
         "Governing who can create groups or manage members",
         "Testing and debugging CEL rules",
         "Building a subscription-entitlement (Stripe billing) gate end to end"
+      ],
+      "relatedGuides": [
+        "resource-metadata"
+      ]
+    },
+    {
+      "topic": "resource-metadata",
+      "file": "AGENT_GUIDE_TO_PRIMITIVE_RESOURCE_METADATA.ts.md",
+      "description": "Typed metadata on any resource — categories, md.self/md.caller in CEL, batch reads, workflow steps",
+      "keywords": [
+        "resource metadata",
+        "metadata category",
+        "md.self",
+        "md.caller",
+        "metadataManifest",
+        "MetadataCategoryConfig",
+        "readRule",
+        "writeRule",
+        "resourceMetadata",
+        "getBatch",
+        "metadata.write",
+        "metadata.read",
+        "attrs",
+        "fromWorkflow"
+      ],
+      "useCases": [
+        "Attaching schema'd, access-controlled data to a user, group, collection, database, or workflow subject",
+        "Reading and writing a metadata category from the client or CLI, including a batch read",
+        "Referencing declared metadata in a group, collection, or database access rule",
+        "Reading the calling user's own metadata (md.caller) in an access rule",
+        "Writing metadata from a workflow step, restricted to that workflow with fromWorkflow()",
+        "Substituting a metadata value into a database operation's filter or data"
+      ],
+      "concepts": [
+        "metadata category config (schema + readRule/writeRule)",
+        "declared-access manifest ([metadata.self]/[metadata.paths])",
+        "md.self.<category>.<key>",
+        "md.self.attrs (projected category)",
+        "md.caller (user.userId root)",
+        "metadata.write / metadata.read workflow steps",
+        "trusted-author model"
+      ],
+      "relatedGuides": [
+        "access-control",
+        "users-and-groups",
+        "databases",
+        "workflows"
+      ],
+      "variants": [
+        {
+          "language": "ts",
+          "file": "AGENT_GUIDE_TO_PRIMITIVE_RESOURCE_METADATA.ts.md"
+        },
+        {
+          "language": "swift",
+          "file": "AGENT_GUIDE_TO_PRIMITIVE_RESOURCE_METADATA.swift.md"
+        }
       ]
     },
     {

--- a/scripts/sync-map.json
+++ b/scripts/sync-map.json
@@ -13,6 +13,7 @@
     { "page": "docs/getting-started/devtools.md", "template": "guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DEVTOOLS.template.md" },
     { "page": "docs/getting-started/invitations.md", "template": "guides/latest/AGENT_GUIDE_TO_PRIMITIVE_INVITATIONS.template.md" },
     { "page": "docs/getting-started/prompts.md", "template": "guides/latest/AGENT_GUIDE_TO_PRIMITIVE_PROMPTS.template.md" },
+    { "page": "docs/getting-started/resource-metadata.md", "template": "guides/latest/AGENT_GUIDE_TO_PRIMITIVE_RESOURCE_METADATA.template.md" },
     { "page": "docs/getting-started/users-and-groups.md", "template": "guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.template.md" },
     { "page": "docs/getting-started/workflows.md", "template": "guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md" },
     { "page": "docs/getting-started/workflows.md", "template": "guides/latest/AGENT_GUIDE_TO_PRIMITIVE_SCRIPTS.template.md", "note": "the page's `script` step section" },


### PR DESCRIPTION
Automated `docs-next-sync` pass against the library main tips, triggered by the nightly release js-bao-wss#1383.



> **Delta PR.** This PR covers only the library window since the previous sync PR (or since the last merge, if none is open) — it does not contain earlier open sync PRs' content. Merge sync PRs **oldest first**; consecutive ones conflict on the stamp/submodule pin by construction, and `docs-pr-sweep` knows how to rebase and land the chain.

SYNC_STATUS: ready

# docs-next-sync — nightly truing pass (2026-07-04)

Trued the `next` channel against the library `main` tip. Submodule `js-bao-wss` fast-forwarded `e72da39d → 20de84bf` (**39 commits**, the full window since the last stamp — no earlier open sync PR seeded a narrower delta); `primitive-app-dev` and `swift-primitive-app-dev` had no new commits. All gates green; changes left in the working tree for the workflow to open the PR.

Triggering context: js-bao-wss#1383 (nightly release 2026-07-04), advancing the deployed SHA by one test-only nightly-fix commit — but the docs stamp was still at the *previous* nightly's base (`e72da39d`), so this pass's real diff is the full "metadata" feature-line batch shipped that night (7 PRs), not just the one nightly-fix commit.

## Gate results

| Gate | Result |
|---|---|
| `pnpm check:examples` (parity, TS compile, TOML ×193, CLI ×460, sync-map, source-stamp) | ✅ green |
| `npx vitepress build docs` (dead links) | ✅ green |
| `pnpm render:guides` | ✅ 20 templates → 36 builds rendered, guides.json current |
| `pnpm stamp:sources` | ✅ restamped to `20de84bf` (channel: next) |
| Swift compile | skipped here (needs macOS host — covered by the macOS CI job) |
| `node scripts/check-example-parity.mjs` | 2 `lone-js` blocks on the new page (resource-metadata.md:42,61) — deliberate, see below |

## Per-item disposition

All seven PRs in this batch are the same feature line: resource metadata (declared, schema'd, CEL-gated key/value data attached to any resource) — a follow-up to base epic js-bao-wss#1304, which shipped **before** this docs repo's last stamp and was **never documented** here. The previous truing pass (PR #229, merged `d00d564`) explicitly deferred drafting a concept page for #1304 pending an editorial/IA decision, citing its missing client SDK as the blocking concern. This batch adds exactly that SDK (JS client `resourceMetadata` + CLI), so this pass drafts the page rather than deferring again — see "Larger change" below.

| Item (js-bao-wss) | Disposition |
|---|---|
| **#1366** wire groups/collections into the metadata manifest (`md.self` on group/collection rule sets, projected `attrs`) | **drafted** as part of the new Resource Metadata page/guide; **updated** `users-and-groups.md` + `AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.template.md` (group-type-config `[metadata.self]`, `attrs` projection, cross-link) |
| **#1356** `$md.self.<category>.<key>` substitution in database operation `filter`/`data` | **updated** `working-with-databases.md` (Access Control with CEL section) + `AGENT_GUIDE_TO_PRIMITIVE_DATABASES.template.md` (operation-substitution note) |
| **#1375** batch read endpoint + JS client (`client.resourceMetadata`) + CLI (`primitive metadata`) | **drafted** as the core of the new Resource Metadata page/guide; **updated** `primitive-cli.md` (CLI quick-reference entry) |
| **#1358** server-assigned group IDs (`groupId` optional on create) | **updated** `users-and-groups.md` + `AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.template.md` (optional `--id`/`groupId`, exact 400 messages) |
| **#1371** `metadata.write`/`metadata.read` workflow steps + `fromWorkflow()` in category rules | **updated** `workflows.md` (new Metadata Steps section + Step Reference row) + `AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md`; full step contract in the new Resource Metadata guide |
| **#1370** caller-rooted metadata paths (`user.userId` / `md.caller`) | **drafted** in the new Resource Metadata page/guide (the one server-authenticated root, exact bindable surfaces verified against `metadata-cel-access.ts` + the 9 call sites in `database-operations-controller.ts`/`databases-controller.ts`/`workflows-controller.ts`) |
| **#1359** docs: metadata writes don't validate resource existence | **drafted** in the new Resource Metadata page/guide (Metadata Lifecycle section) |
| `20de84bf` nightly-fix (stale group-create test assertion) | **internal** — test-only, no doc-visible behavior change |

Also touched (consequence of the new page, not a separate upstream item): `access-control.md` + its guide (new "Metadata categories" row in the rules-surface table, `md.self`/`md.caller` mentioned in the shared identity-context intro), `configuring-primitive-services.md` + `AGENT_GUIDE_TO_PRIMITIVE_CONFIGURATION.template.md` (added the pre-existing-but-missing `metadata-category-configs/*.toml` line to the config directory map — this omission predates this batch but was caught by the cross-page grep while adding the new capability), `scripts/sync-map.json` (registered the new page/template pair), `guides/latest/guides.json` (new `resource-metadata` topic entry + reciprocal `relatedGuides` on `access-control`/`users-and-groups`/`databases`/`workflows`).

## Larger change flagged for human review

**New page: `docs/getting-started/resource-metadata.md`, sidebar-placed in "Users and Auth" right after Access Control** — paired with a new agent guide, `AGENT_GUIDE_TO_PRIMITIVE_RESOURCE_METADATA.template.md` (builds to `.ts.md`/`.swift.md`; the Swift build omits the client-SDK section since the Swift client has no `resourceMetadata` namespace — see below).

This is a genuinely large addition (a full concept page + guide, four other pages updated, a new sidebar entry, a new guides.json topic) covering: category configs (schema/`readRule`/`writeRule`), value read/write/batch-read (client + CLI), `md.self`/`attrs`/declared paths in CEL rules, the caller-rooted `md.caller`, the `metadata.write`/`metadata.read` workflow steps, and the writes-don't-validate-existence lifecycle note. Every fact was verified directly against `library_repos/js-bao-wss` source (service/controller/CLI/client code, not PR summaries) — CLI syntax additionally passed the mechanical `check:cli` gate (460 invocations checked against the built `primitive-admin`, including every one shown in the new page/guide).

**Placement is an editorial judgment call** — I placed it beside Access Control because the entire feature is CEL-rule-shaped (categories carry `readRule`/`writeRule`; the CEL surface is the main draw), but "Platform Services" (beside App Secrets, a similarly cross-cutting declared/CEL-gated resource) is a defensible alternative. A reviewer should confirm or move it.

Everything drafted is scoped to what's actually shipped with real developer-facing surface (REST + CLI + JS client) — the base epic #1304's *design* (SWR caching, observability, the full traversal-DAG resolver internals) is deliberately left out as implementation detail, matching the page/guide altitude (concept + patterns, not the resolver's internals).

## Parity gaps (not filed — already tracked upstream)

The JS client `resourceMetadata` namespace has no Swift-client or web-admin counterpart. Both gaps are **already tracked as open issues in `js-bao-wss`** (found before filing, per `.claude/ISSUE_FILING.md`'s "check for an existing issue first"):
- Swift client: js-bao-wss#1373 ("Swift client: port resourceMetadata get/set/getBatch (parity with #1352)") — open
- web-admin: js-bao-wss#1374 ("web-admin: resource-metadata inspector view (parity with #1352)") — open

The new guide scopes the client-SDK section to `{{#lang ts}}` accordingly (verified: the Swift build of the new guide contains no `client.resourceMetadata` mention). No new issues filed — nothing to add beyond referencing the existing numbers.

## Issues

No open `primitive-docs` issues named a blocker in this batch (checked `gh issue list --state open` — zero open issues in this repo) and none required closing. No `Fixes #NN` line applies this pass.

## Sources vs docs — unresolved contradictions

None found. One **cross-page staleness** was caught and fixed while adding the new capability (not itself part of this batch's diff, but surfaced by the "grep the set for the old fact" step): `configuring-primitive-services.md` and its guide's config-directory map were missing the `metadata-category-configs/*.toml` line that has existed since #1304 — added alongside the new page.

## Tests / verification performed

- Every API shape, CLI flag, TOML field, and CEL binding site in the new page/guide was verified against source (`resource-metadata-service.ts`, `metadata-controller.ts`, `metadata-cel-access.ts`, `metadata-bindings.ts`, `resourceMetadataApi.ts`, `toml-metadata-config.ts`, `cli/src/commands/metadata.ts`, `cli/src/commands/sync.ts`, `metadata-step.ts`, `default-registry.ts`, `groups-controller.ts`, `groupsApi.ts`, `cli/src/commands/groups.ts`) — not transcribed from PR descriptions.
- `pnpm check:examples` green: TS corpus compiles against submodule source, all 193 TOML blocks (including every new one) validate, all 460 documented CLI invocations (including every new `primitive metadata`/`primitive groups create` example) validate against the built `primitive-admin`, sync-map and guides.json are internally consistent, source stamp matches.
- `npx vitepress build docs` green — no dead links from the new sidebar entry or any cross-reference added across the five other touched pages.
- Ran a self-review pass (docs-page-review lenses) against the new page/guide pair after first draft; found and fixed two never-say-list phrasings (a stray "not currently bound" gap-marker sentence, and a "there is no client-side X" gap callout reframed positively) before finalizing.

---
Review the doc changes and the disposition above, then merge into `next`. Publishing to `main` happens separately at a production release.

> Generated unattended by the Claude Code CLI. Verify facts against source before merging.