### PR TITLE
Document that resource metadata reads are polling-only (#237)

### DIFF
--- a/docs/getting-started/resource-metadata.md
+++ b/docs/getting-started/resource-metadata.md
@@ -54,6 +54,8 @@ primitive metadata set user 01HXY... profile --data '{"tier":"pro","displayName"
 primitive metadata get user 01HXY... profile --json
 ```
 
+Metadata reads are on-demand: a `get` returns the value at the moment of the call, and changes are not pushed to clients. A client that needs current values polls on whatever interval fits its freshness needs. This is a deliberate division of labor: metadata holds configuration and state the server reads, while state that must react in real time on the client belongs in a [document](./working-with-documents.md), where connected clients receive updates automatically.
+
 ### Batch Reads
 
 Read several resources' categories in one call — useful for a listing view that would otherwise issue one request per row. The call always succeeds; per-resource and per-category problems (a missing category, a denied `readRule`) show up inside the results instead of failing the whole batch:

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_RESOURCE_METADATA.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_RESOURCE_METADATA.swift.md
@@ -52,6 +52,7 @@ primitive metadata get-batch --requests '[{"resourceType":"user","resourceId":"0
 - Errors on single read/write: `404 NOT_FOUND` (no such category on that resource type), `403 FORBIDDEN` (`readRule`/`writeRule` denied), `400` (schema validation failure, or writing the reserved `attrs` category → `RESERVED_CATEGORY`).
 - All CLI text output (`keyValue`/`success`/`info`) goes to **stderr** — only `--json` output goes to stdout. A `primitive metadata get ... > out.txt` without `--json` produces an empty file.
 - `set --data` and `--data-file` are mutually available; `--data-file` wins if both are passed. The payload must be a JSON object.
+- **Reads are polling-only.** Metadata reads return point-in-time values; changes are not pushed to clients, and there is no subscription surface. Poll on whatever interval the use case's freshness requires. State that must react in real time on the client belongs in a [document](AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.md) — connected clients receive document updates automatically; metadata is for configuration and state the server reads.
 
 ## Declaring metadata for CEL rules
 
@@ -175,6 +176,7 @@ A write never checks that the target resource exists — a write for a not-yet-c
 - Relying on resource deletion to clean up its metadata — there's no cascade; delete metadata explicitly in the same flow.
 - Trying to create or list category configs from the client SDK — that surface is TOML-sync/admin-REST only.
 - Treating `set()` as a merge — it's a full replace of the category's data.
+- Expecting a metadata change to appear on other clients without a new read — updates are never pushed; poll for freshness, or model live client state in a document instead.
 
 ## Related guides
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_RESOURCE_METADATA.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_RESOURCE_METADATA.template.md
@@ -73,6 +73,7 @@ primitive metadata get-batch --requests '[{"resourceType":"user","resourceId":"0
 - Errors on single read/write: `404 NOT_FOUND` (no such category on that resource type), `403 FORBIDDEN` (`readRule`/`writeRule` denied), `400` (schema validation failure, or writing the reserved `attrs` category → `RESERVED_CATEGORY`).
 - All CLI text output (`keyValue`/`success`/`info`) goes to **stderr** — only `--json` output goes to stdout. A `primitive metadata get ... > out.txt` without `--json` produces an empty file.
 - `set --data` and `--data-file` are mutually available; `--data-file` wins if both are passed. The payload must be a JSON object.
+- **Reads are polling-only.** Metadata reads return point-in-time values; changes are not pushed to clients, and there is no subscription surface. Poll on whatever interval the use case's freshness requires. State that must react in real time on the client belongs in a [document](AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.md) — connected clients receive document updates automatically; metadata is for configuration and state the server reads.
 
 ## Declaring metadata for CEL rules
 
@@ -196,6 +197,7 @@ A write never checks that the target resource exists — a write for a not-yet-c
 - Relying on resource deletion to clean up its metadata — there's no cascade; delete metadata explicitly in the same flow.
 - Trying to create or list category configs from the client SDK — that surface is TOML-sync/admin-REST only.
 - Treating `set()` as a merge — it's a full replace of the category's data.
+- Expecting a metadata change to appear on other clients without a new read — updates are never pushed; poll for freshness, or model live client state in a document instead.
 
 ## Related guides
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_RESOURCE_METADATA.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_RESOURCE_METADATA.ts.md
@@ -71,6 +71,7 @@ primitive metadata get-batch --requests '[{"resourceType":"user","resourceId":"0
 - Errors on single read/write: `404 NOT_FOUND` (no such category on that resource type), `403 FORBIDDEN` (`readRule`/`writeRule` denied), `400` (schema validation failure, or writing the reserved `attrs` category → `RESERVED_CATEGORY`).
 - All CLI text output (`keyValue`/`success`/`info`) goes to **stderr** — only `--json` output goes to stdout. A `primitive metadata get ... > out.txt` without `--json` produces an empty file.
 - `set --data` and `--data-file` are mutually available; `--data-file` wins if both are passed. The payload must be a JSON object.
+- **Reads are polling-only.** Metadata reads return point-in-time values; changes are not pushed to clients, and there is no subscription surface. Poll on whatever interval the use case's freshness requires. State that must react in real time on the client belongs in a [document](AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.md) — connected clients receive document updates automatically; metadata is for configuration and state the server reads.
 
 ## Declaring metadata for CEL rules
 
@@ -194,6 +195,7 @@ A write never checks that the target resource exists — a write for a not-yet-c
 - Relying on resource deletion to clean up its metadata — there's no cascade; delete metadata explicitly in the same flow.
 - Trying to create or list category configs from the client SDK — that surface is TOML-sync/admin-REST only.
 - Treating `set()` as a merge — it's a full replace of the category's data.
+- Expecting a metadata change to appear on other clients without a new read — updates are never pushed; poll for freshness, or model live client state in a document instead.
 
 ## Related guides
 


### PR DESCRIPTION
## What the issue reported

#237 asks the docs to state, wherever resource metadata reads are described, that metadata has no change-notification/push mechanism — reads are plain polling `GET`s. This is a deliberate upstream design decision (Primitive-Labs/js-bao-wss#1364, item 3), and adopters have hit the surprise expecting metadata to behave like documents.

## Verified against source

The client metadata API (`library_repos/js-bao-wss/src/client/api/resourceMetadataApi.ts`) exposes exactly `get`/`set`/`getBatch`, all plain request/response — no subscribe/watch/notification surface exists anywhere in the client.

## What changed

- `docs/getting-started/resource-metadata.md` — new paragraph after the read/write example: reads are on-demand, changes are not pushed, poll for freshness; real-time client state belongs in a document.
- `guides/latest/AGENT_GUIDE_TO_PRIMITIVE_RESOURCE_METADATA.template.md` — matching "Reads are polling-only" bullet in the values section, plus an anti-pattern entry (expecting a metadata change to appear on other clients without a new read). Builds re-rendered via `pnpm render:guides`.

Wording is framed as the design contract (per STYLE.md's never-say rules), not a feature-gap callout, and stays language-neutral in the guide since the bullet renders into both builds.

## Validation

- `pnpm check:examples` — green end to end (parity, TS+Swift compilation, TOML, guide render/registry, CLI, source stamp)
- `npx vitepress build docs` — green
- docs-page-review + docs-sync-check run on the touched pair — pass; both review suggestions applied

Fixes #237