### PR TITLE
Warn that bare != on an absent CEL optional is true; presence checks use size()/hasValue() (#249)

### DIFF
--- a/docs/getting-started/workflows.md
+++ b/docs/getting-started/workflows.md
@@ -90,7 +90,7 @@ content = "Generate premium content for {{ input.topic }}."
 
 Every step output carries an engine-managed `ok` boolean (and `skipped: true` when `runIf` was falsy, `errored: true` when captured by `continueOnError`), so downstream `runIf` expressions can branch reliably on `steps.<id>.ok` or `!steps.<id>.skipped`.
 
-CEL optional types are enabled in every workflow context, so you can collapse multi-conjunct null guards: `steps.fetch.?data.?items.orValue([]).size() > 0`.
+CEL optional types are enabled in every workflow context, so you can collapse multi-conjunct null guards: `steps.fetch.?data.?items.orValue([]).size() > 0`. One caution: comparing a `.?` path to a value with `!=` is **true when the path is absent** — `input.metadata.?userId != ''` passes for input with no `userId` at all. For strings, lists, and maps, write "present and non-empty" as `size(input.metadata.?userId) > 0` — `size()` is `0` for an absent path and for a present-but-null value; for numbers and booleans, use `.hasValue()`.
 
 When a step reads a value from an upstream step that can itself be skipped, list that upstream in `skipWhenSkipped` so the dependent skips too instead of failing on the missing output:
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.swift.md
@@ -780,14 +780,16 @@ Common operations work directly on optional values — no `.orValue()` unwrap ne
 
 | Expression | Semantics |
 |---|---|
-| `size(steps.x.?data)` | `none` → `0`; `some(xs)` → `xs.size()`. Works for lists, maps, strings, bytes. |
-| `steps.x.?body.?token != ''` | `none` is never equal to any scalar value (absent ≠ empty string). |
-| `steps.x.?body.?err == null` | `none == null` is `true` (absent path treated as null). |
+| `size(steps.x.?data)` | `none` → `0`; a present-but-`null` value → `0`; `some(xs)` → `xs.size()`. Works for lists, maps, strings, bytes. |
+| `steps.x.?body.?err == null` / `!= null` | `none == null` is `true` (an absent path compares equal to null), so `!= null` means "present and non-null". |
+| `steps.x.?body.?token != 'v'` | **TRUE when the path is absent.** `none` never equals a non-null value, and `!=` is derived as the negation — this is is-distinct-from, not a presence check. |
+
+**Presence checks on strings, lists, maps, and bytes use `size()`, not a bare `!=`.** A guard like `runIf = "input.metadata.?userId != ''"` *passes* for input with no `userId` at all — the opposite of the intent. Write "present and non-empty" as `size(input.metadata.?userId) > 0` (and "absent or empty" as `== 0`): `size()` is `0` for an absent path and for a present-but-null value, so it covers both. For values without a size (numbers, booleans), use `.hasValue()` instead — `size()` on a present number or boolean is an evaluation error (which fails the step), and `.hasValue()` is `true` for a present-but-`null` value. Comparing against `null` is the one safe bare comparison — `.?err != null` correctly means present-and-non-null.
 
 ```cel
 runIf = "size(steps['fetch'].?data) > 0"
 runIf = "steps['profile'].?body.?err != null"
-runIf = "steps['profile'].?body.?token != ''"
+runIf = "size(steps['profile'].?body.?token) > 0"   # present and non-empty — NOT `.?token != ''`
 ```
 
 You can still use `.orValue()` and `.hasValue()` when you need explicit control over the fallback value:

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md
@@ -780,14 +780,16 @@ Common operations work directly on optional values — no `.orValue()` unwrap ne
 
 | Expression | Semantics |
 |---|---|
-| `size(steps.x.?data)` | `none` → `0`; `some(xs)` → `xs.size()`. Works for lists, maps, strings, bytes. |
-| `steps.x.?body.?token != ''` | `none` is never equal to any scalar value (absent ≠ empty string). |
-| `steps.x.?body.?err == null` | `none == null` is `true` (absent path treated as null). |
+| `size(steps.x.?data)` | `none` → `0`; a present-but-`null` value → `0`; `some(xs)` → `xs.size()`. Works for lists, maps, strings, bytes. |
+| `steps.x.?body.?err == null` / `!= null` | `none == null` is `true` (an absent path compares equal to null), so `!= null` means "present and non-null". |
+| `steps.x.?body.?token != 'v'` | **TRUE when the path is absent.** `none` never equals a non-null value, and `!=` is derived as the negation — this is is-distinct-from, not a presence check. |
+
+**Presence checks on strings, lists, maps, and bytes use `size()`, not a bare `!=`.** A guard like `runIf = "input.metadata.?userId != ''"` *passes* for input with no `userId` at all — the opposite of the intent. Write "present and non-empty" as `size(input.metadata.?userId) > 0` (and "absent or empty" as `== 0`): `size()` is `0` for an absent path and for a present-but-null value, so it covers both. For values without a size (numbers, booleans), use `.hasValue()` instead — `size()` on a present number or boolean is an evaluation error (which fails the step), and `.hasValue()` is `true` for a present-but-`null` value. Comparing against `null` is the one safe bare comparison — `.?err != null` correctly means present-and-non-null.
 
 ```cel
 runIf = "size(steps['fetch'].?data) > 0"
 runIf = "steps['profile'].?body.?err != null"
-runIf = "steps['profile'].?body.?token != ''"
+runIf = "size(steps['profile'].?body.?token) > 0"   # present and non-empty — NOT `.?token != ''`
 ```
 
 You can still use `.orValue()` and `.hasValue()` when you need explicit control over the fallback value:

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.ts.md
@@ -780,14 +780,16 @@ Common operations work directly on optional values — no `.orValue()` unwrap ne
 
 | Expression | Semantics |
 |---|---|
-| `size(steps.x.?data)` | `none` → `0`; `some(xs)` → `xs.size()`. Works for lists, maps, strings, bytes. |
-| `steps.x.?body.?token != ''` | `none` is never equal to any scalar value (absent ≠ empty string). |
-| `steps.x.?body.?err == null` | `none == null` is `true` (absent path treated as null). |
+| `size(steps.x.?data)` | `none` → `0`; a present-but-`null` value → `0`; `some(xs)` → `xs.size()`. Works for lists, maps, strings, bytes. |
+| `steps.x.?body.?err == null` / `!= null` | `none == null` is `true` (an absent path compares equal to null), so `!= null` means "present and non-null". |
+| `steps.x.?body.?token != 'v'` | **TRUE when the path is absent.** `none` never equals a non-null value, and `!=` is derived as the negation — this is is-distinct-from, not a presence check. |
+
+**Presence checks on strings, lists, maps, and bytes use `size()`, not a bare `!=`.** A guard like `runIf = "input.metadata.?userId != ''"` *passes* for input with no `userId` at all — the opposite of the intent. Write "present and non-empty" as `size(input.metadata.?userId) > 0` (and "absent or empty" as `== 0`): `size()` is `0` for an absent path and for a present-but-null value, so it covers both. For values without a size (numbers, booleans), use `.hasValue()` instead — `size()` on a present number or boolean is an evaluation error (which fails the step), and `.hasValue()` is `true` for a present-but-`null` value. Comparing against `null` is the one safe bare comparison — `.?err != null` correctly means present-and-non-null.
 
 ```cel
 runIf = "size(steps['fetch'].?data) > 0"
 runIf = "steps['profile'].?body.?err != null"
-runIf = "steps['profile'].?body.?token != ''"
+runIf = "size(steps['profile'].?body.?token) > 0"   # present and non-empty — NOT `.?token != ''`
 ```
 
 You can still use `.orValue()` and `.hasValue()` when you need explicit control over the fallback value:


### PR DESCRIPTION
## What the issue reported

Issue #249: CEL optional-types support gives `size()`, `==`, `!=` overloads for `.?` navigation, but the guide never warned that `!=` against a value is **true when the path is absent** — so a guard like `runIf = "input.metadata.?userId != ''"` passes for input with no `userId`. Worse, the workflows guide actively showed `.?token != ''` as a recommended runIf idiom.

## Verified against source

Checked against `library_repos/js-bao-wss/src/services/cel-evaluator.ts` (equality overload, size overload, celSizeOf) and the safe-nav unit tests at the stamped SHA:

- `none == null` → true; `none ==` any non-null value → false; `!=` is auto-derived as the negation, so `x.?f != ''` is TRUE when absent.
- `size(none)` → 0 and `size()` of a present-but-null value → 0, so `size(x.?f) > 0` is the correct "present and non-empty" idiom for strings, lists, maps, and bytes.
- `size()` on a present number/boolean is an evaluation error (fails the step), so the rule is scoped to sized types with `.hasValue()` named for the rest (a page-review finding on the first draft).
- `.?err != null` is the one safe bare comparison — it correctly means present-and-non-null.

## What changed

- `guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md` (+ rendered builds) — the Safe navigation semantics table now leads with the safe `== null / != null` row, flags the `!= 'v'` row as is-distinct-from (true when absent), adds a bolded presence-check rule scoped by type, and the runIf example block replaces the footgun idiom `.?token != ''` with `size(...) > 0`.
- `docs/getting-started/workflows.md` — one caution sentence added to the Conditional Execution paragraph that introduces CEL optional types.

## Validation

- `pnpm check:examples` — pass
- `npx vitepress build docs` — pass
- docs-page-review + docs-sync-check run on the pair; the should-fix (unscoped `size()` rule would fail on numeric fields) and both nits addressed. Reviewer's idiom sweep confirms no other bare `.?field != <value>` presence idiom remains anywhere in docs/, guides/, or examples/.

Fixes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)