### PR TITLE
Fix workflows guide: applyToQuery output shape (#266)

### DIFF
--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.swift.md
@@ -285,7 +285,7 @@ databaseId = "{{ input.tasksDbId }}"
 operationName = "mark-overdue"      # NOTE: uses `operationName`, not `operation`
 [steps.params]
 now = "2026-04-27T00:00:00Z"
-# Output: { matched, updated, truncated? }
+# Output: { matched, affected, failed, truncated?, appliedLimit?, warning? }
 ```
 
 Workflows have no batch-write step kind. To apply a set of updates, run `forEach` over a `database.mutate` step (see `forEach` below), or use `database.applyToQuery` for query-driven updates.

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md
@@ -285,7 +285,7 @@ databaseId = "{{ input.tasksDbId }}"
 operationName = "mark-overdue"      # NOTE: uses `operationName`, not `operation`
 [steps.params]
 now = "2026-04-27T00:00:00Z"
-# Output: { matched, updated, truncated? }
+# Output: { matched, affected, failed, truncated?, appliedLimit?, warning? }
 ```
 
 Workflows have no batch-write step kind. To apply a set of updates, run `forEach` over a `database.mutate` step (see `forEach` below), or use `database.applyToQuery` for query-driven updates.

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.ts.md
@@ -285,7 +285,7 @@ databaseId = "{{ input.tasksDbId }}"
 operationName = "mark-overdue"      # NOTE: uses `operationName`, not `operation`
 [steps.params]
 now = "2026-04-27T00:00:00Z"
-# Output: { matched, updated, truncated? }
+# Output: { matched, affected, failed, truncated?, appliedLimit?, warning? }
 ```
 
 Workflows have no batch-write step kind. To apply a set of updates, run `forEach` over a `database.mutate` step (see `forEach` below), or use `database.applyToQuery` for query-driven updates.


### PR DESCRIPTION
## What the issue reported

The workflows guide's `database.applyToQuery` step example documented its output as `{ matched, updated, truncated? }`. A real integration test (primitive-seesaw) failed with `No such key: updated` because the actual payload has no `updated` key.

## Verified against source

`database-operations-controller.ts` (`library_repos/js-bao-wss/src/app-api/controllers/`) builds the applyToQuery response as `{ matched, affected, failed }`, with `truncated`, `appliedLimit`, and (for non-delete ops) `warning` added only when the match set exceeds an *explicitly-set* `source.limit`. When the cap is exceeded and no `source.limit` was set, the call refuses outright with a 400 rather than truncating — confirming the issue's secondary point that `truncated` doesn't mean "silently truncated by default."

This is the same shape already correctly documented in the databases guide (`AGENT_GUIDE_TO_PRIMITIVE_DATABASES.template.md`) and `docs/getting-started/working-with-databases.md:243` — only the workflows guide's example comment was stale.

## What changed

- `guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md` — corrected the output comment on the `applyToQuery` step example to `{ matched, affected, failed, truncated?, appliedLimit?, warning? }`.
- Re-rendered `.ts.md` / `.swift.md` builds via `pnpm render:guides`.

`docs/getting-started/workflows.md`'s applyToQuery example never stated an output shape (nothing stale there), and its sibling `working-with-databases.md` already had the correct shape — so no docs/ change was needed; confirmed via docs-sync-check.

## Validation

- `pnpm build:source-packages` (next channel gates read submodule source)
- `pnpm check:examples` — pass
- `npx vitepress build docs` — pass
- docs-page-review and docs-sync-check run on the diff — clean

Fixes #266