### PR TITLE
docs-next-sync: js-bao-wss changes (automated, 2026-07-08)

### DIFF
--- a/docs-sources.json
+++ b/docs-sources.json
@@ -1,9 +1,9 @@
 {
   "channel": "next",
-  "stampedAt": "2026-07-07",
+  "stampedAt": "2026-07-08",
   "libraries": {
     "js-bao-wss": {
-      "commit": "444938b2b95d711d8f12935c10b1587b1fb75c81",
+      "commit": "429808a0ea9029ef904b8bde25b69bac71bbed65",
       "npm": {
         "js-bao-wss-client": "2.0.4",
         "js-bao": "0.5.1",

--- a/docs/getting-started/workflows.md
+++ b/docs/getting-started/workflows.md
@@ -332,6 +332,8 @@ capabilities = ["membership"]
 
 `membership` lets the workflow change group membership — the `group.addMember`, `group.removeMember`, and `group.removeAll` steps. Without the grant, those steps in a system workflow are refused. Read-only group checks never need it.
 
+`sync push` only sets `capabilities` when it creates a workflow. To grant or revoke capabilities on a workflow that already exists, use `primitive workflows update <id> --capabilities membership` (a comma-separated list; `--capabilities ""` revokes all).
+
 [`iterate-users`](#iterate-users) is system-only — it fans out across the entire user roster, which no single caller has the standing to do. A workflow that uses it must set `runAs = "system"`, or the server rejects it when you push.
 
 ### Acting on Behalf of a User
@@ -432,7 +434,7 @@ primitive sync diff
 primitive sync push
 ```
 
-When a workflow needs flags `sync push` doesn't carry (`requiresClientApply`, `syncCallable`, queue caps), set them with `primitive workflows update`.
+`syncCallable` is the one `[workflow]` field `sync push` won't flip on an existing workflow — the server re-validates it against the currently-active steps, so set it with `primitive workflows update --sync-callable true` after the new steps are live. (`capabilities` has a similar create-only limitation — see [above](#sensitive-capabilities).) Every other field round-trips through `sync push`.
 
 For reusable step blocks, lift them into `<workflowDir>/../workflow-fragments/<name>.toml` and reference them from a workflow via `include = ["<name>"]`. The CLI flattens fragment references before push; `primitive workflows expand <workflow.toml>` prints the expanded result for debugging.
 
@@ -799,6 +801,19 @@ scope = "user"
 aliasKey = "tracker"
 saveAs = "tracker"
 ```
+
+**Writing many records in one step.** `document.save` and `document.patch` accept `records` (an array) instead of `recordId` + `data`; `document.delete` accepts `recordIds` (an array of strings) instead of `recordId`. A step takes one form or the other, never both — supplying `recordId` alongside `records`/`recordIds` fails the step. Batch mode collapses a `forEach` fan-out into a single step that resolves the document's ACL once and applies every record in one transaction per chunk (chunked at 100 records; a batch over 100 records makes several sequential chunk round-trips, each atomic on its own but not atomic with the others — a failure partway through leaves earlier chunks committed):
+
+```toml
+[[steps]]
+id = "upsert-holdings"
+kind = "document.save"
+documentId = "{{ input.docId }}"
+modelName = "Holding"
+records = "{{ steps.rows.output.result.rows }}"   # each { id?, ...fields } — id is optional; omitted ids are minted server-side
+```
+
+`document.save` returns `{ saved, savedIds }` and `document.patch` returns `{ patched, patchedIds }` (each element of `records` needs an `id` for `patch`); `document.delete` returns `{ deleted }` (a non-existent id is a no-op, not an error). Re-running a batch save whose records had no `id` mints fresh ids each time rather than upserting the same ones — give records an explicit `id` if the workflow might retry.
 
 ### Group Steps
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_CONFIGURATION.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_CONFIGURATION.md
@@ -75,15 +75,17 @@ Every command resolves its target environment in order: `--env <name>` flag → 
 
 ## What sync does NOT carry
 
-Some settings are set with dedicated update commands rather than TOML (app-level settings that *do* sync are listed under [App settings](#app-settings-app-toml)):
+Some settings are set with dedicated update commands rather than TOML (app-level settings that *do* sync are listed under [App settings](#app-settings-app-toml)). Two workflow-level fields are the exception to "TOML round-trips everything": `sync push` sets them only when it **creates** a workflow, never when it updates one already on the server — flip them on an existing workflow with a direct update instead:
 
 ```bash
-primitive workflows update <id> --requires-client-apply false
-primitive workflows update <id> --sync-callable true
+primitive workflows update <id> --sync-callable true     # existing workflow only; the server re-validates against the currently-active steps
+primitive workflows update <id> --capabilities membership   # existing workflow only; comma-separated, "" revokes all
 primitive apps update --member-invitations-enabled true --member-invitation-limit 5
 primitive apps update --test-account-bases alice@example.com
 primitive apps update --redirect-uris "https://app.example.com/auth/callback"  # no TOML key
 ```
+
+`requiresClientApply` is an ordinary `[workflow]` TOML field — `sync push` forwards it on both create and update — so `primitive workflows update <id> --requires-client-apply false` is a convenience, not the only path.
 
 ## Secrets
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_CONFIGURATION.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_CONFIGURATION.template.md
@@ -75,15 +75,17 @@ Every command resolves its target environment in order: `--env <name>` flag → 
 
 ## What sync does NOT carry
 
-Some settings are set with dedicated update commands rather than TOML (app-level settings that *do* sync are listed under [App settings](#app-settings-app-toml)):
+Some settings are set with dedicated update commands rather than TOML (app-level settings that *do* sync are listed under [App settings](#app-settings-app-toml)). Two workflow-level fields are the exception to "TOML round-trips everything": `sync push` sets them only when it **creates** a workflow, never when it updates one already on the server — flip them on an existing workflow with a direct update instead:
 
 ```bash
-primitive workflows update <id> --requires-client-apply false
-primitive workflows update <id> --sync-callable true
+primitive workflows update <id> --sync-callable true     # existing workflow only; the server re-validates against the currently-active steps
+primitive workflows update <id> --capabilities membership   # existing workflow only; comma-separated, "" revokes all
 primitive apps update --member-invitations-enabled true --member-invitation-limit 5
 primitive apps update --test-account-bases alice@example.com
 primitive apps update --redirect-uris "https://app.example.com/auth/callback"  # no TOML key
 ```
+
+`requiresClientApply` is an ordinary `[workflow]` TOML field — `sync push` forwards it on both create and update — so `primitive workflows update <id> --requires-client-apply false` is a convenience, not the only path.
 
 ## Secrets
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.swift.md
@@ -30,7 +30,7 @@ greeting = "Hello {{ input.name }}"
 ```
 
 Workflow-level fields the engine actually reads:
-`perUserMaxRunning`, `perUserMaxQueued`, `perAppMaxRunning` (default 25), `perAppMaxQueued` (default 10000), `queueTtlSeconds` (default 43200), `dequeueOrder`, `accessRule`, `runAs` (default `caller` — see "Execution identity" below), `capabilities` (system-only grants), `inputSchema`, `outputSchema`, `requiresClientApply` (default `true` — see "Client apply" below), `syncCallable` (default `false` — see "Synchronous invocation" below). Sync pushes the schema fields, access rule, `runAs`/`capabilities`, queue settings, step list, `requiresClientApply`, and `syncCallable`.
+`perUserMaxRunning`, `perUserMaxQueued`, `perAppMaxRunning` (default 25), `perAppMaxQueued` (default 10000), `queueTtlSeconds` (default 43200), `dequeueOrder`, `accessRule`, `runAs` (default `caller` — see "Execution identity" below), `capabilities` (system-only grants), `inputSchema`, `outputSchema`, `requiresClientApply` (default `true` — see "Client apply" below), `syncCallable` (default `false` — see "Synchronous invocation" below). `sync push` forwards every one of these — `name`, `description`, `status`, `accessRule`, `runAs`, queue settings, schemas, `requiresClientApply`, step list — on both a fresh create and a push to an existing workflow, with two exceptions that need a direct CLI update instead: `syncCallable` on an existing workflow (the server re-validates it against the currently-active steps, so `sync push` omits it there — use `primitive workflows update --sync-callable true` after the new steps are live) and `capabilities` on an existing workflow (`sync push` persists `capabilities` on create only — grant or revoke them on an existing workflow with `primitive workflows update --capabilities <list>`, comma-separated, `""` to revoke all).
 
 ### Per-step common fields
 
@@ -351,6 +351,48 @@ kind = "document.save"
 runIf = "outputs.tracker.documentId == null"
 # ... create the user's tracker document
 ```
+
+### `document.save` / `patch` / `delete` — batch mode (`records` / `recordIds`)
+
+Each write step works in exactly one of two modes, never mixed: singular (`recordId` [+ `data`]) or batch (`records` for `save`/`patch`, `recordIds` for `delete`). Batch mode is keyed off the array field being present at all (not off `recordId` being absent) — supplying both a singular and an array field on the same step is a hard non-retryable error. Batch mode resolves the document ACL once and applies every record in one Yjs transaction + one persist + one broadcast **per chunk**, instead of the per-record cost of a `forEach` fan-out.
+
+| Mode | Input | Output |
+|---|---|---|
+| singular | `recordId` (+ `data`) | unchanged: `save`/`patch` → `{ record }`; `delete` → `{ deleted: true, id }` |
+| batch | `records` (save/patch) / `recordIds` (delete) | `save` → `{ saved, savedIds }`; `patch` → `{ patched, patchedIds }`; `delete` → `{ deleted }` |
+
+```toml
+[[steps]]
+id = "upsert-holdings"
+kind = "document.save"
+documentId = "{{ outputs.doc.documentId }}"
+modelName = "holding"
+records = "{{ steps.rows.output.result.rows }}"   # Array<{ id?, ...fields }> — id optional, minted server-side (ulid()) when absent
+
+[[steps]]
+id = "merge-holdings"
+kind = "document.patch"
+documentId = "{{ outputs.doc.documentId }}"
+modelName = "holding"
+records = "{{ steps.rows.output.result.rows }}"   # Array<{ id, ...fields }> — id REQUIRED per element
+
+[[steps]]
+id = "remove-obsolete"
+kind = "document.delete"
+documentId = "{{ outputs.doc.documentId }}"
+modelName = "holding"
+recordIds = "{{ steps.plan.output.result.obsoleteIds }}"   # string[] — a non-existent id is a no-op, not an error
+```
+
+Rules and edge cases:
+
+- **Chunk cap = 100 records** (server constant). A batch of N records runs as `ceil(N / 100)` sequential DO round-trips, not one unbounded transaction.
+- **Validation-first, then fail-fast.** A structural pass runs over every record before the first chunk is sent (well-formed objects; `patch` elements require a non-empty `id`; `recordIds` entries are non-empty strings). A structural failure fails the whole step non-retryably, names the offending index, and writes nothing.
+- **Per-chunk atomicity, not whole-batch atomicity.** Each chunk (≤100 records) commits atomically, but a batch spanning multiple chunks is not atomic across chunks — a failure on chunk *k* leaves chunks `0..k-1` committed. The error names the offending record. Keep a batch ≤100 (one chunk) for all-or-nothing, or design the workflow for idempotent re-runs.
+- **Duplicate ids within one batch:** allowed, last write wins (records apply in id order within the transaction).
+- **Batch failures are non-retryable** — a validation or constraint failure fails the run immediately rather than retrying.
+- **Id-less batch `save` and retries.** An omitted `id` mints a fresh ULID server-side on every attempt — retrying a batch save whose records had no `id` (e.g. after a transient error) creates duplicates rather than upserting the originals. Supply explicit ids, or make the workflow idempotent some other way, if the step might retry.
+- **Projection freshness.** A batch marks the document's query projection dirty once (rebuilt on the next read) instead of updating it inline per record — the first `document.query`/`count` after a batch pays one rebuild rather than N inline upserts. Single-record writes still update the projection inline.
 
 ### `group.addMember` / `removeMember` / `removeAll` / `checkMembership` / `listMembers` / `listUserMemberships`
 
@@ -935,7 +977,9 @@ runAs = "system"
 capabilities = ["membership"]
 ```
 
-`membership` gates the `group.addMember` / `group.removeMember` / `group.removeAll` steps in a **system** run — without the grant they reject (`group.addMember requires the 'membership' capability`). Read-only group steps (`checkMembership`, `listMembers`, `listUserMemberships`) are never gated, and caller runs are governed by access rules, not capabilities, so the gate never applies to them.
+`membership` gates the `group.addMember` / `group.removeMember` / `group.removeAll` steps in a **system** run — without the grant they reject (`group.addMember requires the 'membership' capability`). Read-only group steps (`checkMembership`, `listMembers`, `listUserMemberships`) are never gated, and caller runs are governed by access rules, not capabilities, so the gate never applies to them. When the group type carries no explicit rule set (no `GroupTypeConfig` row, or one with `ruleSetId` unset), a system run holding `membership` is allowed through anyway — the granted capability stands in for a CEL rule the app never configured. A group type with an explicit rule set is still governed by that rule set, never overridden by the capability.
+
+Grant or revoke `capabilities` on a workflow that already exists with `primitive workflows update <id> --capabilities <list>` (comma-separated; `""` revokes all) — `sync push` only persists `capabilities` when creating a new workflow (see above).
 
 **`iterate-users` is system-only.** A workflow containing an `iterate-users` step must set `runAs = "system"` — otherwise it's rejected at save time (`'iterate-users' is system-only and may appear only in a runAs:"system" workflow`).
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md
@@ -30,7 +30,7 @@ greeting = "Hello {{ input.name }}"
 ```
 
 Workflow-level fields the engine actually reads:
-`perUserMaxRunning`, `perUserMaxQueued`, `perAppMaxRunning` (default 25), `perAppMaxQueued` (default 10000), `queueTtlSeconds` (default 43200), `dequeueOrder`, `accessRule`, `runAs` (default `caller` — see "Execution identity" below), `capabilities` (system-only grants), `inputSchema`, `outputSchema`, `requiresClientApply` (default `true` — see "Client apply" below), `syncCallable` (default `false` — see "Synchronous invocation" below). Sync pushes the schema fields, access rule, `runAs`/`capabilities`, queue settings, step list, `requiresClientApply`, and `syncCallable`.
+`perUserMaxRunning`, `perUserMaxQueued`, `perAppMaxRunning` (default 25), `perAppMaxQueued` (default 10000), `queueTtlSeconds` (default 43200), `dequeueOrder`, `accessRule`, `runAs` (default `caller` — see "Execution identity" below), `capabilities` (system-only grants), `inputSchema`, `outputSchema`, `requiresClientApply` (default `true` — see "Client apply" below), `syncCallable` (default `false` — see "Synchronous invocation" below). `sync push` forwards every one of these — `name`, `description`, `status`, `accessRule`, `runAs`, queue settings, schemas, `requiresClientApply`, step list — on both a fresh create and a push to an existing workflow, with two exceptions that need a direct CLI update instead: `syncCallable` on an existing workflow (the server re-validates it against the currently-active steps, so `sync push` omits it there — use `primitive workflows update --sync-callable true` after the new steps are live) and `capabilities` on an existing workflow (`sync push` persists `capabilities` on create only — grant or revoke them on an existing workflow with `primitive workflows update --capabilities <list>`, comma-separated, `""` to revoke all).
 
 ### Per-step common fields
 
@@ -351,6 +351,48 @@ kind = "document.save"
 runIf = "outputs.tracker.documentId == null"
 # ... create the user's tracker document
 ```
+
+### `document.save` / `patch` / `delete` — batch mode (`records` / `recordIds`)
+
+Each write step works in exactly one of two modes, never mixed: singular (`recordId` [+ `data`]) or batch (`records` for `save`/`patch`, `recordIds` for `delete`). Batch mode is keyed off the array field being present at all (not off `recordId` being absent) — supplying both a singular and an array field on the same step is a hard non-retryable error. Batch mode resolves the document ACL once and applies every record in one Yjs transaction + one persist + one broadcast **per chunk**, instead of the per-record cost of a `forEach` fan-out.
+
+| Mode | Input | Output |
+|---|---|---|
+| singular | `recordId` (+ `data`) | unchanged: `save`/`patch` → `{ record }`; `delete` → `{ deleted: true, id }` |
+| batch | `records` (save/patch) / `recordIds` (delete) | `save` → `{ saved, savedIds }`; `patch` → `{ patched, patchedIds }`; `delete` → `{ deleted }` |
+
+```toml
+[[steps]]
+id = "upsert-holdings"
+kind = "document.save"
+documentId = "{{ outputs.doc.documentId }}"
+modelName = "holding"
+records = "{{ steps.rows.output.result.rows }}"   # Array<{ id?, ...fields }> — id optional, minted server-side (ulid()) when absent
+
+[[steps]]
+id = "merge-holdings"
+kind = "document.patch"
+documentId = "{{ outputs.doc.documentId }}"
+modelName = "holding"
+records = "{{ steps.rows.output.result.rows }}"   # Array<{ id, ...fields }> — id REQUIRED per element
+
+[[steps]]
+id = "remove-obsolete"
+kind = "document.delete"
+documentId = "{{ outputs.doc.documentId }}"
+modelName = "holding"
+recordIds = "{{ steps.plan.output.result.obsoleteIds }}"   # string[] — a non-existent id is a no-op, not an error
+```
+
+Rules and edge cases:
+
+- **Chunk cap = 100 records** (server constant). A batch of N records runs as `ceil(N / 100)` sequential DO round-trips, not one unbounded transaction.
+- **Validation-first, then fail-fast.** A structural pass runs over every record before the first chunk is sent (well-formed objects; `patch` elements require a non-empty `id`; `recordIds` entries are non-empty strings). A structural failure fails the whole step non-retryably, names the offending index, and writes nothing.
+- **Per-chunk atomicity, not whole-batch atomicity.** Each chunk (≤100 records) commits atomically, but a batch spanning multiple chunks is not atomic across chunks — a failure on chunk *k* leaves chunks `0..k-1` committed. The error names the offending record. Keep a batch ≤100 (one chunk) for all-or-nothing, or design the workflow for idempotent re-runs.
+- **Duplicate ids within one batch:** allowed, last write wins (records apply in id order within the transaction).
+- **Batch failures are non-retryable** — a validation or constraint failure fails the run immediately rather than retrying.
+- **Id-less batch `save` and retries.** An omitted `id` mints a fresh ULID server-side on every attempt — retrying a batch save whose records had no `id` (e.g. after a transient error) creates duplicates rather than upserting the originals. Supply explicit ids, or make the workflow idempotent some other way, if the step might retry.
+- **Projection freshness.** A batch marks the document's query projection dirty once (rebuilt on the next read) instead of updating it inline per record — the first `document.query`/`count` after a batch pays one rebuild rather than N inline upserts. Single-record writes still update the projection inline.
 
 ### `group.addMember` / `removeMember` / `removeAll` / `checkMembership` / `listMembers` / `listUserMemberships`
 
@@ -935,7 +977,9 @@ runAs = "system"
 capabilities = ["membership"]
 ```
 
-`membership` gates the `group.addMember` / `group.removeMember` / `group.removeAll` steps in a **system** run — without the grant they reject (`group.addMember requires the 'membership' capability`). Read-only group steps (`checkMembership`, `listMembers`, `listUserMemberships`) are never gated, and caller runs are governed by access rules, not capabilities, so the gate never applies to them.
+`membership` gates the `group.addMember` / `group.removeMember` / `group.removeAll` steps in a **system** run — without the grant they reject (`group.addMember requires the 'membership' capability`). Read-only group steps (`checkMembership`, `listMembers`, `listUserMemberships`) are never gated, and caller runs are governed by access rules, not capabilities, so the gate never applies to them. When the group type carries no explicit rule set (no `GroupTypeConfig` row, or one with `ruleSetId` unset), a system run holding `membership` is allowed through anyway — the granted capability stands in for a CEL rule the app never configured. A group type with an explicit rule set is still governed by that rule set, never overridden by the capability.
+
+Grant or revoke `capabilities` on a workflow that already exists with `primitive workflows update <id> --capabilities <list>` (comma-separated; `""` revokes all) — `sync push` only persists `capabilities` when creating a new workflow (see above).
 
 **`iterate-users` is system-only.** A workflow containing an `iterate-users` step must set `runAs = "system"` — otherwise it's rejected at save time (`'iterate-users' is system-only and may appear only in a runAs:"system" workflow`).
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.ts.md
@@ -30,7 +30,7 @@ greeting = "Hello {{ input.name }}"
 ```
 
 Workflow-level fields the engine actually reads:
-`perUserMaxRunning`, `perUserMaxQueued`, `perAppMaxRunning` (default 25), `perAppMaxQueued` (default 10000), `queueTtlSeconds` (default 43200), `dequeueOrder`, `accessRule`, `runAs` (default `caller` — see "Execution identity" below), `capabilities` (system-only grants), `inputSchema`, `outputSchema`, `requiresClientApply` (default `true` — see "Client apply" below), `syncCallable` (default `false` — see "Synchronous invocation" below). Sync pushes the schema fields, access rule, `runAs`/`capabilities`, queue settings, step list, `requiresClientApply`, and `syncCallable`.
+`perUserMaxRunning`, `perUserMaxQueued`, `perAppMaxRunning` (default 25), `perAppMaxQueued` (default 10000), `queueTtlSeconds` (default 43200), `dequeueOrder`, `accessRule`, `runAs` (default `caller` — see "Execution identity" below), `capabilities` (system-only grants), `inputSchema`, `outputSchema`, `requiresClientApply` (default `true` — see "Client apply" below), `syncCallable` (default `false` — see "Synchronous invocation" below). `sync push` forwards every one of these — `name`, `description`, `status`, `accessRule`, `runAs`, queue settings, schemas, `requiresClientApply`, step list — on both a fresh create and a push to an existing workflow, with two exceptions that need a direct CLI update instead: `syncCallable` on an existing workflow (the server re-validates it against the currently-active steps, so `sync push` omits it there — use `primitive workflows update --sync-callable true` after the new steps are live) and `capabilities` on an existing workflow (`sync push` persists `capabilities` on create only — grant or revoke them on an existing workflow with `primitive workflows update --capabilities <list>`, comma-separated, `""` to revoke all).
 
 ### Per-step common fields
 
@@ -351,6 +351,48 @@ kind = "document.save"
 runIf = "outputs.tracker.documentId == null"
 # ... create the user's tracker document
 ```
+
+### `document.save` / `patch` / `delete` — batch mode (`records` / `recordIds`)
+
+Each write step works in exactly one of two modes, never mixed: singular (`recordId` [+ `data`]) or batch (`records` for `save`/`patch`, `recordIds` for `delete`). Batch mode is keyed off the array field being present at all (not off `recordId` being absent) — supplying both a singular and an array field on the same step is a hard non-retryable error. Batch mode resolves the document ACL once and applies every record in one Yjs transaction + one persist + one broadcast **per chunk**, instead of the per-record cost of a `forEach` fan-out.
+
+| Mode | Input | Output |
+|---|---|---|
+| singular | `recordId` (+ `data`) | unchanged: `save`/`patch` → `{ record }`; `delete` → `{ deleted: true, id }` |
+| batch | `records` (save/patch) / `recordIds` (delete) | `save` → `{ saved, savedIds }`; `patch` → `{ patched, patchedIds }`; `delete` → `{ deleted }` |
+
+```toml
+[[steps]]
+id = "upsert-holdings"
+kind = "document.save"
+documentId = "{{ outputs.doc.documentId }}"
+modelName = "holding"
+records = "{{ steps.rows.output.result.rows }}"   # Array<{ id?, ...fields }> — id optional, minted server-side (ulid()) when absent
+
+[[steps]]
+id = "merge-holdings"
+kind = "document.patch"
+documentId = "{{ outputs.doc.documentId }}"
+modelName = "holding"
+records = "{{ steps.rows.output.result.rows }}"   # Array<{ id, ...fields }> — id REQUIRED per element
+
+[[steps]]
+id = "remove-obsolete"
+kind = "document.delete"
+documentId = "{{ outputs.doc.documentId }}"
+modelName = "holding"
+recordIds = "{{ steps.plan.output.result.obsoleteIds }}"   # string[] — a non-existent id is a no-op, not an error
+```
+
+Rules and edge cases:
+
+- **Chunk cap = 100 records** (server constant). A batch of N records runs as `ceil(N / 100)` sequential DO round-trips, not one unbounded transaction.
+- **Validation-first, then fail-fast.** A structural pass runs over every record before the first chunk is sent (well-formed objects; `patch` elements require a non-empty `id`; `recordIds` entries are non-empty strings). A structural failure fails the whole step non-retryably, names the offending index, and writes nothing.
+- **Per-chunk atomicity, not whole-batch atomicity.** Each chunk (≤100 records) commits atomically, but a batch spanning multiple chunks is not atomic across chunks — a failure on chunk *k* leaves chunks `0..k-1` committed. The error names the offending record. Keep a batch ≤100 (one chunk) for all-or-nothing, or design the workflow for idempotent re-runs.
+- **Duplicate ids within one batch:** allowed, last write wins (records apply in id order within the transaction).
+- **Batch failures are non-retryable** — a validation or constraint failure fails the run immediately rather than retrying.
+- **Id-less batch `save` and retries.** An omitted `id` mints a fresh ULID server-side on every attempt — retrying a batch save whose records had no `id` (e.g. after a transient error) creates duplicates rather than upserting the originals. Supply explicit ids, or make the workflow idempotent some other way, if the step might retry.
+- **Projection freshness.** A batch marks the document's query projection dirty once (rebuilt on the next read) instead of updating it inline per record — the first `document.query`/`count` after a batch pays one rebuild rather than N inline upserts. Single-record writes still update the projection inline.
 
 ### `group.addMember` / `removeMember` / `removeAll` / `checkMembership` / `listMembers` / `listUserMemberships`
 
@@ -935,7 +977,9 @@ runAs = "system"
 capabilities = ["membership"]
 ```
 
-`membership` gates the `group.addMember` / `group.removeMember` / `group.removeAll` steps in a **system** run — without the grant they reject (`group.addMember requires the 'membership' capability`). Read-only group steps (`checkMembership`, `listMembers`, `listUserMemberships`) are never gated, and caller runs are governed by access rules, not capabilities, so the gate never applies to them.
+`membership` gates the `group.addMember` / `group.removeMember` / `group.removeAll` steps in a **system** run — without the grant they reject (`group.addMember requires the 'membership' capability`). Read-only group steps (`checkMembership`, `listMembers`, `listUserMemberships`) are never gated, and caller runs are governed by access rules, not capabilities, so the gate never applies to them. When the group type carries no explicit rule set (no `GroupTypeConfig` row, or one with `ruleSetId` unset), a system run holding `membership` is allowed through anyway — the granted capability stands in for a CEL rule the app never configured. A group type with an explicit rule set is still governed by that rule set, never overridden by the capability.
+
+Grant or revoke `capabilities` on a workflow that already exists with `primitive workflows update <id> --capabilities <list>` (comma-separated; `""` revokes all) — `sync push` only persists `capabilities` when creating a new workflow (see above).
 
 **`iterate-users` is system-only.** A workflow containing an `iterate-users` step must set `runAs = "system"` — otherwise it's rejected at save time (`'iterate-users' is system-only and may appear only in a runAs:"system" workflow`).
 

--- a/guides/latest/guides.json
+++ b/guides/latest/guides.json
@@ -15,7 +15,7 @@
     }
   },
   "builtAgainst": {
-    "stampedAt": "2026-07-07",
+    "stampedAt": "2026-07-08",
     "channel": "next",
     "packages": {
       "js-bao-wss-client": "2.0.4",


### PR DESCRIPTION
Automated `docs-next-sync` pass against the library main tips, triggered by the nightly release js-bao-wss#1405.



> **Delta PR.** This PR covers only the library window since the previous sync PR (or since the last merge, if none is open) — it does not contain earlier open sync PRs' content. Merge sync PRs **oldest first**; consecutive ones conflict on the stamp/submodule pin by construction, and `docs-pr-sweep` knows how to rebase and land the chain.

SYNC_STATUS: ready

# docs-next-sync — 2026-07-08 (js-bao-wss 444938b2 → 429808a0)

Truing window: 16 `js-bao-wss` commits since the 2026-07-07 stamp (444938b2), corresponding to 4 merged PRs. `primitive-app-dev` and `swift-primitive-app-dev` had no new commits. No open `primitive-docs` issues existed at scan time (`gh issue list --state open` returned empty), so there were no upstream-keyed or promote-on-parity issues to fold in.

## Commit → disposition

| PR | Commits | Disposition |
|---|---|---|
| #1401 / #1177 — shared TOML→workflow payload builder (`buildWorkflowPayloadFromToml`); fixes `status`/`capabilities`/`perAppMax*`/`queueTtlSeconds` silently dropping on one or more of the three create/update payload call-sites | 429808a0, b8bc5d6e, bdac55bc | **Updated `docs/getting-started/workflows.md`, `guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md`, and `guides/latest/AGENT_GUIDE_TO_PRIMITIVE_CONFIGURATION.template.md`.** The old claim "`sync push` doesn't carry `requiresClientApply`, `syncCallable`, queue caps" is no longer true for `requiresClientApply` and the queue-cap fields (all now round-trip via `sync push` on both create and update) — rewrote to name the two fields that genuinely still need a direct CLI update on an *existing* workflow: `syncCallable` (server re-validates against currently-active steps, unchanged pre-existing behavior) and `capabilities` (server PATCH still doesn't persist it on update — confirmed via the new `workflow-payload-roundtrip.test.ts`, which explicitly asserts `capabilities` create-only). Also found and fixed the same stale "`requiresClientApply` needs a dedicated update command" claim in the Configuration guide's "What sync does NOT carry" section — a third occurrence of the fact the diff didn't touch directly but was already wrong and is now corrected for consistency (cross-page grep per the skill's factual-change guidance). |
| #1400 / #1232 — new `primitive workflows update --capabilities <list>` CLI flag (grant/revoke on an existing workflow; comma-separated, `""` revokes all) | 76d981f4, 2991bd9c | **Drafted new capability.** Documented in `docs/getting-started/workflows.md`'s "Sensitive capabilities" section and in the Workflows/Configuration guide templates, alongside the create-only limitation above (this flag is precisely the CLI fallback needed because `sync push` can't change `capabilities` on an existing workflow). The documented invocation (`primitive workflows update <id> --capabilities membership`) passed the CLI-invocation validation gate against the submodule's `primitive-admin` build. |
| #1403 / #1399 — system-run CEL access-control bug fix: a `runAs:"system"` workflow holding the `membership` capability was still deny-closed when the group type had no explicit rule set (no config row, or a config row with `ruleSetId` unset) | 74c61497, df95d144, 22c487f6 | **No human-doc change — bug fix restoring an already-documented promise.** `docs/getting-started/workflows.md`'s existing statement ("`membership` lets the workflow change group membership... without the grant, refused") was already accurate in its letter and remains so; it never claimed the no-rule-set case worked, so there's no now-false sentence to fix. Added the edge case to `guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md` (agent-guide altitude wants this footgun/edge-case density; the human concept page doesn't). |
| #1382 / #1393 — bulk document write: `document.save`/`document.patch` accept `records` (array), `document.delete` accepts `recordIds` (array); chunk cap 100; new internal `saveMany`/`patchMany`/`deleteMany` on `document-models.ts`, consumed by the workflow document step | c5436e14, 0d5a7379, 5f7632be, 9fa0db5c, eedc3279, f7e465fb, 3bfbd25e, 6547cbe1 | **Drafted new capability.** Added a "Writing many records in one step" subsection to `docs/getting-started/workflows.md`'s Document Steps section (concept-page altitude: the two-mode split, chunk cap, per-chunk-not-whole-batch atomicity, id-less-retry-duplicates caveat) and a denser reference subsection to the Workflows guide template (full rules: validation-first/fail-fast, duplicate-id-last-wins, non-retryable failures, projection-freshness tradeoff) — verified against `src/workflows/steps/document-step.ts` and `src/document-models.ts` (`DOCUMENT_BATCH_CHUNK_CAP = 100`) rather than trusted from the library's own internal `docs/workflows.md` (used as a lead, not a source). This is TOML-only workflow config (server-side step kind), not a client SDK surface — no JS/Swift parity gap. |

## Issues

No open `primitive-docs` issues at scan time — nothing to close, nothing gated, no `Fixes #NN` lines to add.

No parity gaps filed — all four changes are either CLI-only, workflow-TOML-only (platform-neutral, no client SDK surface), or internal server/access-control fixes with no now-false doc claim to correct.

## Gates

- `pnpm submodules:update` + `pnpm build:source-packages` — clean fast-forward (444938b2 → 429808a0), source packages rebuilt.
- `pnpm render:guides` — 20 templates rendered, 36 builds.
- `pnpm check:examples` — green: corpus/guide sync, TypeScript compile (159 files against submodule source), TOML validation (195 blocks incl. the new batch-write and `--capabilities` examples), CLI-invocation validation (460 checked against submodule `primitive-admin`, including the new `workflows update --capabilities` invocation), sync-map check, source-stamp check. (Swift compile skipped — no macOS host in this environment; covered by the macOS CI job per the script's own message.)
- `pnpm stamp:sources` — restamped to 2026-07-08 / 429808a0 after docs were updated to match.
- `npx vitepress build docs` — clean build, no dead links (including the new `#sensitive-capabilities` cross-reference anchor).

No unfixable gate failures this pass — nothing blocked.

---
Review the doc changes and the disposition above, then merge into `next`. Publishing to `main` happens separately at a production release.

> Generated unattended by the Claude Code CLI. Verify facts against source before merging.