### PR TITLE
Add the CI test-account recipe: invite-only pre-create and admin metadata grant (#252)

### DIFF
--- a/docs/getting-started/authentication.md
+++ b/docs/getting-started/authentication.md
@@ -163,7 +163,7 @@ Display `AUTH_USER_DISABLED` in your sign-in UI as a distinct error so the user 
 
 For integration tests and local dev, Primitive supports a `+primitivetest` OTP bypass: whitelist a base email per app, and derived addresses like `alice+primitivetest-teacher@example.com` sign in through the normal OTP flow with the magic code `000000` — no real email round-trip, and a first sign-in provisions the account through the app's normal signup path. One mailbox covers a whole fleet of role-distinguished test users.
 
-See [Test Users for Automated Testing](./primitive-cli.md#test-users-for-automated-testing) on the CLI page for setup, the sign-in pattern, and the security guardrails.
+See [Test Users for Automated Testing](./primitive-cli.md#test-users-for-automated-testing) on the CLI page for setup, the sign-in pattern, the security guardrails, and the CI recipe for invite-only apps.
 
 ## How It Works Under the Hood
 

--- a/docs/getting-started/primitive-cli.md
+++ b/docs/getting-started/primitive-cli.md
@@ -521,6 +521,29 @@ Guardrails:
 
 Use this for automated tests and local development — not for staging or production flows.
 
+### CI Recipe for Invite-Only Apps
+
+Because the signup gates apply, a fresh derived address on an invite-only app is stopped at the email step — waitlisted or rejected before any code is accepted. Rather than routing invitation emails through CI, add the member directly:
+
+```bash
+# 1. One-time app setup: whitelist the base
+primitive apps update --test-account-bases ci@example.com
+
+# 2. Per test user: add the derived address as a member — no invitation email.
+#    --json returns the new member's userId for scripting.
+primitive users create ci+primitivetest-checkout@example.com --json
+
+# 3. The test session signs in through the normal OTP flow with code 000000
+```
+
+`users create` adds the membership directly, so the invite gate never fires and the OTP sign-in proceeds as an existing member. For features gated on [resource metadata](./resource-metadata.md) — a subscription entitlement, a feature flag — an app owner or admin can set the test user's state directly, since app-level owners and admins bypass category write rules:
+
+```bash
+primitive metadata set user <userId> entitlements --data '{"tier":"pro"}'
+```
+
+With those steps a headless or browser-automation session can sign in as a fresh, entitled member with no human interaction.
+
 ## Scripting
 
 For automation and scripting, most commands support `--json` output:

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_AUTHENTICATION.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_AUTHENTICATION.swift.md
@@ -549,6 +549,10 @@ Guardrails:
 
 Manage the whitelist with `primitive apps update --test-account-bases …` (max 50 bases per app), or in the web-admin settings UI — both edit the same `testAccountBaseEmails` list.
 
+**Invite-only apps: pre-create the member.** A fresh derived address on an invite-only app is gated at the email step (`INVITATION_REQUIRED` / `ADDED_TO_WAITLIST`) before any code is accepted. For CI, skip the invitation flow: `primitive users create <base>+primitivetest-<x>@<domain>` adds the membership directly (no invitation email), and the OTP sign-in with `"000000"` then proceeds as an existing member (the response's `isNewUser` is `false` — pre-created members can't exercise new-user flows).
+
+**Entitlement-gated features: grant via an admin metadata write.** When features key off resource metadata (subscription tier, feature flags), an app-level owner/admin can set the test user's state directly — `primitive metadata set user <userId> <category> --data '{...}'` — because owners/admins bypass category write rules (see the [Resource Metadata guide](AGENT_GUIDE_TO_PRIMITIVE_RESOURCE_METADATA.md)). The full CI sequence: whitelist the base once, `users create` the derived address, sign in with `"000000"`, grant metadata — a headless session gets a fresh, entitled member with zero human interaction.
+
 **Don't use this in production user flows.**
 
 ---

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_AUTHENTICATION.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_AUTHENTICATION.template.md
@@ -675,6 +675,10 @@ Guardrails:
 
 Manage the whitelist with `primitive apps update --test-account-bases …` (max 50 bases per app), or in the web-admin settings UI — both edit the same `testAccountBaseEmails` list.
 
+**Invite-only apps: pre-create the member.** A fresh derived address on an invite-only app is gated at the email step (`INVITATION_REQUIRED` / `ADDED_TO_WAITLIST`) before any code is accepted. For CI, skip the invitation flow: `primitive users create <base>+primitivetest-<x>@<domain>` adds the membership directly (no invitation email), and the OTP sign-in with `"000000"` then proceeds as an existing member (the response's `isNewUser` is `false` — pre-created members can't exercise new-user flows).
+
+**Entitlement-gated features: grant via an admin metadata write.** When features key off resource metadata (subscription tier, feature flags), an app-level owner/admin can set the test user's state directly — `primitive metadata set user <userId> <category> --data '{...}'` — because owners/admins bypass category write rules (see the [Resource Metadata guide](AGENT_GUIDE_TO_PRIMITIVE_RESOURCE_METADATA.md)). The full CI sequence: whitelist the base once, `users create` the derived address, sign in with `"000000"`, grant metadata — a headless session gets a fresh, entitled member with zero human interaction.
+
 **Don't use this in production user flows.**
 
 ---

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_AUTHENTICATION.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_AUTHENTICATION.ts.md
@@ -651,6 +651,10 @@ Guardrails:
 
 Manage the whitelist with `primitive apps update --test-account-bases …` (max 50 bases per app), or in the web-admin settings UI — both edit the same `testAccountBaseEmails` list.
 
+**Invite-only apps: pre-create the member.** A fresh derived address on an invite-only app is gated at the email step (`INVITATION_REQUIRED` / `ADDED_TO_WAITLIST`) before any code is accepted. For CI, skip the invitation flow: `primitive users create <base>+primitivetest-<x>@<domain>` adds the membership directly (no invitation email), and the OTP sign-in with `"000000"` then proceeds as an existing member (the response's `isNewUser` is `false` — pre-created members can't exercise new-user flows).
+
+**Entitlement-gated features: grant via an admin metadata write.** When features key off resource metadata (subscription tier, feature flags), an app-level owner/admin can set the test user's state directly — `primitive metadata set user <userId> <category> --data '{...}'` — because owners/admins bypass category write rules (see the [Resource Metadata guide](AGENT_GUIDE_TO_PRIMITIVE_RESOURCE_METADATA.md)). The full CI sequence: whitelist the base once, `users create` the derived address, sign in with `"000000"`, grant metadata — a headless session gets a fresh, entitled member with zero human interaction.
+
 **Don't use this in production user flows.**
 
 ---


### PR DESCRIPTION
## What the issue reported

Issue #252: the `+primitivetest` test-account flow is the CI/browser-automation auth story, but the guides didn't cover it end-to-end — specifically the interaction with invite-only gating (a fresh derived address is waitlisted at the email step) and how to entitle a test user for metadata-gated features.

## Verified against source

Checked against `library_repos/js-bao-wss` at the stamped SHA:

- The core flow (`testAccountBaseEmails` via `--test-account-bases`, fixed OTP `000000`, suffix shape, guardrails, invite-gate behavior) **was already documented** on the CLI page's "Test Users for Automated Testing" section and in the AUTHENTICATION guide — this PR adds only the missing recipe.
- `primitive users create <email>` (default `--role member`) creates the membership directly with no invitation email; `checkAccess` passes for an existing member at both the OTP request and verify steps, so the invite gate never fires — verified through the controller and provisioning-service flow.
- App-level owners/admins bypass metadata category write rules (`evaluateCategoryAccess` short-circuits), so `primitive metadata set user <id> <category> --data '{...}'` can entitle the test user; command syntax verified against the CLI.
- Pre-created members return `isNewUser: false` — stated in the guide so agents don't expect new-user flows through this recipe.

## What changed

- `docs/getting-started/primitive-cli.md` — new "CI Recipe for Invite-Only Apps" subsection (whitelist once → `users create --json` the derived address → sign in with `000000` → admin metadata grant); the section-wide scope warning moved above the recipe so it closes the guardrails block.
- `docs/getting-started/authentication.md` — the pointer sentence now mentions the CI recipe.
- `guides/latest/AGENT_GUIDE_TO_PRIMITIVE_AUTHENTICATION.template.md` (+ rendered builds) — two reference-depth paragraphs: pre-create for invite-only apps, and the admin metadata grant with the full zero-interaction sequence.

## Validation

- `pnpm check:examples` — pass (all CLI invocations validated against the submodule-built primitive-admin)
- `npx vitepress build docs` — pass
- docs-page-review + docs-sync-check run across the set; the ordering finding and both nits fixed before this PR. The review also surfaced a platform gap (admin-api `add-by-email` lacks the reserved-email role boundary) — being filed as a js-bao-wss bug separately, not documented.

Fixes #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)