### PR TITLE
Document the default-filter rescue for skipped-step reads and the passthrough output transform (#250)

### DIFF
--- a/docs/getting-started/workflows.md
+++ b/docs/getting-started/workflows.md
@@ -488,8 +488,10 @@ items = "{{ steps.fetch.items }}"     # single-expression mode preserves arrays
 The step's result is the templated table itself — `steps.final` (and `outputs.output`, via `saveAs`) becomes:
 
 ```json
-{ "greeting": "Hello Ada", "items": ["alpha", "beta"] }
+{ "greeting": "Hello Ada", "items": ["alpha", "beta"], "ok": true }
 ```
+
+(The `ok` field is the engine's verdict stamp — it's added to every object result, so don't use `ok` as a data field of your own.)
 
 ### `script`
 
@@ -1069,7 +1071,7 @@ Templates have **no arithmetic** — <span v-pre>`{{ a + b }}`</span> won't reso
 
 ### Unresolved Paths
 
-In interpolation mode an unresolved path renders as `<missing: steps.x.y>`, so the gap is visible in step output and logs. In single-expression mode it resolves to `null`, so downstream `runIf` comparisons work naturally. Set `strict = true` on a step to make any unresolved template path fail the step instead. To be strict about only some params while leaving others null-tolerant, list them in `strictParams = ["userId", ...]` — a listed top-level param fails on a missing path but still tolerates a resolved `null`. When a template names a root that doesn't exist, the error lists the valid ones (`input`, `steps`, `outputs`, `meta`, `secrets`), which catches typos like <span v-pre>`{{ inputs.userId }}`</span>.
+In interpolation mode an unresolved path renders as `<missing: steps.x.y>`, so the gap is visible in step output and logs. In single-expression mode it resolves to `null`, so downstream `runIf` comparisons work naturally. A filter chain that starts with `default` rescues a missing path instead — <span v-pre>`{{ steps.x.output.result | default: '' }}`</span> renders `''` even when step `x` was skipped and recorded no output, which keeps a result table clean when some of its fields come from optionally-skipped steps. Set `strict = true` on a step to make any unresolved template path fail the step instead. To be strict about only some params while leaving others null-tolerant, list them in `strictParams = ["userId", ...]` — a listed top-level param fails on a missing path but still tolerates a resolved `null`. When a template names a root that doesn't exist, the error lists the valid ones (`input`, `steps`, `outputs`, `meta`, `secrets`), which catches typos like <span v-pre>`{{ inputs.userId }}`</span>.
 
 ## Next Steps
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.swift.md
@@ -750,7 +750,7 @@ Available filters (see `src/workflows/runner/templates.ts` for full list):
 
 Templates have **no arithmetic** (`{{ a + b }}` won't work). Move math into a step or filter chain.
 
-**Missing path sentinel.** In interpolation mode (`"prefix-{{ steps.x.y }}-suffix"`), an unresolved path renders as `<missing: steps.x.y>` so it's visible in step output and logs. In single-expression mode (`"{{ steps.x.y }}"` alone) the raw value is `null` so downstream `runIf`/comparisons work naturally. A resolved `null` interpolates as `"null"`; a resolved empty string interpolates as `""`. Set `strict = true` on the step to throw on any unresolved path instead, or `strictParams = ["userId", ...]` to make only the named top-level params strict-on-missing (a resolved `null` is still tolerated); `strict = true` covers everything and wins when both are set. When a template references a root outside the five valid roots (`input`, `steps`, `outputs`, `meta`, `secrets`), the strict-mode error lists them — catching typos like `{{ inputs.userId }}`.
+**Missing path sentinel.** In interpolation mode (`"prefix-{{ steps.x.y }}-suffix"`), an unresolved path renders as `<missing: steps.x.y>` so it's visible in step output and logs. In single-expression mode (`"{{ steps.x.y }}"` alone) the raw value is `null` so downstream `runIf`/comparisons work naturally. A resolved `null` interpolates as `"null"`; a resolved empty string interpolates as `""`. A filter chain that **begins with `default`** (or `now`) rescues a missing path instead: `{{ steps.x.output.result | default: '' }}` renders `''` when the path is unresolved — including when step `x` was skipped and recorded no `output` at all. That makes `default` the idiom for skipped-step collapse in an output table: a field built from an optionally-skipped step yields the fallback value rather than `<missing: …>`. Set `strict = true` on the step to throw on any unresolved path instead, or `strictParams = ["userId", ...]` to make only the named top-level params strict-on-missing (a resolved `null` is still tolerated); `strict = true` covers everything and wins when both are set. When a template references a root outside the five valid roots (`input`, `steps`, `outputs`, `meta`, `secrets`), the strict-mode error lists them — catching typos like `{{ inputs.userId }}`.
 
 ## `runIf` (CEL, not templates)
 
@@ -924,7 +924,17 @@ After all steps run:
 - `outputs[saveAs]` holds outputs for steps with `saveAs`.
 - The workflow's final result is `outputs.output` if any step used `saveAs = "output"`, otherwise the full `outputs` map.
 
-**Best practice**: end with a `transform` step using `saveAs = "output"` that explicitly shapes the return value.
+**Best practice**: end with a `transform` step using `saveAs = "output"` that explicitly shapes the return value. Because a single-expression `output` forwards the raw value (see [Templating](#templating)), the minimal form is a passthrough — useful when one step's result *is* the run's result:
+
+```toml
+[[steps]]
+id = "result"
+kind = "transform"
+output = "{{ steps.evaluate.output.result }}"   # single expression — forwards the raw value
+saveAs = "output"
+```
+
+Arrays and primitives pass through byte-for-byte. An **object** result additionally carries the engine's `ok: true` verdict stamp (see [Uniform step verdict](#uniform-step-verdict)) — the stamp overwrites any `ok` key of your own on the forwarded object, so don't use `ok` as a data field in a run result.
 
 ### Uniform step verdict
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md
@@ -750,7 +750,7 @@ Available filters (see `src/workflows/runner/templates.ts` for full list):
 
 Templates have **no arithmetic** (`{{ a + b }}` won't work). Move math into a step or filter chain.
 
-**Missing path sentinel.** In interpolation mode (`"prefix-{{ steps.x.y }}-suffix"`), an unresolved path renders as `<missing: steps.x.y>` so it's visible in step output and logs. In single-expression mode (`"{{ steps.x.y }}"` alone) the raw value is `null` so downstream `runIf`/comparisons work naturally. A resolved `null` interpolates as `"null"`; a resolved empty string interpolates as `""`. Set `strict = true` on the step to throw on any unresolved path instead, or `strictParams = ["userId", ...]` to make only the named top-level params strict-on-missing (a resolved `null` is still tolerated); `strict = true` covers everything and wins when both are set. When a template references a root outside the five valid roots (`input`, `steps`, `outputs`, `meta`, `secrets`), the strict-mode error lists them — catching typos like `{{ inputs.userId }}`.
+**Missing path sentinel.** In interpolation mode (`"prefix-{{ steps.x.y }}-suffix"`), an unresolved path renders as `<missing: steps.x.y>` so it's visible in step output and logs. In single-expression mode (`"{{ steps.x.y }}"` alone) the raw value is `null` so downstream `runIf`/comparisons work naturally. A resolved `null` interpolates as `"null"`; a resolved empty string interpolates as `""`. A filter chain that **begins with `default`** (or `now`) rescues a missing path instead: `{{ steps.x.output.result | default: '' }}` renders `''` when the path is unresolved — including when step `x` was skipped and recorded no `output` at all. That makes `default` the idiom for skipped-step collapse in an output table: a field built from an optionally-skipped step yields the fallback value rather than `<missing: …>`. Set `strict = true` on the step to throw on any unresolved path instead, or `strictParams = ["userId", ...]` to make only the named top-level params strict-on-missing (a resolved `null` is still tolerated); `strict = true` covers everything and wins when both are set. When a template references a root outside the five valid roots (`input`, `steps`, `outputs`, `meta`, `secrets`), the strict-mode error lists them — catching typos like `{{ inputs.userId }}`.
 
 ## `runIf` (CEL, not templates)
 
@@ -924,7 +924,17 @@ After all steps run:
 - `outputs[saveAs]` holds outputs for steps with `saveAs`.
 - The workflow's final result is `outputs.output` if any step used `saveAs = "output"`, otherwise the full `outputs` map.
 
-**Best practice**: end with a `transform` step using `saveAs = "output"` that explicitly shapes the return value.
+**Best practice**: end with a `transform` step using `saveAs = "output"` that explicitly shapes the return value. Because a single-expression `output` forwards the raw value (see [Templating](#templating)), the minimal form is a passthrough — useful when one step's result *is* the run's result:
+
+```toml
+[[steps]]
+id = "result"
+kind = "transform"
+output = "{{ steps.evaluate.output.result }}"   # single expression — forwards the raw value
+saveAs = "output"
+```
+
+Arrays and primitives pass through byte-for-byte. An **object** result additionally carries the engine's `ok: true` verdict stamp (see [Uniform step verdict](#uniform-step-verdict)) — the stamp overwrites any `ok` key of your own on the forwarded object, so don't use `ok` as a data field in a run result.
 
 ### Uniform step verdict
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.ts.md
@@ -750,7 +750,7 @@ Available filters (see `src/workflows/runner/templates.ts` for full list):
 
 Templates have **no arithmetic** (`{{ a + b }}` won't work). Move math into a step or filter chain.
 
-**Missing path sentinel.** In interpolation mode (`"prefix-{{ steps.x.y }}-suffix"`), an unresolved path renders as `<missing: steps.x.y>` so it's visible in step output and logs. In single-expression mode (`"{{ steps.x.y }}"` alone) the raw value is `null` so downstream `runIf`/comparisons work naturally. A resolved `null` interpolates as `"null"`; a resolved empty string interpolates as `""`. Set `strict = true` on the step to throw on any unresolved path instead, or `strictParams = ["userId", ...]` to make only the named top-level params strict-on-missing (a resolved `null` is still tolerated); `strict = true` covers everything and wins when both are set. When a template references a root outside the five valid roots (`input`, `steps`, `outputs`, `meta`, `secrets`), the strict-mode error lists them — catching typos like `{{ inputs.userId }}`.
+**Missing path sentinel.** In interpolation mode (`"prefix-{{ steps.x.y }}-suffix"`), an unresolved path renders as `<missing: steps.x.y>` so it's visible in step output and logs. In single-expression mode (`"{{ steps.x.y }}"` alone) the raw value is `null` so downstream `runIf`/comparisons work naturally. A resolved `null` interpolates as `"null"`; a resolved empty string interpolates as `""`. A filter chain that **begins with `default`** (or `now`) rescues a missing path instead: `{{ steps.x.output.result | default: '' }}` renders `''` when the path is unresolved — including when step `x` was skipped and recorded no `output` at all. That makes `default` the idiom for skipped-step collapse in an output table: a field built from an optionally-skipped step yields the fallback value rather than `<missing: …>`. Set `strict = true` on the step to throw on any unresolved path instead, or `strictParams = ["userId", ...]` to make only the named top-level params strict-on-missing (a resolved `null` is still tolerated); `strict = true` covers everything and wins when both are set. When a template references a root outside the five valid roots (`input`, `steps`, `outputs`, `meta`, `secrets`), the strict-mode error lists them — catching typos like `{{ inputs.userId }}`.
 
 ## `runIf` (CEL, not templates)
 
@@ -924,7 +924,17 @@ After all steps run:
 - `outputs[saveAs]` holds outputs for steps with `saveAs`.
 - The workflow's final result is `outputs.output` if any step used `saveAs = "output"`, otherwise the full `outputs` map.
 
-**Best practice**: end with a `transform` step using `saveAs = "output"` that explicitly shapes the return value.
+**Best practice**: end with a `transform` step using `saveAs = "output"` that explicitly shapes the return value. Because a single-expression `output` forwards the raw value (see [Templating](#templating)), the minimal form is a passthrough — useful when one step's result *is* the run's result:
+
+```toml
+[[steps]]
+id = "result"
+kind = "transform"
+output = "{{ steps.evaluate.output.result }}"   # single expression — forwards the raw value
+saveAs = "output"
+```
+
+Arrays and primitives pass through byte-for-byte. An **object** result additionally carries the engine's `ok: true` verdict stamp (see [Uniform step verdict](#uniform-step-verdict)) — the stamp overwrites any `ok` key of your own on the forwarded object, so don't use `ok` as a data field in a run result.
 
 ### Uniform step verdict
 


### PR DESCRIPTION
## What the issue reported

Issue #250 asked to document (1) the run-output rule (`outputs.output` from the step with `saveAs = "output"`, falling back to the whole `outputs` map), (2) the passthrough-transform pattern, and (3) the skipped-step collapse via `{{ ... | default: '' }}`.

## Verified against source

Checked against `library_repos/js-bao-wss` at the stamped SHA (`app-workflow.ts` output determination, `runner/templates.ts`, `runner/engine.ts`, `steps/transform-step.ts`):

- **Asks (1) and most of (2) were already documented** — `workflows.md` ("The run's final output", the worked transform example) and the WORKFLOWS guide (lifecycle list, "Output contract" section, best-practice line, single-expression mode) state the rule and the ending-transform pattern accurately. This PR implements only the missing deltas.
- A filter chain that *begins with* `default` (or `now`) rescues a missing path; the `default` filter returns the fallback for null/undefined/`''`; a skipped step's stub records no `output` key, so `{{ steps.x.output.result | default: '' }}` renders `''` when step x was skipped.
- Single-expression transforms forward the raw value — arrays and primitives byte-for-byte; **object** results additionally carry the engine's `ok: true` verdict stamp, which overwrites any `ok` key of your own (page-review finding, now documented rather than overclaiming "verbatim").

## What changed

- `guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md` (+ rendered builds) — the "Missing path sentinel" paragraph documents the default-rescue and the skipped-step-collapse idiom; the "Output contract" best practice gains the minimal passthrough TOML example with the object/`ok`-stamp caveat.
- `docs/getting-started/workflows.md` — one default-rescue sentence in "Unresolved Paths", and the worked transform example's shown result now includes the engine's `ok: true` stamp (a pre-existing inaccuracy in the same fact family, flagged by the page review).

## Validation

- `pnpm check:examples` — pass (the new TOML fence passes the real workflow validator, no `novalidate` opt-out)
- `npx vitepress build docs` — pass
- docs-page-review + docs-sync-check run on the pair; the must-fix (object passthrough is not verbatim — `ok` stamp) and both smaller findings fixed before this PR.

Fixes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)