### PR TITLE
Set-audit fixups: convert remaining pipeline and per-param snippets to native TOML

### DIFF
--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.swift.md
@@ -653,16 +653,12 @@ required = true
 
 **Per-parameter access control** restricts what value a caller may pass:
 
-```json
-{
-  "params": {
-    "studentId": {
-      "type": "string",
-      "required": true,
-      "access": "value in memberGroups('parent-of')"
-    }
-  }
-}
+```toml novalidate
+[[operations.params]]
+name = "studentId"
+type = "string"
+required = true
+access = "value in memberGroups('parent-of')"
 ```
 
 ### Substitution variables

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.template.md
@@ -639,16 +639,12 @@ required = true
 
 **Per-parameter access control** restricts what value a caller may pass:
 
-```json
-{
-  "params": {
-    "studentId": {
-      "type": "string",
-      "required": true,
-      "access": "value in memberGroups('parent-of')"
-    }
-  }
-}
+```toml novalidate
+[[operations.params]]
+name = "studentId"
+type = "string"
+required = true
+access = "value in memberGroups('parent-of')"
 ```
 
 ### Substitution variables

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.ts.md
@@ -663,16 +663,12 @@ required = true
 
 **Per-parameter access control** restricts what value a caller may pass:
 
-```json
-{
-  "params": {
-    "studentId": {
-      "type": "string",
-      "required": true,
-      "access": "value in memberGroups('parent-of')"
-    }
-  }
-}
+```toml novalidate
+[[operations.params]]
+name = "studentId"
+type = "string"
+required = true
+access = "value in memberGroups('parent-of')"
 ```
 
 ### Substitution variables

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_PERFORMANCE.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_PERFORMANCE.swift.md
@@ -62,15 +62,44 @@ name = "dashboardBundle"
 type = "pipeline"
 modelName = "_pipeline"
 access = "user.userId == database.metadata.ownerId"
-definition = '''
-{"steps":[
-  {"name":"groups","type":"query","modelName":"groups","filter":{"ownerId":"$user.userId"},"limit":50},
-  {"name":"accounts","type":"query","modelName":"accounts","filter":{"ownerId":"$user.userId"},"limit":100},
-  {"name":"holdings","type":"query","modelName":"holdings","filter":{"ownerId":"$user.userId"},"limit":1000},
-  {"name":"targets","type":"query","modelName":"targets","filter":{},"limit":1000},
-  {"name":"latestSnapshot","type":"query","modelName":"snapshots","filter":{"ownerId":"$user.userId"},"sort":{"createdAt":-1},"limit":1}
-],"return":"all"}
-'''
+[operations.definition]
+return = "all"
+
+[[operations.definition.steps]]
+name = "groups"
+type = "query"
+modelName = "groups"
+filter = { ownerId = "$user.userId" }
+limit = 50
+
+[[operations.definition.steps]]
+name = "accounts"
+type = "query"
+modelName = "accounts"
+filter = { ownerId = "$user.userId" }
+limit = 100
+
+[[operations.definition.steps]]
+name = "holdings"
+type = "query"
+modelName = "holdings"
+filter = { ownerId = "$user.userId" }
+limit = 1000
+
+[[operations.definition.steps]]
+name = "targets"
+type = "query"
+modelName = "targets"
+filter = {}
+limit = 1000
+
+[[operations.definition.steps]]
+name = "latestSnapshot"
+type = "query"
+modelName = "snapshots"
+filter = { ownerId = "$user.userId" }
+sort = { createdAt = -1 }
+limit = 1
 ```
 
 Then execute it in one round trip and read each step's `data`:

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_PERFORMANCE.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_PERFORMANCE.template.md
@@ -74,15 +74,44 @@ name = "dashboardBundle"
 type = "pipeline"
 modelName = "_pipeline"
 access = "user.userId == database.metadata.ownerId"
-definition = '''
-{"steps":[
-  {"name":"groups","type":"query","modelName":"groups","filter":{"ownerId":"$user.userId"},"limit":50},
-  {"name":"accounts","type":"query","modelName":"accounts","filter":{"ownerId":"$user.userId"},"limit":100},
-  {"name":"holdings","type":"query","modelName":"holdings","filter":{"ownerId":"$user.userId"},"limit":1000},
-  {"name":"targets","type":"query","modelName":"targets","filter":{},"limit":1000},
-  {"name":"latestSnapshot","type":"query","modelName":"snapshots","filter":{"ownerId":"$user.userId"},"sort":{"createdAt":-1},"limit":1}
-],"return":"all"}
-'''
+[operations.definition]
+return = "all"
+
+[[operations.definition.steps]]
+name = "groups"
+type = "query"
+modelName = "groups"
+filter = { ownerId = "$user.userId" }
+limit = 50
+
+[[operations.definition.steps]]
+name = "accounts"
+type = "query"
+modelName = "accounts"
+filter = { ownerId = "$user.userId" }
+limit = 100
+
+[[operations.definition.steps]]
+name = "holdings"
+type = "query"
+modelName = "holdings"
+filter = { ownerId = "$user.userId" }
+limit = 1000
+
+[[operations.definition.steps]]
+name = "targets"
+type = "query"
+modelName = "targets"
+filter = {}
+limit = 1000
+
+[[operations.definition.steps]]
+name = "latestSnapshot"
+type = "query"
+modelName = "snapshots"
+filter = { ownerId = "$user.userId" }
+sort = { createdAt = -1 }
+limit = 1
 ```
 
 Then execute it in one round trip and read each step's `data`:

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_PERFORMANCE.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_PERFORMANCE.ts.md
@@ -62,15 +62,44 @@ name = "dashboardBundle"
 type = "pipeline"
 modelName = "_pipeline"
 access = "user.userId == database.metadata.ownerId"
-definition = '''
-{"steps":[
-  {"name":"groups","type":"query","modelName":"groups","filter":{"ownerId":"$user.userId"},"limit":50},
-  {"name":"accounts","type":"query","modelName":"accounts","filter":{"ownerId":"$user.userId"},"limit":100},
-  {"name":"holdings","type":"query","modelName":"holdings","filter":{"ownerId":"$user.userId"},"limit":1000},
-  {"name":"targets","type":"query","modelName":"targets","filter":{},"limit":1000},
-  {"name":"latestSnapshot","type":"query","modelName":"snapshots","filter":{"ownerId":"$user.userId"},"sort":{"createdAt":-1},"limit":1}
-],"return":"all"}
-'''
+[operations.definition]
+return = "all"
+
+[[operations.definition.steps]]
+name = "groups"
+type = "query"
+modelName = "groups"
+filter = { ownerId = "$user.userId" }
+limit = 50
+
+[[operations.definition.steps]]
+name = "accounts"
+type = "query"
+modelName = "accounts"
+filter = { ownerId = "$user.userId" }
+limit = 100
+
+[[operations.definition.steps]]
+name = "holdings"
+type = "query"
+modelName = "holdings"
+filter = { ownerId = "$user.userId" }
+limit = 1000
+
+[[operations.definition.steps]]
+name = "targets"
+type = "query"
+modelName = "targets"
+filter = {}
+limit = 1000
+
+[[operations.definition.steps]]
+name = "latestSnapshot"
+type = "query"
+modelName = "snapshots"
+filter = { ownerId = "$user.userId" }
+sort = { createdAt = -1 }
+limit = 1
 ```
 
 Then execute it in one round trip and read each step's `data`:


### PR DESCRIPTION
Follow-ups from the post-sweep set audit of the native-TOML standard (#254):

- `guides/latest/AGENT_GUIDE_TO_PRIMITIVE_PERFORMANCE.template.md` — the `dashboardBundle` pipeline was still a triple-quoted JSON string (missed by the original grep, which only matched single-quoted `= '{`). All five steps are plain queries with TOML-representable filters; converted to `[operations.definition]` + `[[operations.definition.steps]]`, matching the databases guide's converted `projectDashboard`.
- `guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.template.md` — per-parameter access control was illustrated as a JSON object snippet; now a native `[[operations.params]]` fragment, uniform with the rest of the guide.

Validation: `pnpm check:examples` and `npx vitepress build docs` green.