### PR TITLE
Document native TOML operation syntax, sync migrate-toml, and codegen result-typing limits (#244)

### DIFF
--- a/docs/getting-started/working-with-databases.md
+++ b/docs/getting-started/working-with-databases.md
@@ -49,24 +49,50 @@ name = "list-products"
 type = "query"
 modelName = "product"
 access = "true"
-definition = '{"sort":{"name":1}}'
+
+[operations.definition]
+sort = { name = 1 }
 
 [[operations]]
 name = "get-product"
 type = "query"
 modelName = "product"
 access = "true"
-definition = '{"filter":{"id":"$params.id"}}'
-params = '{"id":{"type":"string","required":true}}'
+
+[operations.definition]
+filter = { id = "$params.id" }
+
+[[operations.params]]
+name = "id"
+type = "string"
+required = true
 
 [[operations]]
 name = "create-product"
 type = "mutation"
 modelName = "product"
 access = "isMemberOf('admin', database.celContext.adminGroupId)"
-definition = '{"operations":[{"op":"save","data":{"name":"$params.name","price":"$params.price","createdBy":"$user.userId"}}]}'
-params = '{"name":{"type":"string","required":true},"price":{"type":"number","required":true}}'
+
+[[operations.definition.operations]]
+op = "save"
+
+[operations.definition.operations.data]
+name = "$params.name"
+price = "$params.price"
+createdBy = "$user.userId"
+
+[[operations.params]]
+name = "name"
+type = "string"
+required = true
+
+[[operations.params]]
+name = "price"
+type = "number"
+required = true
 ```
+
+An operation's `definition` and `params` can also be written as single-line JSON strings (`definition = '{"sort":{"name":1}}'`) — the two forms are equivalent on the server, and several examples below use the compact JSON form. `primitive sync pull` writes new files with TOML tables and keeps whichever form a file already uses; `primitive sync migrate-toml` rewrites a file from JSON strings to TOML tables in place.
 
 ### 3. Push to Server
 
@@ -320,6 +346,8 @@ primitive databases codegen -o ./src/generated/db
 ```
 
 Codegen reads the database-type TOML from the auto-resolved sync directory; pass `--sync-dir <path>` to override it. This reads the `[models.*]` blocks and `[[operations]]` definitions and emits typed interfaces — one per model, plus typed params and results per operation. Fields and params restricted to a fixed set of string values become TypeScript string-literal unions, so invalid values are caught at compile time (enum params are also validated server-side).
+
+Result types are generated from the operation's `type`, not its `definition` — a query with a `projection` is still typed as the full record, pipeline results are typed as a generic step map, and mutation result elements are `unknown` — so declare a local type where a call site needs more precision.
 
 ## Bulk CSV Import
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.swift.md
@@ -92,17 +92,44 @@ name = "listTasks"
 type = "query"
 modelName = "tasks"
 access = "isMemberOf('team', database.celContext.teamId)"
-definition = '{"filter":{"projectId":"$params.projectId"},"sort":{"createdAt":-1},"limit":50}'
-params = '{"projectId":{"type":"string","required":true}}'
+
+[operations.definition]
+filter = { projectId = "$params.projectId" }
+sort = { createdAt = -1 }
+limit = 50
+
+[[operations.params]]
+name = "projectId"
+type = "string"
+required = true
 
 [[operations]]
 name = "createTask"
 type = "mutation"
 modelName = "tasks"
 access = "isMemberOf('team', database.celContext.teamId)"
-definition = '{"operations":[{"op":"save","data":{"title":"$params.title","projectId":"$params.projectId","status":"open","createdBy":"$user.userId"}}]}'
-params = '{"title":{"type":"string","required":true},"projectId":{"type":"string","required":true}}'
+
+[[operations.definition.operations]]
+op = "save"
+
+[operations.definition.operations.data]
+title = "$params.title"
+projectId = "$params.projectId"
+status = "open"
+createdBy = "$user.userId"
+
+[[operations.params]]
+name = "title"
+type = "string"
+required = true
+
+[[operations.params]]
+name = "projectId"
+type = "string"
+required = true
 ```
+
+`definition` and `params` can equivalently be written as single-line JSON strings (`definition = '{"filter":{...}}'`) — see [Operation types](#operation-types) for both forms and `primitive sync migrate-toml` for converting a file.
 
 Push configuration to the server:
 
@@ -145,10 +172,14 @@ primitive sync pull            # Pull current config from server
 primitive sync diff            # Preview changes
 primitive sync push            # Push local config to server
 primitive sync push --dry-run  # See what would change without applying
+primitive sync migrate-toml    # Rewrite database-type files to native [operations.definition] tables
+primitive sync migrate-toml --dry-run  # Preview the rewrite without writing files
 # Override with a fixed path:
 primitive sync init --dir ./config
 primitive sync push --dir ./config
 ```
+
+`migrate-toml` is a purely local rewrite — it converts JSON-string `definition`/`params` fields to native TOML tables in place, semantically identical on the server (see [Operation types](#operation-types) for the two forms and the fallback rules).
 
 The config directory structure:
 
@@ -602,7 +633,48 @@ This also works with `$steps.*` references in pipelines (see [Settings record pa
 
 ### Operation types
 
-Operations are defined in the `[[operations]]` array in the database type TOML file. The `definition` and `params` fields are JSON strings. A `definition` may equivalently be written as an inline TOML table (`definition = { filter = { "$in" = [...] } }`); both forms round-trip stably through `sync push`/`pull`. `sync push` warns (does not block) on an unrecognized filter operator — the supported set is `$eq`, `$ne`, `$gt`, `$gte`, `$lt`, `$lte`, `$in`, `$nin`, `$exists`, `$contains`, `$startsWith`, `$endsWith`, `$containsText`, plus logical `$and`/`$or`.
+Operations are defined in the `[[operations]]` array in the database type TOML file. An operation's `definition` and `params` can be written in two forms, semantically identical on the server:
+
+- **Native TOML tables** — the primary form: `definition` as an `[operations.definition]` table (nested tables like `[operations.definition.filter]`; mutation steps as `[[operations.definition.operations]]` array-of-tables) and `params` as one `[[operations.params]]` entry per parameter (`name`, `type`, `required`, and any other param keys). `sync pull` writes new files in this form. A compact inline table (`definition = { filter = { "$in" = [...] } }`) also counts as native and round-trips stably.
+- **JSON strings** — `definition = '{...}'` and `params = '{...}'` single-line encodings; here `params` is an object keyed by param name rather than an array. The per-op reference examples below use this compact encoding — the JSON inside `definition` is the same shape either way.
+
+The same mutation in both forms:
+
+```toml
+# Native TOML tables
+[[operations]]
+name = "approvePost"
+type = "mutation"
+modelName = "posts"
+access = "isMemberOf('class-teachers', database.id)"
+
+[[operations.definition.operations]]
+op = "patch"
+id = "$params.id"
+
+[operations.definition.operations.data]
+status = "approved"
+
+[[operations.params]]
+name = "id"
+type = "string"
+required = true
+```
+
+```toml
+# JSON-string encoding — same operation
+[[operations]]
+name = "approvePost"
+type = "mutation"
+modelName = "posts"
+access = "isMemberOf('class-teachers', database.id)"
+definition = '{"operations":[{"op":"patch","id":"$params.id","data":{"status":"approved"}}]}'
+params = '{"id":{"type":"string","required":true}}'
+```
+
+The form is **sticky per file**: `sync pull` preserves whichever form each operation already uses (per op, so mixed files stay mixed), so a JSON-string file keeps that shape until you rewrite it — `primitive sync migrate-toml` (add `--dry-run` to preview) converts a file's JSON-string fields to native tables in place as a purely local rewrite. A value TOML cannot represent — a `null`, or a mixed-type array such as `"$and": ["$database.metadata.peerVisible", {...}]` — falls back to a JSON string for that field on emit, with a log line naming the operation; the rest of the file stays native.
+
+`sync push` accepts both forms and warns (does not block) on an unrecognized filter operator — the supported set is `$eq`, `$ne`, `$gt`, `$gte`, `$lt`, `$lte`, `$in`, `$nin`, `$exists`, `$contains`, `$startsWith`, `$endsWith`, `$containsText`, plus logical `$and`/`$or`.
 
 #### Query — read records
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.template.md
@@ -71,17 +71,44 @@ name = "listTasks"
 type = "query"
 modelName = "tasks"
 access = "isMemberOf('team', database.celContext.teamId)"
-definition = '{"filter":{"projectId":"$params.projectId"},"sort":{"createdAt":-1},"limit":50}'
-params = '{"projectId":{"type":"string","required":true}}'
+
+[operations.definition]
+filter = { projectId = "$params.projectId" }
+sort = { createdAt = -1 }
+limit = 50
+
+[[operations.params]]
+name = "projectId"
+type = "string"
+required = true
 
 [[operations]]
 name = "createTask"
 type = "mutation"
 modelName = "tasks"
 access = "isMemberOf('team', database.celContext.teamId)"
-definition = '{"operations":[{"op":"save","data":{"title":"$params.title","projectId":"$params.projectId","status":"open","createdBy":"$user.userId"}}]}'
-params = '{"title":{"type":"string","required":true},"projectId":{"type":"string","required":true}}'
+
+[[operations.definition.operations]]
+op = "save"
+
+[operations.definition.operations.data]
+title = "$params.title"
+projectId = "$params.projectId"
+status = "open"
+createdBy = "$user.userId"
+
+[[operations.params]]
+name = "title"
+type = "string"
+required = true
+
+[[operations.params]]
+name = "projectId"
+type = "string"
+required = true
 ```
+
+`definition` and `params` can equivalently be written as single-line JSON strings (`definition = '{"filter":{...}}'`) — see [Operation types](#operation-types) for both forms and `primitive sync migrate-toml` for converting a file.
 
 Push configuration to the server:
 
@@ -112,10 +139,14 @@ primitive sync pull            # Pull current config from server
 primitive sync diff            # Preview changes
 primitive sync push            # Push local config to server
 primitive sync push --dry-run  # See what would change without applying
+primitive sync migrate-toml    # Rewrite database-type files to native [operations.definition] tables
+primitive sync migrate-toml --dry-run  # Preview the rewrite without writing files
 # Override with a fixed path:
 primitive sync init --dir ./config
 primitive sync push --dir ./config
 ```
+
+`migrate-toml` is a purely local rewrite — it converts JSON-string `definition`/`params` fields to native TOML tables in place, semantically identical on the server (see [Operation types](#operation-types) for the two forms and the fallback rules).
 
 The config directory structure:
 
@@ -274,6 +305,12 @@ primitive databases codegen -o ./src/generated/db
 Codegen reads the database-type TOML from the auto-resolved sync directory (`.primitive/sync/<env>/<appId>/`); pass `--sync-dir <path>` only when overriding it. With no `-o`, generated files land in `<sync-dir>/database-types/generated/`.
 
 **Codegen enum / union / required typing.** When a field or an operation param restricts a string to a fixed set of values, codegen emits a TypeScript string-literal union (e.g. `status: "open" | "in-progress" | "closed"`) instead of `string`, and enum params are validated server-side as well. Fields that operation params mark `required` are emitted as non-optional on the generated record interface. This keeps generated types aligned with the server's validation instead of widening everything to `string`.
+
+**Codegen result-typing limits.** Three places where a generated result alias is looser (or wider) than the payload the server actually returns — declare a local type at the call site instead of leaning on the alias:
+
+- `pipeline` op results are always typed `PipelineResult` (`{ steps: Record<string, unknown> }`), even when the definition's `return` mode reshapes the payload into something else.
+- `mutation` results type `results` as `unknown[]`, though each element carries `{ success, id }`.
+- `query` results are typed as the full record interface even when the definition sets a `projection` — at runtime the server returns only the projected fields, so the generated type promises fields that aren't there.
 {{/lang}}
 
 ## Database Types
@@ -582,7 +619,48 @@ This also works with `$steps.*` references in pipelines (see [Settings record pa
 
 ### Operation types
 
-Operations are defined in the `[[operations]]` array in the database type TOML file. The `definition` and `params` fields are JSON strings. A `definition` may equivalently be written as an inline TOML table (`definition = { filter = { "$in" = [...] } }`); both forms round-trip stably through `sync push`/`pull`. `sync push` warns (does not block) on an unrecognized filter operator — the supported set is `$eq`, `$ne`, `$gt`, `$gte`, `$lt`, `$lte`, `$in`, `$nin`, `$exists`, `$contains`, `$startsWith`, `$endsWith`, `$containsText`, plus logical `$and`/`$or`.
+Operations are defined in the `[[operations]]` array in the database type TOML file. An operation's `definition` and `params` can be written in two forms, semantically identical on the server:
+
+- **Native TOML tables** — the primary form: `definition` as an `[operations.definition]` table (nested tables like `[operations.definition.filter]`; mutation steps as `[[operations.definition.operations]]` array-of-tables) and `params` as one `[[operations.params]]` entry per parameter (`name`, `type`, `required`, and any other param keys). `sync pull` writes new files in this form. A compact inline table (`definition = { filter = { "$in" = [...] } }`) also counts as native and round-trips stably.
+- **JSON strings** — `definition = '{...}'` and `params = '{...}'` single-line encodings; here `params` is an object keyed by param name rather than an array. The per-op reference examples below use this compact encoding — the JSON inside `definition` is the same shape either way.
+
+The same mutation in both forms:
+
+```toml
+# Native TOML tables
+[[operations]]
+name = "approvePost"
+type = "mutation"
+modelName = "posts"
+access = "isMemberOf('class-teachers', database.id)"
+
+[[operations.definition.operations]]
+op = "patch"
+id = "$params.id"
+
+[operations.definition.operations.data]
+status = "approved"
+
+[[operations.params]]
+name = "id"
+type = "string"
+required = true
+```
+
+```toml
+# JSON-string encoding — same operation
+[[operations]]
+name = "approvePost"
+type = "mutation"
+modelName = "posts"
+access = "isMemberOf('class-teachers', database.id)"
+definition = '{"operations":[{"op":"patch","id":"$params.id","data":{"status":"approved"}}]}'
+params = '{"id":{"type":"string","required":true}}'
+```
+
+The form is **sticky per file**: `sync pull` preserves whichever form each operation already uses (per op, so mixed files stay mixed), so a JSON-string file keeps that shape until you rewrite it — `primitive sync migrate-toml` (add `--dry-run` to preview) converts a file's JSON-string fields to native tables in place as a purely local rewrite. A value TOML cannot represent — a `null`, or a mixed-type array such as `"$and": ["$database.metadata.peerVisible", {...}]` — falls back to a JSON string for that field on emit, with a log line naming the operation; the rest of the file stays native.
+
+`sync push` accepts both forms and warns (does not block) on an unrecognized filter operator — the supported set is `$eq`, `$ne`, `$gt`, `$gte`, `$lt`, `$lte`, `$in`, `$nin`, `$exists`, `$contains`, `$startsWith`, `$endsWith`, `$containsText`, plus logical `$and`/`$or`.
 
 #### Query — read records
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.ts.md
@@ -89,17 +89,44 @@ name = "listTasks"
 type = "query"
 modelName = "tasks"
 access = "isMemberOf('team', database.celContext.teamId)"
-definition = '{"filter":{"projectId":"$params.projectId"},"sort":{"createdAt":-1},"limit":50}'
-params = '{"projectId":{"type":"string","required":true}}'
+
+[operations.definition]
+filter = { projectId = "$params.projectId" }
+sort = { createdAt = -1 }
+limit = 50
+
+[[operations.params]]
+name = "projectId"
+type = "string"
+required = true
 
 [[operations]]
 name = "createTask"
 type = "mutation"
 modelName = "tasks"
 access = "isMemberOf('team', database.celContext.teamId)"
-definition = '{"operations":[{"op":"save","data":{"title":"$params.title","projectId":"$params.projectId","status":"open","createdBy":"$user.userId"}}]}'
-params = '{"title":{"type":"string","required":true},"projectId":{"type":"string","required":true}}'
+
+[[operations.definition.operations]]
+op = "save"
+
+[operations.definition.operations.data]
+title = "$params.title"
+projectId = "$params.projectId"
+status = "open"
+createdBy = "$user.userId"
+
+[[operations.params]]
+name = "title"
+type = "string"
+required = true
+
+[[operations.params]]
+name = "projectId"
+type = "string"
+required = true
 ```
+
+`definition` and `params` can equivalently be written as single-line JSON strings (`definition = '{"filter":{...}}'`) — see [Operation types](#operation-types) for both forms and `primitive sync migrate-toml` for converting a file.
 
 Push configuration to the server:
 
@@ -141,10 +168,14 @@ primitive sync pull            # Pull current config from server
 primitive sync diff            # Preview changes
 primitive sync push            # Push local config to server
 primitive sync push --dry-run  # See what would change without applying
+primitive sync migrate-toml    # Rewrite database-type files to native [operations.definition] tables
+primitive sync migrate-toml --dry-run  # Preview the rewrite without writing files
 # Override with a fixed path:
 primitive sync init --dir ./config
 primitive sync push --dir ./config
 ```
+
+`migrate-toml` is a purely local rewrite — it converts JSON-string `definition`/`params` fields to native TOML tables in place, semantically identical on the server (see [Operation types](#operation-types) for the two forms and the fallback rules).
 
 The config directory structure:
 
@@ -302,6 +333,12 @@ primitive databases codegen -o ./src/generated/db
 Codegen reads the database-type TOML from the auto-resolved sync directory (`.primitive/sync/<env>/<appId>/`); pass `--sync-dir <path>` only when overriding it. With no `-o`, generated files land in `<sync-dir>/database-types/generated/`.
 
 **Codegen enum / union / required typing.** When a field or an operation param restricts a string to a fixed set of values, codegen emits a TypeScript string-literal union (e.g. `status: "open" | "in-progress" | "closed"`) instead of `string`, and enum params are validated server-side as well. Fields that operation params mark `required` are emitted as non-optional on the generated record interface. This keeps generated types aligned with the server's validation instead of widening everything to `string`.
+
+**Codegen result-typing limits.** Three places where a generated result alias is looser (or wider) than the payload the server actually returns — declare a local type at the call site instead of leaning on the alias:
+
+- `pipeline` op results are always typed `PipelineResult` (`{ steps: Record<string, unknown> }`), even when the definition's `return` mode reshapes the payload into something else.
+- `mutation` results type `results` as `unknown[]`, though each element carries `{ success, id }`.
+- `query` results are typed as the full record interface even when the definition sets a `projection` — at runtime the server returns only the projected fields, so the generated type promises fields that aren't there.
 
 ## Database Types
 
@@ -606,7 +643,48 @@ This also works with `$steps.*` references in pipelines (see [Settings record pa
 
 ### Operation types
 
-Operations are defined in the `[[operations]]` array in the database type TOML file. The `definition` and `params` fields are JSON strings. A `definition` may equivalently be written as an inline TOML table (`definition = { filter = { "$in" = [...] } }`); both forms round-trip stably through `sync push`/`pull`. `sync push` warns (does not block) on an unrecognized filter operator — the supported set is `$eq`, `$ne`, `$gt`, `$gte`, `$lt`, `$lte`, `$in`, `$nin`, `$exists`, `$contains`, `$startsWith`, `$endsWith`, `$containsText`, plus logical `$and`/`$or`.
+Operations are defined in the `[[operations]]` array in the database type TOML file. An operation's `definition` and `params` can be written in two forms, semantically identical on the server:
+
+- **Native TOML tables** — the primary form: `definition` as an `[operations.definition]` table (nested tables like `[operations.definition.filter]`; mutation steps as `[[operations.definition.operations]]` array-of-tables) and `params` as one `[[operations.params]]` entry per parameter (`name`, `type`, `required`, and any other param keys). `sync pull` writes new files in this form. A compact inline table (`definition = { filter = { "$in" = [...] } }`) also counts as native and round-trips stably.
+- **JSON strings** — `definition = '{...}'` and `params = '{...}'` single-line encodings; here `params` is an object keyed by param name rather than an array. The per-op reference examples below use this compact encoding — the JSON inside `definition` is the same shape either way.
+
+The same mutation in both forms:
+
+```toml
+# Native TOML tables
+[[operations]]
+name = "approvePost"
+type = "mutation"
+modelName = "posts"
+access = "isMemberOf('class-teachers', database.id)"
+
+[[operations.definition.operations]]
+op = "patch"
+id = "$params.id"
+
+[operations.definition.operations.data]
+status = "approved"
+
+[[operations.params]]
+name = "id"
+type = "string"
+required = true
+```
+
+```toml
+# JSON-string encoding — same operation
+[[operations]]
+name = "approvePost"
+type = "mutation"
+modelName = "posts"
+access = "isMemberOf('class-teachers', database.id)"
+definition = '{"operations":[{"op":"patch","id":"$params.id","data":{"status":"approved"}}]}'
+params = '{"id":{"type":"string","required":true}}'
+```
+
+The form is **sticky per file**: `sync pull` preserves whichever form each operation already uses (per op, so mixed files stay mixed), so a JSON-string file keeps that shape until you rewrite it — `primitive sync migrate-toml` (add `--dry-run` to preview) converts a file's JSON-string fields to native tables in place as a purely local rewrite. A value TOML cannot represent — a `null`, or a mixed-type array such as `"$and": ["$database.metadata.peerVisible", {...}]` — falls back to a JSON string for that field on emit, with a log line naming the operation; the rest of the file stays native.
+
+`sync push` accepts both forms and warns (does not block) on an unrecognized filter operator — the supported set is `$eq`, `$ne`, `$gt`, `$gte`, `$lt`, `$lte`, `$in`, `$nin`, `$exists`, `$contains`, `$startsWith`, `$endsWith`, `$containsText`, plus logical `$and`/`$or`.
 
 #### Query — read records
 


### PR DESCRIPTION
## What the issue reported

#244: the databases guide shows every operation `definition`/`params` as JSON strings stuffed into TOML and never mentions the native TOML form (`[operations.definition]` tables, `[[operations.params]]` array-of-tables) or `primitive sync migrate-toml`; and the codegen section says nothing about the places where generated result types diverge from the runtime payload.

## Verified against source (stamped submodule)

- `primitive sync migrate-toml [app-id] [--dir <path>] [--dry-run]` exists (`cli/src/commands/sync.ts:5822`; help output confirmed against the built CLI). It is a purely local rewrite (source comment at `sync.ts:5833`).
- Native/JSON form semantics from `cli/src/lib/toml-database-config.ts` and the issue-#752 integration test: new files pull as native; form is preserved per operation on pull (mixed files stay mixed); un-TOMLable values (`null`, mixed-type arrays) fall back to a JSON string per field with a log line; a compact inline table counts as native and round-trips stably (issue #1255 fix).
- All three codegen caveats confirmed in `cli/src/lib/db-codegen/dbTemplates.ts`: `pipeline` → `PipelineResult { steps: Record<string, unknown> }` regardless of `return` mode (js-bao-wss#1437, open), `mutation` → `results: unknown[]` (#1438, open), `query` → full record interface with `projection` ignored (#1439, open).
- One deviation from the issue's aside: the "TOML parse error due to apostrophes" warning box was **kept** — it concerns CEL `access` strings, which stay strings in both forms, so the native form does not obviate it.

## What changed

- `guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.template.md`:
  - Quickstart TOML converted to the native form (the block agents copy first), with a pointer to the two-forms reference.
  - "Operation types" intro rewritten: native tables as the primary form, JSON strings as the equivalent compact encoding, a side-by-side converted mutation, and the stickiness / migrate-toml / JSON-fallback semantics.
  - CLI sync block gains the `migrate-toml` invocations (both validated by the CLI gate) plus a one-line semantics note.
  - Codegen section (ts-scoped) gains "result-typing limits" with the three caveats in present-tense contract framing and the declare-a-local-type guidance.
- `docs/getting-started/working-with-databases.md` (sync rule): quickstart example converted to native form, a short two-forms + migrate-toml paragraph, and one sentence on result types being generated from the op `type` rather than the `definition`.
- Builds re-rendered via `pnpm render:guides`.

Per-op reference examples on both sides deliberately keep the compact JSON-string encoding (the issue scoped the conversion to a representative example; the intro states the equivalence explicitly).

## Validation

- `pnpm check:examples` — green end to end; CLI invocation count rose 460 → 462 (the two new `migrate-toml` forms validated against the submodule-built CLI); all new native-form TOML blocks pass the TOML gate
- `npx vitepress build docs` — green
- docs-page-review lenses on the diff + docs-sync-check across the working-with-databases ↔ DATABASES pair — pass

Fixes #244