### PR TITLE
Docs next-sync 2026-07-09: blob.delete, caller-mode blob policy, +primitivetest auto-provision, import batching, template loader/onboarding

### DIFF
--- a/docs-sources.json
+++ b/docs-sources.json
@@ -1,9 +1,9 @@
 {
   "channel": "next",
-  "stampedAt": "2026-07-08",
+  "stampedAt": "2026-07-09",
   "libraries": {
     "js-bao-wss": {
-      "commit": "429808a0ea9029ef904b8bde25b69bac71bbed65",
+      "commit": "38c5a497af89b21a5b56d6e05c1f259d89f9af69",
       "npm": {
         "js-bao-wss-client": "2.0.4",
         "js-bao": "0.5.1",
@@ -11,9 +11,9 @@
       }
     },
     "primitive-app-dev": {
-      "commit": "89ccafd9137cdeab6336d82dd183d48bcb8c2502",
+      "commit": "ae7df678cb3ac5dc8a9f8c6d936ba36eed880acb",
       "npm": {
-        "primitive-app": "3.0.2"
+        "primitive-app": "3.0.3"
       }
     },
     "swift-primitive-app-dev": {

--- a/docs/getting-started/authentication.md
+++ b/docs/getting-started/authentication.md
@@ -32,6 +32,7 @@ Both starter templates ship a drop-in login flow:
   appName="My App"
   defaultContinueRoute="home"
   emailAuthMethod="one_time_code"
+  onboardingRoute="onboarding"
 />
 ```
 
@@ -54,7 +55,7 @@ AuthGateView(
 | Component | `PrimitiveLogin` | `PrimitiveLoginView`, wrapped by `AuthGateView` |
 | Email sign-in | `emailAuthMethod`: `"magic_link"` (default) or `"one_time_code"` | One-time code |
 | Social sign-in | Google button appears automatically when configured | Google and Sign in with Apple buttons appear automatically when configured (Google runs in an `ASWebAuthenticationSession` sheet) |
-| After sign-in | Navigates to `defaultContinueRoute` | Renders the `AuthGateView` content closure |
+| After sign-in | New users pass through the template's `/onboarding` step (profile completion + passkey prompt), then land on `defaultContinueRoute` | Renders the `AuthGateView` content closure |
 
 ### Choosing Your Email Sign-In Method (Web)
 
@@ -108,7 +109,7 @@ That's it — the template's login component automatically shows a "Sign in with
 
 ## Passkeys (WebAuthn)
 
-Passkeys let returning users sign in with biometrics (fingerprint, face) or hardware security keys. The web template's `PrimitiveLogin` flow supports passkeys automatically — users can register a passkey after signing in, then use it for future logins.
+Passkeys let returning users sign in with biometrics (fingerprint, face) or hardware security keys. The web template's `PrimitiveLogin` flow supports passkeys automatically — the onboarding step prompts users to register one after sign-in, whichever method they signed in with, and they can use it for future logins.
 
 On iOS, the client wraps Apple's `AuthenticationServices` in two one-call helpers — `client.auth.signInWithPasskey()` and `client.auth.registerPasskey(deviceName:)` — and the iOS template offers passkey enrollment after a first sign-in by another method, then lists and manages saved passkeys from the profile screen. Passkeys require the app's associated-domains entitlement to list your RP domain; see [Deep links and universal links](#deep-links-and-universal-links).
 
@@ -160,7 +161,7 @@ Display `AUTH_USER_DISABLED` in your sign-in UI as a distinct error so the user 
 
 ## Test User Sign-In for Automated Testing
 
-For integration tests and local dev, Primitive supports a `+primitivetest` OTP bypass: whitelist a base email per app, and derived addresses like `alice+primitivetest-teacher@example.com` sign in through the normal OTP flow with the magic code `000000` — no real email round-trip. One mailbox covers a whole fleet of role-distinguished test users.
+For integration tests and local dev, Primitive supports a `+primitivetest` OTP bypass: whitelist a base email per app, and derived addresses like `alice+primitivetest-teacher@example.com` sign in through the normal OTP flow with the magic code `000000` — no real email round-trip, and a first sign-in provisions the account through the app's normal signup path. One mailbox covers a whole fleet of role-distinguished test users.
 
 See [Test Users for Automated Testing](./primitive-cli.md#test-users-for-automated-testing) on the CLI page for setup, the sign-in pattern, and the security guardrails.
 

--- a/docs/getting-started/blobs-and-files.md
+++ b/docs/getting-started/blobs-and-files.md
@@ -116,7 +116,7 @@ Signed URLs:
 
 - Are safe to put in `<img>` tags or hand to clients that can't attach auth headers
 - Expire after the time you specify — from 30 seconds up to 24 hours (default 5 minutes)
-- Respect the bucket's preset at generation time — if the user can't read, the call fails
+- Respect the bucket's preset at generation time — if the user can't share, the call fails
 - Don't require the recipient to be authenticated during the valid window
 
 Use a short expiry for user-facing URLs and regenerate as needed.
@@ -163,6 +163,20 @@ templateType = "report-ready"
 to = "{{ input.email }}"
 variables = { downloadUrl = "{{ steps.report-url.url }}" }
 ```
+
+When a flow is done with a blob — a temporary snapshot, an intermediate artifact — clean it up with `blob.delete`:
+
+```toml
+[[steps]]
+id = "cleanup"
+kind = "blob.delete"
+bucketKey = "reports"
+blobId = "{{ steps.save-report.blobId }}"
+```
+
+`blob.delete` returns `{ deleted: true, blobId, bucketId }` and reports success even when the blob is already gone, so a retried run doesn't fail on cleanup it already did. (For blobs with a natural lifespan, a [TTL tier](#ttl-tiers) expires them without any step at all.)
+
+Blob steps in a `runAs = "caller"` workflow enforce the bucket's [preset or rule set](#access-presets) with the same per-operation granularity as direct client calls: upload checks `write`, download checks `read`, signedUrl checks `share`, delete checks `delete`. A `runAs = "system"` run is app-privileged and skips the bucket policy.
 
 ## Buckets vs. Document Blobs
 

--- a/docs/getting-started/primitive-cli.md
+++ b/docs/getting-started/primitive-cli.md
@@ -510,7 +510,7 @@ Each whitelisted base authorizes unlimited derived addresses of the form `<base-
 
 :::
 
-The derived account must already exist as a user in this app — invite it ahead of time or seed it as part of test setup. The bypass never auto-provisions, which keeps a public-mode app from being signed up as `attacker+primitivetest@<whitelisted>`.
+A first sign-in provisions the derived account through the same signup path as a real user, and the response's `isNewUser` reflects whether the account was just created — so first-run and new-user flows can be exercised through the bypass. The app's signup-mode gates apply exactly as for a normal signup: an invite-only app still requires an invitation or invite token (or adds the address to the waitlist when that's enabled), and domain mode still rejects disallowed domains. The whitelist is what keeps provisioning safe — only the app owner's own `+primitivetest` derivatives are eligible.
 
 Guardrails:
 

--- a/docs/getting-started/workflows.md
+++ b/docs/getting-started/workflows.md
@@ -174,7 +174,7 @@ A workflow runs on the server, but its result often belongs in a **document** �
 2. When a run reaches `apply_pending`, a client calls `claimApply()` (an exclusive, time-limited claim), runs the handler, then `confirmApply()` — or `releaseApply()` on failure so another client can retry.
 3. `define(...)` wraps this loop for you — when the status event arrives, the client claims the lease, runs your handler, and confirms (or releases on a thrown error). Most apps never call claim/confirm directly.
 
-If a workflow's output doesn't need to land in a document — it writes to databases, sends email, returns a value — leave `requiresClientApply` off. Server-only workflows (cron-fired jobs especially) should set it to `false` explicitly, otherwise runs sit in `apply_pending` waiting for a client that never comes:
+If a workflow's output doesn't need to land in a document — it writes to databases, sends email, returns a value — leave `requiresClientApply` off. Server-only workflows (cron- and webhook-fired jobs especially) should set it to `false` explicitly, otherwise runs sit in `apply_pending` waiting for a client that never comes:
 
 ```bash
 primitive workflows update <workflow-id> --requires-client-apply false
@@ -294,7 +294,7 @@ Push the rule with `primitive sync push` like any other workflow config, or chan
 
 ## System Workflows
 
-By default a workflow runs **as the user who started it** (`runAs = "caller"`): every step acts with that member's own permissions — it touches only documents they can access, and its group and data operations are checked against their roles. This is the safe default, and most workflows want it.
+By default a workflow runs **as the user who started it** (`runAs = "caller"`): every step acts with that member's own permissions — it touches only documents they can access, its group and data operations are checked against their roles, and its blob steps are checked against the bucket's access policy. This is the safe default, and most workflows want it.
 
 Set `runAs = "system"` to run a workflow as the **app itself** instead of as any one user:
 
@@ -463,7 +463,7 @@ Every step has an `id` (unique within the workflow) and a `kind` (the step type)
 | `workflow.call` | Run a child workflow synchronously, inline (use `forEach` to fan out) |
 | `block.call` | Invoke a prompt, integration, script, or workflow block selected by `blockType` — a unified wrapper over the four steps above |
 | `email.send` | Send an email (template-based or inline) |
-| `blob.upload` / `blob.download` / `blob.signedUrl` | Read, write, or sign blob URLs |
+| `blob.upload` / `blob.download` / `blob.signedUrl` / `blob.delete` | Write, read, sign URLs for, or delete bucket blobs |
 | `analytics.write` / `analytics.query` | Emit analytics events or query server-side aggregates |
 | `noop` | Return `{ message, payload }`; useful as a placeholder |
 
@@ -953,7 +953,7 @@ templateType = "announcement"
 
 ### Blob Steps
 
-`blob.upload`, `blob.download`, and `blob.signedUrl` read, write, and sign URLs for files in [blob buckets](./blobs-and-files.md) — the standard way to hand a generated file (a PDF report, an export) to users:
+`blob.upload`, `blob.download`, `blob.signedUrl`, and `blob.delete` write, read, sign URLs for, and delete files in [blob buckets](./blobs-and-files.md) — the standard way to hand a generated file (a PDF report, an export) to users, and to clean one up when a flow is done with it:
 
 ```toml
 [[steps]]
@@ -972,7 +972,9 @@ blobId = "{{ steps.save.blobId }}"
 expiresInSeconds = 3600
 ```
 
-`blob.upload` returns the `blobId`; `blob.signedUrl` mints a time-limited URL you can email or return to the client. See [Blobs and Files](./blobs-and-files.md#using-buckets-in-workflows) for the full pattern.
+`blob.upload` returns the `blobId`; `blob.signedUrl` mints a time-limited URL you can email or return to the client. `blob.delete` removes a blob by `blobId` and returns `{ deleted: true, blobId, bucketId }` — it reports success even when the blob is already gone, so a retried run doesn't fail on cleanup it already did.
+
+When the run is `runAs = "caller"` (the default), every blob step enforces the bucket's [access preset or rule set](./blobs-and-files.md#access-presets) with the same per-operation granularity as direct client calls — upload checks `write`, download checks `read`, signedUrl checks `share`, delete checks `delete`. A `runAs = "system"` run is app-privileged and skips the bucket policy. See [Blobs and Files](./blobs-and-files.md#using-buckets-in-workflows) for the full pattern.
 
 ### Analytics Steps
 

--- a/examples/auth/test-user-otp.swift
+++ b/examples/auth/test-user-otp.swift
@@ -1,7 +1,8 @@
 import JsBaoClient
 
 // Sign in a `+primitivetest` account in an integration test using the magic
-// OTP code. The derived account must already exist as a user in the app.
+// OTP code. A first verify provisions the account through the normal signup
+// path (the app's signup-mode gates apply).
 func signInTestUser(client: JsBaoClient) async throws {
   // #region example
   // Requires the app owner to have added "alice@example.com" to the app's

--- a/examples/auth/test-user-otp.ts
+++ b/examples/auth/test-user-otp.ts
@@ -1,7 +1,8 @@
 import type { JsBaoClient } from "js-bao-wss-client";
 
 // Sign in a `+primitivetest` account in an integration test using the magic
-// OTP code. The derived account must already exist as a user in the app.
+// OTP code. A first verify provisions the account through the normal signup
+// path (the app's signup-mode gates apply).
 export async function signInTestUser(client: JsBaoClient) {
   // #region example
   // Requires the app owner to have added "alice@example.com" to the app's

--- a/examples/documents/dataloader-glue.ts
+++ b/examples/documents/dataloader-glue.ts
@@ -13,6 +13,7 @@ export function useTodoList(props: { listId: string }, showCompleted: boolean, d
   const {
     data: todos,
     initialDataLoaded,
+    showSkeleton, // gate loading UI on this: true while the document opens, suppressed on fast warm reloads
     reload,
   } = useJsBaoDataLoader<{ items: TodoItem[]; total: number }>({
     subscribeTo: [TodoItem],
@@ -26,5 +27,5 @@ export function useTodoList(props: { listId: string }, showCompleted: boolean, d
     },
   });
   // #endregion example
-  return { todos, initialDataLoaded, reload };
+  return { todos, initialDataLoaded, showSkeleton, reload };
 }

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_AUTHENTICATION.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_AUTHENTICATION.swift.md
@@ -543,7 +543,7 @@ Guardrails:
 
 - Per-app whitelist. The base address (`alice@example.com`) must be on the app's `testAccountBaseEmails` list — explicit owner consent.
 - Only `+primitivetest<suffix>` derivatives are eligible. The bare base is never a test account.
-- The derived user must already exist as an `AppUser` in this app — bypass never auto-provisions.
+- First verify provisions the derived user through the standard signup path and returns the real `isNewUser`, so first-run/new-user flows are testable through the bypass. Signup-mode gates apply as 403s exactly like a normal signup: `INVITATION_REQUIRED` (invite-only, no invitation), `ADDED_TO_WAITLIST` (invite-only with waitlist — the address is added), `DOMAIN_NOT_ALLOWED` (domain mode); an `inviteToken` is honored and provisions with the invitation's role (member-role invitations only — see the reserved-email boundary below).
 - Issued tokens are short-lived (~30 minutes) and carry a `primitiveBypass: true` claim that gets re-checked on every request, so removing the base from the whitelist revokes sessions immediately.
 - `+primitivetest*` accounts can sign in as ordinary members but are reserved at admin / owner / invitation boundaries — they cannot hold those roles.
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_AUTHENTICATION.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_AUTHENTICATION.template.md
@@ -548,6 +548,10 @@ Web-template glue (Vue) gating `<router-view>` on the auth flag:
 
 Components inside the gate **don't** need to null-check `currentUser` or watch `isAuthenticated`. If auth is lost, they unmount.
 
+### Onboarding hand-off (template)
+
+Every sign-in method in the template funnels through a shared `/onboarding` route (`PrimitiveOnboarding`): `PrimitiveLogin` (OTP verify and passkey conditional UI) and the OAuth/magic-link callback push to it with `continueURL`, `isNewUser`, and `promptAddPasskey` as query params (state survives a refresh), and the route handles profile completion and the passkey prompt before navigating to the continue URL. Configure the target with `onboardingRoute` or `onboardingUrl` on `PrimitiveLogin`/`PrimitiveOauthCallback`; omit both and sign-in navigates straight to the continue URL. Customize the step (name/avatar required or optional, passkey prompt) via the `PrimitiveOnboarding` props where the route is declared.
+
 ### Reactive watchers (downstream stores)
 
 Web-template glue (Vue) reacting to auth-state transitions — initialize on sign-in, reset on sign-out:
@@ -665,7 +669,7 @@ Guardrails:
 
 - Per-app whitelist. The base address (`alice@example.com`) must be on the app's `testAccountBaseEmails` list — explicit owner consent.
 - Only `+primitivetest<suffix>` derivatives are eligible. The bare base is never a test account.
-- The derived user must already exist as an `AppUser` in this app — bypass never auto-provisions.
+- First verify provisions the derived user through the standard signup path and returns the real `isNewUser`, so first-run/new-user flows are testable through the bypass. Signup-mode gates apply as 403s exactly like a normal signup: `INVITATION_REQUIRED` (invite-only, no invitation), `ADDED_TO_WAITLIST` (invite-only with waitlist — the address is added), `DOMAIN_NOT_ALLOWED` (domain mode); an `inviteToken` is honored and provisions with the invitation's role (member-role invitations only — see the reserved-email boundary below).
 - Issued tokens are short-lived (~30 minutes) and carry a `primitiveBypass: true` claim that gets re-checked on every request, so removing the base from the whitelist revokes sessions immediately.
 - `+primitivetest*` accounts can sign in as ordinary members but are reserved at admin / owner / invitation boundaries — they cannot hold those roles.
 
@@ -706,7 +710,7 @@ Overrides are tracked by `primitive sync` (TOML in `email-templates/`). Custom t
 6. Gate your app layout on `isAuthenticated` so child components can assume `currentUser`.
 7. Watch `isAuthenticated` reactively in downstream stores (it changes both directions).
 8. Sequence: auth ready → open documents → query data.
-9. Offer passkey registration when `promptAddPasskey` is true after magic-link/OTP verify.
+9. The template's `/onboarding` route owns the post-sign-in passkey prompt and profile completion for every method; a hand-rolled auth UI should offer passkey registration when `promptAddPasskey` is true after verify.
 10. Customize email templates via CLI if you need branded auth emails.
 {{/lang}}
 {{#lang swift}}

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_AUTHENTICATION.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_AUTHENTICATION.ts.md
@@ -543,6 +543,10 @@ Web-template glue (Vue) gating `<router-view>` on the auth flag:
 
 Components inside the gate **don't** need to null-check `currentUser` or watch `isAuthenticated`. If auth is lost, they unmount.
 
+### Onboarding hand-off (template)
+
+Every sign-in method in the template funnels through a shared `/onboarding` route (`PrimitiveOnboarding`): `PrimitiveLogin` (OTP verify and passkey conditional UI) and the OAuth/magic-link callback push to it with `continueURL`, `isNewUser`, and `promptAddPasskey` as query params (state survives a refresh), and the route handles profile completion and the passkey prompt before navigating to the continue URL. Configure the target with `onboardingRoute` or `onboardingUrl` on `PrimitiveLogin`/`PrimitiveOauthCallback`; omit both and sign-in navigates straight to the continue URL. Customize the step (name/avatar required or optional, passkey prompt) via the `PrimitiveOnboarding` props where the route is declared.
+
 ### Reactive watchers (downstream stores)
 
 Web-template glue (Vue) reacting to auth-state transitions — initialize on sign-in, reset on sign-out:
@@ -641,7 +645,7 @@ Guardrails:
 
 - Per-app whitelist. The base address (`alice@example.com`) must be on the app's `testAccountBaseEmails` list — explicit owner consent.
 - Only `+primitivetest<suffix>` derivatives are eligible. The bare base is never a test account.
-- The derived user must already exist as an `AppUser` in this app — bypass never auto-provisions.
+- First verify provisions the derived user through the standard signup path and returns the real `isNewUser`, so first-run/new-user flows are testable through the bypass. Signup-mode gates apply as 403s exactly like a normal signup: `INVITATION_REQUIRED` (invite-only, no invitation), `ADDED_TO_WAITLIST` (invite-only with waitlist — the address is added), `DOMAIN_NOT_ALLOWED` (domain mode); an `inviteToken` is honored and provisions with the invitation's role (member-role invitations only — see the reserved-email boundary below).
 - Issued tokens are short-lived (~30 minutes) and carry a `primitiveBypass: true` claim that gets re-checked on every request, so removing the base from the whitelist revokes sessions immediately.
 - `+primitivetest*` accounts can sign in as ordinary members but are reserved at admin / owner / invitation boundaries — they cannot hold those roles.
 
@@ -681,5 +685,5 @@ Overrides are tracked by `primitive sync` (TOML in `email-templates/`). Custom t
 6. Gate your app layout on `isAuthenticated` so child components can assume `currentUser`.
 7. Watch `isAuthenticated` reactively in downstream stores (it changes both directions).
 8. Sequence: auth ready → open documents → query data.
-9. Offer passkey registration when `promptAddPasskey` is true after magic-link/OTP verify.
+9. The template's `/onboarding` route owns the post-sign-in passkey prompt and profile completion for every method; a hand-rolled auth UI should offer passkey registration when `promptAddPasskey` is true after verify.
 10. Customize email templates via CLI if you need branded auth emails.

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_BLOB_BUCKETS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_BLOB_BUCKETS.swift.md
@@ -183,7 +183,7 @@ The signed-URL request endpoint requires `member` permission on the app, so gene
 
 ## Workflow integration
 
-The `blob.upload`, `blob.download`, and `blob.signedUrl` workflow steps write to and read from buckets. Steps reference the bucket by `bucketId` or `bucketKey`. See the [Workflows guide](AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.md).
+The `blob.upload`, `blob.download`, `blob.signedUrl`, and `blob.delete` workflow steps write to, read from, sign URLs for, and delete from buckets. Steps reference the bucket by `bucketId` or `bucketKey`. A `runAs:"caller"` run evaluates this bucket policy per op with the same mapping as direct calls (upload → `write`, download → `read`, signedUrl → `share`, delete → `delete`); a `runAs:"system"` run is app-privileged and skips it. See the [Workflows guide](AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.md).
 
 ---
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_BLOB_BUCKETS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_BLOB_BUCKETS.template.md
@@ -164,7 +164,7 @@ imgEl.src = url;
 
 ## Workflow integration
 
-The `blob.upload`, `blob.download`, and `blob.signedUrl` workflow steps write to and read from buckets. Steps reference the bucket by `bucketId` or `bucketKey`. See the [Workflows guide](AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.md).
+The `blob.upload`, `blob.download`, `blob.signedUrl`, and `blob.delete` workflow steps write to, read from, sign URLs for, and delete from buckets. Steps reference the bucket by `bucketId` or `bucketKey`. A `runAs:"caller"` run evaluates this bucket policy per op with the same mapping as direct calls (upload → `write`, download → `read`, signedUrl → `share`, delete → `delete`); a `runAs:"system"` run is app-privileged and skips it. See the [Workflows guide](AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.md).
 
 ---
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_BLOB_BUCKETS.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_BLOB_BUCKETS.ts.md
@@ -202,7 +202,7 @@ imgEl.src = url;
 
 ## Workflow integration
 
-The `blob.upload`, `blob.download`, and `blob.signedUrl` workflow steps write to and read from buckets. Steps reference the bucket by `bucketId` or `bucketKey`. See the [Workflows guide](AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.md).
+The `blob.upload`, `blob.download`, `blob.signedUrl`, and `blob.delete` workflow steps write to, read from, sign URLs for, and delete from buckets. Steps reference the bucket by `bucketId` or `bucketKey`. A `runAs:"caller"` run evaluates this bucket policy per op with the same mapping as direct calls (upload → `write`, download → `read`, signedUrl → `share`, delete → `delete`); a `runAs:"system"` run is app-privileged and skips it. See the [Workflows guide](AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.md).
 
 ---
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.swift.md
@@ -284,7 +284,7 @@ primitive databases records query <id> <model> --filter '{"status":"open"}'
 
 # Data migration (records + indexes + constraints; type config excluded — run sync push on target first)
 primitive databases export <id> --output ./out
-primitive databases import ./out --overwrite [--dry-run]
+primitive databases import ./out --overwrite [--dry-run] [--batch-size 5000] [--stop-on-error]
 
 # CSV bulk import — load a CSV file into a database via a batch save operation
 primitive databases import-csv <database-id> <file.csv> --model <name> \
@@ -292,6 +292,8 @@ primitive databases import-csv <database-id> <file.csv> --model <name> \
   [--types '{"price":"number"}'] [--id-column <col>] [--batch-size 5000] \
   [--delimiter ,] [--dry-run] [--stop-on-error] [--json]
 ```
+
+`databases import` writes records in chunked batch requests: `--batch-size` sets records per request (default 5000, ceiling 25000; an invalid value fails before any write). A failing chunk is reported and the run continues by default — the command still exits non-zero at the end; `--stop-on-error` aborts the whole run (including a multi-database export dir) at the first failing chunk. Record upserts are keyed by `_id`, so re-running an import after a partial failure is safe.
 
 `database-types delete <type>` refuses with a 409 when live database instances of that type still exist — delete the instances first (`primitive databases delete <id>`) or pass `--force` to delete the type anyway (this orphans the instances). `-y`/`--yes` only skips the confirmation prompt; it does not bypass the guard.
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.template.md
@@ -251,7 +251,7 @@ primitive databases records query <id> <model> --filter '{"status":"open"}'
 
 # Data migration (records + indexes + constraints; type config excluded — run sync push on target first)
 primitive databases export <id> --output ./out
-primitive databases import ./out --overwrite [--dry-run]
+primitive databases import ./out --overwrite [--dry-run] [--batch-size 5000] [--stop-on-error]
 
 # CSV bulk import — load a CSV file into a database via a batch save operation
 primitive databases import-csv <database-id> <file.csv> --model <name> \
@@ -259,6 +259,8 @@ primitive databases import-csv <database-id> <file.csv> --model <name> \
   [--types '{"price":"number"}'] [--id-column <col>] [--batch-size 5000] \
   [--delimiter ,] [--dry-run] [--stop-on-error] [--json]
 ```
+
+`databases import` writes records in chunked batch requests: `--batch-size` sets records per request (default 5000, ceiling 25000; an invalid value fails before any write). A failing chunk is reported and the run continues by default — the command still exits non-zero at the end; `--stop-on-error` aborts the whole run (including a multi-database export dir) at the first failing chunk. Record upserts are keyed by `_id`, so re-running an import after a partial failure is safe.
 
 `database-types delete <type>` refuses with a 409 when live database instances of that type still exist — delete the instances first (`primitive databases delete <id>`) or pass `--force` to delete the type anyway (this orphans the instances). `-y`/`--yes` only skips the confirmation prompt; it does not bypass the guard.
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.ts.md
@@ -280,7 +280,7 @@ primitive databases records query <id> <model> --filter '{"status":"open"}'
 
 # Data migration (records + indexes + constraints; type config excluded — run sync push on target first)
 primitive databases export <id> --output ./out
-primitive databases import ./out --overwrite [--dry-run]
+primitive databases import ./out --overwrite [--dry-run] [--batch-size 5000] [--stop-on-error]
 
 # CSV bulk import — load a CSV file into a database via a batch save operation
 primitive databases import-csv <database-id> <file.csv> --model <name> \
@@ -288,6 +288,8 @@ primitive databases import-csv <database-id> <file.csv> --model <name> \
   [--types '{"price":"number"}'] [--id-column <col>] [--batch-size 5000] \
   [--delimiter ,] [--dry-run] [--stop-on-error] [--json]
 ```
+
+`databases import` writes records in chunked batch requests: `--batch-size` sets records per request (default 5000, ceiling 25000; an invalid value fails before any write). A failing chunk is reported and the run continues by default — the command still exits non-zero at the end; `--stop-on-error` aborts the whole run (including a multi-database export dir) at the first failing chunk. Record upserts are keyed by `_id`, so re-running an import after a partial failure is safe.
 
 `database-types delete <type>` refuses with a 409 when live database instances of that type still exist — delete the instances first (`primitive databases delete <id>`) or pass `--force` to delete the type anyway (this orphans the instances). `-y`/`--yes` only skips the confirmation prompt; it does not bypass the guard.
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.template.md
@@ -798,7 +798,7 @@ It handles four key concerns:
 
 1. **Waiting for documents to be ready** - The `documentReady` ref/computed tells the loader when all required documents have been opened. Queries won't run until `documentReady` is true, preventing errors from querying before documents are available.
 
-2. **Knowing when UI is ready to render** - The `initialDataLoaded` ref becomes true after the first successful data load, letting you show loading states appropriately.
+2. **Knowing when UI is ready to render** - The `initialDataLoaded` ref becomes true after the first successful data load, and the `showSkeleton` ref gates loading UI without flashing: it is true immediately while the document is still opening, but on reloads after that it only turns true once the load has run longer than `skeletonDelayMs` (option, default 100 ms) — a fast warm reload never flashes a skeleton.
 
 3. **Subscribing to model changes** - When any model in `subscribeTo` changes (local edits or sync from other clients), the loader automatically re-runs `loadData` to keep the UI current.
 
@@ -822,8 +822,8 @@ Under the hood it wraps the same compiled client calls documented above — `Mod
 - **Return a single structured object** from `loadData`
 - NEVER add a watch on `loadData` results. Do processing inside `loadData`.
 - NEVER rely on component remounting for route param changes. The loader only sees changes via `queryParams`.
-- `initialDataLoaded` becomes true after the first successful `loadData`. Use this (not `documentReady`) with `PrimitiveLoadingGate`.
-- Make rendering/redirect decisions ONLY after `initialDataLoaded` is true.
+- Gate skeleton/loading UI (e.g. `PrimitiveLoadingGate`) on `showSkeleton`, not on `documentReady` or raw load state — it handles the initial-load wait and suppresses the warm-reload flash for you.
+- `initialDataLoaded` becomes true after the first successful `loadData`. Make rendering/redirect decisions ONLY after `initialDataLoaded` is true.
 - For side effects after load (like redirects), watch `initialDataLoaded` and act when it becomes true.
 - For sequences of mutations (save/delete/reorder), set `pauseUpdates` while mutating, then call `reload()` afterward to avoid flicker.
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.ts.md
@@ -894,7 +894,7 @@ It handles four key concerns:
 
 1. **Waiting for documents to be ready** - The `documentReady` ref/computed tells the loader when all required documents have been opened. Queries won't run until `documentReady` is true, preventing errors from querying before documents are available.
 
-2. **Knowing when UI is ready to render** - The `initialDataLoaded` ref becomes true after the first successful data load, letting you show loading states appropriately.
+2. **Knowing when UI is ready to render** - The `initialDataLoaded` ref becomes true after the first successful data load, and the `showSkeleton` ref gates loading UI without flashing: it is true immediately while the document is still opening, but on reloads after that it only turns true once the load has run longer than `skeletonDelayMs` (option, default 100 ms) — a fast warm reload never flashes a skeleton.
 
 3. **Subscribing to model changes** - When any model in `subscribeTo` changes (local edits or sync from other clients), the loader automatically re-runs `loadData` to keep the UI current.
 
@@ -914,6 +914,7 @@ Under the hood it wraps the same compiled client calls documented above — `Mod
   const {
     data: todos,
     initialDataLoaded,
+    showSkeleton, // gate loading UI on this: true while the document opens, suppressed on fast warm reloads
     reload,
   } = useJsBaoDataLoader<{ items: TodoItem[]; total: number }>({
     subscribeTo: [TodoItem],
@@ -934,8 +935,8 @@ Under the hood it wraps the same compiled client calls documented above — `Mod
 - **Return a single structured object** from `loadData`
 - NEVER add a watch on `loadData` results. Do processing inside `loadData`.
 - NEVER rely on component remounting for route param changes. The loader only sees changes via `queryParams`.
-- `initialDataLoaded` becomes true after the first successful `loadData`. Use this (not `documentReady`) with `PrimitiveLoadingGate`.
-- Make rendering/redirect decisions ONLY after `initialDataLoaded` is true.
+- Gate skeleton/loading UI (e.g. `PrimitiveLoadingGate`) on `showSkeleton`, not on `documentReady` or raw load state — it handles the initial-load wait and suppresses the warm-reload flash for you.
+- `initialDataLoaded` becomes true after the first successful `loadData`. Make rendering/redirect decisions ONLY after `initialDataLoaded` is true.
 - For side effects after load (like redirects), watch `initialDataLoaded` and act when it becomes true.
 - For sequences of mutations (save/delete/reorder), set `pauseUpdates` while mutating, then call `reload()` afterward to avoid flicker.
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.swift.md
@@ -499,9 +499,9 @@ textBody = "Download: {{ outputs.upload.signedUrl }}"
 
 `to` is a single address (string), not an array. Built-in templates: `magic-link`, `otp`, `document-share`, `document-share-deferred`, `waitlist-invite`, `waitlist-signup-notification`, `admin-invite`, `app-invite`, `access-request-created`, `access-request-resolved`. Register custom types with `primitive email-templates set <type>`. Hourly rate limit: 100 emails per app per hour (`workflowEmailByApp` in `src/config/rate-limits.ts`).
 
-### `blob.upload` / `blob.download` / `blob.signedUrl`
+### `blob.upload` / `blob.download` / `blob.signedUrl` / `blob.delete`
 
-Three separate kinds, NOT one `blob` step with an `action` field.
+Four separate kinds, NOT one `blob` step with an `action` field.
 
 ```toml
 [[steps]]
@@ -528,8 +528,19 @@ kind = "blob.download"
 bucketKey = "reports"
 blobId = "{{ steps.save.blobId }}"
 asBase64 = true                   # default false (returns utf-8 string)
-# Output: { blobId, filename, contentType, numBytes, content?, contentBase64? }
+# Output: { blobId, bucketId, filename, contentType, numBytes, content?, contentBase64? }
+
+[[steps]]
+id = "cleanup"
+kind = "blob.delete"
+bucketKey = "reports"
+blobId = "{{ steps.save.blobId }}"
+# Output: { deleted: true, blobId, bucketId }
 ```
+
+- Every kind takes exactly one of `bucketId` / `bucketKey`; missing both, an unknown bucket, or a missing required param is non-retryable.
+- `blob.delete` is idempotent: it reports `deleted: true` uniformly, including when the blob is already gone — a retried run doesn't fail on cleanup it already did. `blob.signedUrl` never checks blob existence; an authorized caller mints a token even for an absent blob.
+- **Caller-mode access.** In a `runAs:"caller"` run, each kind evaluates the bucket's preset/rule set before the storage op, with the same op mapping as direct client calls: `blob.upload` → `write` (evaluated with `blobId: null`, `createdBy` = the caller), `blob.download` → `read`, `blob.signedUrl` → `share` (minting is gated like sharing, not reading), `blob.delete` → `delete`. Download, signedUrl, and delete load the blob's `createdBy` first so uploader-scoped rules (`record.blobCreatedBy == user.userId`) work; download decides access before revealing whether the blob exists, so a denied caller gets an access error, never not-found. Denial is non-retryable (`"<kind> access denied: …"`). A `runAs:"system"` run skips the bucket policy entirely (app-privileged).
 
 ### `analytics.write` / `analytics.query`
 
@@ -954,8 +965,8 @@ Set `accessRule` once in the `[workflow]` TOML block and it sticks: `primitive s
 
 `runAs` declares the principal a run executes as — `caller` (default) or `system`. It's a top-level `[workflow]` field.
 
-- `runAs = "caller"` (default) — the run executes as the invoking user. Every step acts with that member's permissions: `document.*` steps enforce the caller's per-document ACL, group/data ops are checked against their roles. `accessRule` gates who may start it.
-- `runAs = "system"` — the run executes as the app's synthetic per-app principal (`sys:<appId>`, also the `WorkflowRun` partition key). App-privileged on the **raw** data baseline: direct document/record read/write/delete/manage skips the per-caller ACL. It does **not** bypass a registered database operation's own `access` CEL — a `database.*` step evaluates that rule on every call, system run included (`access = "false"` → `403`; reserve a workflow-only op with `fromWorkflow('key')`, not `"false"`).
+- `runAs = "caller"` (default) — the run executes as the invoking user. Every step acts with that member's permissions: `document.*` steps enforce the caller's per-document ACL, group/data ops are checked against their roles, and `blob.*` steps evaluate the bucket's access policy per op (write/read/share/delete — see the blob steps section). `accessRule` gates who may start it.
+- `runAs = "system"` — the run executes as the app's synthetic per-app principal (`sys:<appId>`, also the `WorkflowRun` partition key). App-privileged on the **raw** data baseline: direct document/record read/write/delete/manage skips the per-caller ACL, and `blob.*` steps skip the bucket policy. It does **not** bypass a registered database operation's own `access` CEL — a `database.*` step evaluates that rule on every call, system run included (`access = "false"` → `403`; reserve a workflow-only op with `fromWorkflow('key')`, not `"false"`).
 
 The invocation gate is enforced once at top-level start (HTTP start/run-sync, cron, webhook, admin test) — never silently downgraded:
 
@@ -1600,7 +1611,7 @@ If a step output contains sensitive data, do NOT `saveAs`. Pipe it directly into
 
 ### Wrong: forgetting `requiresClientApply = false` for server-only workflows
 
-Cron-triggered workflows almost always want `requiresClientApply = false`. Otherwise the run sits in `apply_pending` forever because no client is listening.
+Cron- and webhook-triggered workflows almost always want `requiresClientApply = false`. Otherwise the run sits in `apply_pending` forever because no client is listening.
 
 ```bash
 primitive workflows update <workflow-id> --requires-client-apply false

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md
@@ -499,9 +499,9 @@ textBody = "Download: {{ outputs.upload.signedUrl }}"
 
 `to` is a single address (string), not an array. Built-in templates: `magic-link`, `otp`, `document-share`, `document-share-deferred`, `waitlist-invite`, `waitlist-signup-notification`, `admin-invite`, `app-invite`, `access-request-created`, `access-request-resolved`. Register custom types with `primitive email-templates set <type>`. Hourly rate limit: 100 emails per app per hour (`workflowEmailByApp` in `src/config/rate-limits.ts`).
 
-### `blob.upload` / `blob.download` / `blob.signedUrl`
+### `blob.upload` / `blob.download` / `blob.signedUrl` / `blob.delete`
 
-Three separate kinds, NOT one `blob` step with an `action` field.
+Four separate kinds, NOT one `blob` step with an `action` field.
 
 ```toml
 [[steps]]
@@ -528,8 +528,19 @@ kind = "blob.download"
 bucketKey = "reports"
 blobId = "{{ steps.save.blobId }}"
 asBase64 = true                   # default false (returns utf-8 string)
-# Output: { blobId, filename, contentType, numBytes, content?, contentBase64? }
+# Output: { blobId, bucketId, filename, contentType, numBytes, content?, contentBase64? }
+
+[[steps]]
+id = "cleanup"
+kind = "blob.delete"
+bucketKey = "reports"
+blobId = "{{ steps.save.blobId }}"
+# Output: { deleted: true, blobId, bucketId }
 ```
+
+- Every kind takes exactly one of `bucketId` / `bucketKey`; missing both, an unknown bucket, or a missing required param is non-retryable.
+- `blob.delete` is idempotent: it reports `deleted: true` uniformly, including when the blob is already gone — a retried run doesn't fail on cleanup it already did. `blob.signedUrl` never checks blob existence; an authorized caller mints a token even for an absent blob.
+- **Caller-mode access.** In a `runAs:"caller"` run, each kind evaluates the bucket's preset/rule set before the storage op, with the same op mapping as direct client calls: `blob.upload` → `write` (evaluated with `blobId: null`, `createdBy` = the caller), `blob.download` → `read`, `blob.signedUrl` → `share` (minting is gated like sharing, not reading), `blob.delete` → `delete`. Download, signedUrl, and delete load the blob's `createdBy` first so uploader-scoped rules (`record.blobCreatedBy == user.userId`) work; download decides access before revealing whether the blob exists, so a denied caller gets an access error, never not-found. Denial is non-retryable (`"<kind> access denied: …"`). A `runAs:"system"` run skips the bucket policy entirely (app-privileged).
 
 ### `analytics.write` / `analytics.query`
 
@@ -954,8 +965,8 @@ Set `accessRule` once in the `[workflow]` TOML block and it sticks: `primitive s
 
 `runAs` declares the principal a run executes as — `caller` (default) or `system`. It's a top-level `[workflow]` field.
 
-- `runAs = "caller"` (default) — the run executes as the invoking user. Every step acts with that member's permissions: `document.*` steps enforce the caller's per-document ACL, group/data ops are checked against their roles. `accessRule` gates who may start it.
-- `runAs = "system"` — the run executes as the app's synthetic per-app principal (`sys:<appId>`, also the `WorkflowRun` partition key). App-privileged on the **raw** data baseline: direct document/record read/write/delete/manage skips the per-caller ACL. It does **not** bypass a registered database operation's own `access` CEL — a `database.*` step evaluates that rule on every call, system run included (`access = "false"` → `403`; reserve a workflow-only op with `fromWorkflow('key')`, not `"false"`).
+- `runAs = "caller"` (default) — the run executes as the invoking user. Every step acts with that member's permissions: `document.*` steps enforce the caller's per-document ACL, group/data ops are checked against their roles, and `blob.*` steps evaluate the bucket's access policy per op (write/read/share/delete — see the blob steps section). `accessRule` gates who may start it.
+- `runAs = "system"` — the run executes as the app's synthetic per-app principal (`sys:<appId>`, also the `WorkflowRun` partition key). App-privileged on the **raw** data baseline: direct document/record read/write/delete/manage skips the per-caller ACL, and `blob.*` steps skip the bucket policy. It does **not** bypass a registered database operation's own `access` CEL — a `database.*` step evaluates that rule on every call, system run included (`access = "false"` → `403`; reserve a workflow-only op with `fromWorkflow('key')`, not `"false"`).
 
 The invocation gate is enforced once at top-level start (HTTP start/run-sync, cron, webhook, admin test) — never silently downgraded:
 
@@ -1495,7 +1506,7 @@ If a step output contains sensitive data, do NOT `saveAs`. Pipe it directly into
 
 ### Wrong: forgetting `requiresClientApply = false` for server-only workflows
 
-Cron-triggered workflows almost always want `requiresClientApply = false`. Otherwise the run sits in `apply_pending` forever because no client is listening.
+Cron- and webhook-triggered workflows almost always want `requiresClientApply = false`. Otherwise the run sits in `apply_pending` forever because no client is listening.
 
 ```bash
 primitive workflows update <workflow-id> --requires-client-apply false

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.ts.md
@@ -499,9 +499,9 @@ textBody = "Download: {{ outputs.upload.signedUrl }}"
 
 `to` is a single address (string), not an array. Built-in templates: `magic-link`, `otp`, `document-share`, `document-share-deferred`, `waitlist-invite`, `waitlist-signup-notification`, `admin-invite`, `app-invite`, `access-request-created`, `access-request-resolved`. Register custom types with `primitive email-templates set <type>`. Hourly rate limit: 100 emails per app per hour (`workflowEmailByApp` in `src/config/rate-limits.ts`).
 
-### `blob.upload` / `blob.download` / `blob.signedUrl`
+### `blob.upload` / `blob.download` / `blob.signedUrl` / `blob.delete`
 
-Three separate kinds, NOT one `blob` step with an `action` field.
+Four separate kinds, NOT one `blob` step with an `action` field.
 
 ```toml
 [[steps]]
@@ -528,8 +528,19 @@ kind = "blob.download"
 bucketKey = "reports"
 blobId = "{{ steps.save.blobId }}"
 asBase64 = true                   # default false (returns utf-8 string)
-# Output: { blobId, filename, contentType, numBytes, content?, contentBase64? }
+# Output: { blobId, bucketId, filename, contentType, numBytes, content?, contentBase64? }
+
+[[steps]]
+id = "cleanup"
+kind = "blob.delete"
+bucketKey = "reports"
+blobId = "{{ steps.save.blobId }}"
+# Output: { deleted: true, blobId, bucketId }
 ```
+
+- Every kind takes exactly one of `bucketId` / `bucketKey`; missing both, an unknown bucket, or a missing required param is non-retryable.
+- `blob.delete` is idempotent: it reports `deleted: true` uniformly, including when the blob is already gone — a retried run doesn't fail on cleanup it already did. `blob.signedUrl` never checks blob existence; an authorized caller mints a token even for an absent blob.
+- **Caller-mode access.** In a `runAs:"caller"` run, each kind evaluates the bucket's preset/rule set before the storage op, with the same op mapping as direct client calls: `blob.upload` → `write` (evaluated with `blobId: null`, `createdBy` = the caller), `blob.download` → `read`, `blob.signedUrl` → `share` (minting is gated like sharing, not reading), `blob.delete` → `delete`. Download, signedUrl, and delete load the blob's `createdBy` first so uploader-scoped rules (`record.blobCreatedBy == user.userId`) work; download decides access before revealing whether the blob exists, so a denied caller gets an access error, never not-found. Denial is non-retryable (`"<kind> access denied: …"`). A `runAs:"system"` run skips the bucket policy entirely (app-privileged).
 
 ### `analytics.write` / `analytics.query`
 
@@ -954,8 +965,8 @@ Set `accessRule` once in the `[workflow]` TOML block and it sticks: `primitive s
 
 `runAs` declares the principal a run executes as — `caller` (default) or `system`. It's a top-level `[workflow]` field.
 
-- `runAs = "caller"` (default) — the run executes as the invoking user. Every step acts with that member's permissions: `document.*` steps enforce the caller's per-document ACL, group/data ops are checked against their roles. `accessRule` gates who may start it.
-- `runAs = "system"` — the run executes as the app's synthetic per-app principal (`sys:<appId>`, also the `WorkflowRun` partition key). App-privileged on the **raw** data baseline: direct document/record read/write/delete/manage skips the per-caller ACL. It does **not** bypass a registered database operation's own `access` CEL — a `database.*` step evaluates that rule on every call, system run included (`access = "false"` → `403`; reserve a workflow-only op with `fromWorkflow('key')`, not `"false"`).
+- `runAs = "caller"` (default) — the run executes as the invoking user. Every step acts with that member's permissions: `document.*` steps enforce the caller's per-document ACL, group/data ops are checked against their roles, and `blob.*` steps evaluate the bucket's access policy per op (write/read/share/delete — see the blob steps section). `accessRule` gates who may start it.
+- `runAs = "system"` — the run executes as the app's synthetic per-app principal (`sys:<appId>`, also the `WorkflowRun` partition key). App-privileged on the **raw** data baseline: direct document/record read/write/delete/manage skips the per-caller ACL, and `blob.*` steps skip the bucket policy. It does **not** bypass a registered database operation's own `access` CEL — a `database.*` step evaluates that rule on every call, system run included (`access = "false"` → `403`; reserve a workflow-only op with `fromWorkflow('key')`, not `"false"`).
 
 The invocation gate is enforced once at top-level start (HTTP start/run-sync, cron, webhook, admin test) — never silently downgraded:
 
@@ -1598,7 +1609,7 @@ If a step output contains sensitive data, do NOT `saveAs`. Pipe it directly into
 
 ### Wrong: forgetting `requiresClientApply = false` for server-only workflows
 
-Cron-triggered workflows almost always want `requiresClientApply = false`. Otherwise the run sits in `apply_pending` forever because no client is listening.
+Cron- and webhook-triggered workflows almost always want `requiresClientApply = false`. Otherwise the run sits in `apply_pending` forever because no client is listening.
 
 ```bash
 primitive workflows update <workflow-id> --requires-client-apply false

--- a/guides/latest/guides.json
+++ b/guides/latest/guides.json
@@ -15,13 +15,13 @@
     }
   },
   "builtAgainst": {
-    "stampedAt": "2026-07-08",
+    "stampedAt": "2026-07-09",
     "channel": "next",
     "packages": {
       "js-bao-wss-client": "2.0.4",
       "js-bao": "0.5.1",
       "primitive-admin": "1.0.53",
-      "primitive-app": "3.0.2"
+      "primitive-app": "3.0.3"
     }
   },
   "guides": [


### PR DESCRIPTION
Truing pass against the library main tips (interactive `docs-next-sync` run). Submodules fast-forwarded (js-bao-wss 429808a0 → 38c5a497, primitive-app-dev 89ccafd9 → ae7df67; swift unchanged), sources restamped on the next channel.

## Per-commit disposition

| Library change | Disposition |
|---|---|
| js-bao-wss #1380 (PR #1409) — new `blob.delete` step kind | **Documented**: workflows.md step table + Blob Steps section; blobs-and-files.md workflow section (cleanup stanza, idempotency, TTL cross-ref); WORKFLOWS guide blob section (4th stanza, output shape, idempotency); BLOB_BUCKETS guide integration line |
| js-bao-wss #1406 (PR #1412) — caller-mode blob steps enforce bucket policy | **Documented**: op mapping (upload→write, download→read, signedUrl→**share**, delete→delete) in both products; runAs bullets extended; also fixed blobs-and-files.md's signed-URL bullet which said `read` where the governing op is `share`; download's access-before-existence ordering noted in the guide |
| js-bao-wss #1413 (PR #1414) — `+primitivetest` auto-provisions on first OTP verify | **Updated**: primitive-cli.md (stale "must already exist / never auto-provisions" paragraph replaced with provision-through-signup-path semantics + mode gates), authentication.md, AUTHENTICATION guide guardrail bullet (403 codes: INVITATION_REQUIRED / ADDED_TO_WAITLIST / DOMAIN_NOT_ALLOWED, invite tokens, real isNewUser), shared corpus example comment (`examples/auth/test-user-otp.{ts,swift}`) |
| js-bao-wss #1398 (PR #1410) — `databases import` batch writes | **Updated**: DATABASES guide invocation (+`--batch-size`/`--stop-on-error`) and a semantics paragraph (default 5000/ceiling 25000, continue-and-report with non-zero exit, `_id`-keyed upserts make re-runs safe). import-csv docs verified accurate, unchanged |
| js-bao-wss #1396 (PR #1408) — `databases export` unwrap fix | Internal — bug fix restores documented behavior; no change |
| js-bao-wss #1404 (PR #1407) — webhook path forwards `requiresClientApply` | No correction needed (fix restores documented behavior); extended the "set `requiresClientApply = false`" call-outs from cron-only to cron **and webhook** in both products |
| js-bao-wss #1381 (PR #1394) — reconcile abnormally-ended runs | Internal — no new statuses/model/CLI surface (verified); new admin dispatch routes are below the docs' documented altitude |
| primitive-app-dev bbef9c8 — `useJsBaoDataLoader` `showSkeleton`/`skeletonDelayMs` | **Documented** (ts-scoped): DOCUMENTS guide loading-model concern + rules (gate skeletons on `showSkeleton`, decisions on `initialDataLoaded`), `examples/documents/dataloader-glue.ts`. **Parity gap filed: swift-primitive-app-dev#54** (BaoDataLoader has no anti-flash equivalent — verified in source) |
| primitive-app-dev 81421be — shared `/onboarding` route for all sign-in methods | **Documented**: authentication.md template-login snippet (`onboardingRoute`), after-sign-in table row, passkey prose; AUTHENTICATION guide ts-glue "Onboarding hand-off" section + checklist item 9. Prop-level reference deliberately omitted (template-internal customization, generic-first rule) |
| primitive-app-dev ae7df67 / 0acdb0c / 20d960f / d50fadc | Internal — version bumps, deps, demo env, undocumented prefs glue; no change |

## Issues

- Filed: swift-primitive-app-dev#54 (data-loader anti-flash parity)
- Still open, not this pass's scope: #239 (workflows ACL table document.delete fact — a standing docs bug for the issue sweep, not upstream-keyed), #242 (internal-identifier leaks)
- No open docs issue was unblocked by this window (#237/#238 already have PRs #240/#241)

## Validation

- `pnpm check:examples` — green end to end (TS + Swift compile against the new submodule source, TOML, guide render/registry, 460 CLI invocations, source stamp)
- `npx vitepress build docs` — green
- All facts verified against submodule source by parallel investigation (step params/outputs from `blob-step.ts`, provisioning gates from `otp-controller.ts`/`user-provisioning-service.ts`, CLI flags from `databases.ts` + built CLI help, loader API from `useJsBaoDataLoader.ts`, onboarding wiring from the template router/components)