### PR TITLE
Document runSync timeout terminal semantics (#267)

### DIFF
--- a/docs/getting-started/workflows.md
+++ b/docs/getting-started/workflows.md
@@ -164,7 +164,7 @@ For short, latency-sensitive workflows, opt the workflow into synchronous invoca
 
 :::
 
-The promise resolves for every terminal outcome; only network errors reject. Long-running workflows should use asynchronous `start()` instead.
+The promise resolves for every terminal outcome, including `timeout`; only network errors reject. A timeout doesn't cancel the workflow, but there's no way to recover its outcome afterward — for a workflow where the final result matters, use asynchronous `start()` with `getStatus` instead.
 
 ### Typed Invocations (TypeScript Codegen)
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.swift.md
@@ -1399,10 +1399,10 @@ Opt a workflow into synchronous invocation by setting `syncCallable = true` in t
 Server-side constraints on a `syncCallable` workflow:
 
 - **Step kinds are restricted.** The server validates step kinds against a sync-compatible list when the flag is set (or when steps are pushed against a sync-callable workflow). Long-running or suspending kinds (`event.wait`, `delay` over the timeout) reject at save time with `Workflow contains sync-incompatible steps`.
-- **Timeout.** The invocation timeout defaults to 5s and is capped server-side at 30s (the server CPU budget per request). Exceeding it resolves with `status: "timeout"`.
+- **Timeout.** The invocation timeout defaults to 5s and is capped server-side at 30s (the server CPU budget per request). Exceeding it resolves with `status: "timeout"` — the run isn't cancelled at that boundary, the steps already in flight keep running, but the caller has no way to learn how they end. The run record is stamped `terminated` the moment the timeout fires and is never later updated to `completed`/`failed`. `getStatus` can't recover it either: a `runSync` run has no backing instance the way a `start()` run does, so polling `getStatus` on its `runId` returns `status: "missing"`. There's no supported way to recover a `runSync` call's true outcome after a timeout — for a workflow where the final result matters, use `start()` with `getStatus` instead.
 - **Apply still applies.** A sync-callable workflow may still have `requiresClientApply = true`, in which case the synchronous call resolves with `status: "apply_pending"` and the normal `claimApply`/`confirmApply` flow takes over. Most sync-callable workflows want `requiresClientApply = false`.
 
-Long-running workflows should keep using `start()` plus the WebSocket / polling lifecycle.
+Long-running workflows should keep using `start()` plus the WebSocket / polling lifecycle — a `runSync` timeout has no recovery path, so it's unsafe for anything where you need to know the final outcome.
 
 Call `workflows.runSync` and await the final envelope:
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md
@@ -1376,10 +1376,10 @@ Opt a workflow into synchronous invocation by setting `syncCallable = true` in t
 Server-side constraints on a `syncCallable` workflow:
 
 - **Step kinds are restricted.** The server validates step kinds against a sync-compatible list when the flag is set (or when steps are pushed against a sync-callable workflow). Long-running or suspending kinds (`event.wait`, `delay` over the timeout) reject at save time with `Workflow contains sync-incompatible steps`.
-- **Timeout.** The invocation timeout defaults to 5s and is capped server-side at 30s (the server CPU budget per request). Exceeding it resolves with `status: "timeout"`.
+- **Timeout.** The invocation timeout defaults to 5s and is capped server-side at 30s (the server CPU budget per request). Exceeding it resolves with `status: "timeout"` — the run isn't cancelled at that boundary, the steps already in flight keep running, but the caller has no way to learn how they end. The run record is stamped `terminated` the moment the timeout fires and is never later updated to `completed`/`failed`. `getStatus` can't recover it either: a `runSync` run has no backing instance the way a `start()` run does, so polling `getStatus` on its `runId` returns `status: "missing"`. There's no supported way to recover a `runSync` call's true outcome after a timeout — for a workflow where the final result matters, use `start()` with `getStatus` instead.
 - **Apply still applies.** A sync-callable workflow may still have `requiresClientApply = true`, in which case the synchronous call resolves with `status: "apply_pending"` and the normal `claimApply`/`confirmApply` flow takes over. Most sync-callable workflows want `requiresClientApply = false`.
 
-Long-running workflows should keep using `start()` plus the WebSocket / polling lifecycle.
+Long-running workflows should keep using `start()` plus the WebSocket / polling lifecycle — a `runSync` timeout has no recovery path, so it's unsafe for anything where you need to know the final outcome.
 
 Call `workflows.runSync` and await the final envelope:
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.ts.md
@@ -1404,10 +1404,10 @@ Opt a workflow into synchronous invocation by setting `syncCallable = true` in t
 Server-side constraints on a `syncCallable` workflow:
 
 - **Step kinds are restricted.** The server validates step kinds against a sync-compatible list when the flag is set (or when steps are pushed against a sync-callable workflow). Long-running or suspending kinds (`event.wait`, `delay` over the timeout) reject at save time with `Workflow contains sync-incompatible steps`.
-- **Timeout.** The invocation timeout defaults to 5s and is capped server-side at 30s (the server CPU budget per request). Exceeding it resolves with `status: "timeout"`.
+- **Timeout.** The invocation timeout defaults to 5s and is capped server-side at 30s (the server CPU budget per request). Exceeding it resolves with `status: "timeout"` — the run isn't cancelled at that boundary, the steps already in flight keep running, but the caller has no way to learn how they end. The run record is stamped `terminated` the moment the timeout fires and is never later updated to `completed`/`failed`. `getStatus` can't recover it either: a `runSync` run has no backing instance the way a `start()` run does, so polling `getStatus` on its `runId` returns `status: "missing"`. There's no supported way to recover a `runSync` call's true outcome after a timeout — for a workflow where the final result matters, use `start()` with `getStatus` instead.
 - **Apply still applies.** A sync-callable workflow may still have `requiresClientApply = true`, in which case the synchronous call resolves with `status: "apply_pending"` and the normal `claimApply`/`confirmApply` flow takes over. Most sync-callable workflows want `requiresClientApply = false`.
 
-Long-running workflows should keep using `start()` plus the WebSocket / polling lifecycle.
+Long-running workflows should keep using `start()` plus the WebSocket / polling lifecycle — a `runSync` timeout has no recovery path, so it's unsafe for anything where you need to know the final outcome.
 
 Call `workflows.runSync` and await the final envelope:
 


### PR DESCRIPTION
## What the issue reported

The synchronous-invocation section documented `timeoutMs` and that exceeding it resolves with `status: "timeout"`, but not what happens to the run afterward — whether execution continues server-side, what terminal status the run record reaches, and whether polling `getStatus` on the returned `runId` is the sanctioned recovery. A real workflow (`class-provision`, a resource-lifecycle workflow invoked via `runSync` with `timeoutMs: 30000`) needed this to decide between two opposite recoveries on timeout (poll-and-wait vs. assume-dead-and-teardown), and guessing wrong either duplicates a class or destroys a live one.

## Verified against source

Read `workflows-controller.ts` in `library_repos/js-bao-wss` directly (`runSync`, `status` methods):

- **No cancellation.** `runSync` races the engine against a timer via an `AbortController`, but the abort never reaches the engine — its own comment states there's "no AbortSignal hooked into runners today" and "the engine work continues in the background, but the caller sees the timeout envelope."
- **No later reconciliation.** After a short 50ms grace window to salvage in-flight step results, `dbStatusFor` maps *both* `"timeout"` and `"terminated"` outcomes to a DB status of `"terminated"`, written synchronously within the same request. Nothing in this path revisits the row afterward to promote it to `completed`/`failed`.
- **`getStatus` doesn't recover it.** `status()` resolves a run via the `WORKFLOW_APP` binding instance, which is only ever created by `start()`'s `launchWorkflowRun`. `runSync` never creates that instance — its `instanceId` is built "for audit/listings parity with start()" only (a label, not a real backing instance) — so calling `getStatus` on a runSync run's `runId` fails to resolve an instance and returns `status: "missing"`.

**Bottom line documented:** there is currently no supported way to recover a `runSync` call's true outcome after a timeout. For workflows where the final result matters, the guidance is to use `start()` + `getStatus` instead of `runSync`.

## What changed

- `guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md` — expanded the "Synchronous invocation" section's Timeout bullet with the full terminal-state contract; re-rendered `.ts.md` / `.swift.md`.
- `docs/getting-started/workflows.md` — added one practical-guidance sentence to the concept page's "From Your App (Synchronous)" section (concept-tier altitude; full mechanism detail stays in the guide).

## Validation

- `pnpm build:source-packages`
- `pnpm check:examples` — pass
- `npx vitepress build docs` — pass
- Self-reviewed against STYLE.md (tier, never-say list, infra-internal-name sweep) — clean; both docs/ and guides/ sides updated together with matching facts

Fixes #267