### PR TITLE
Correct applyToQuery step output shape in workflows guide (#266)

### DIFF
--- a/docs/getting-started/working-with-databases.md
+++ b/docs/getting-started/working-with-databases.md
@@ -240,7 +240,7 @@ type = "string"
 required = true
 ```
 
-**Response:** `{ matched, affected, failed }` — when the definition sets a `source.limit`, the response also carries `truncated` and `appliedLimit`. Re-running until `truncated` comes back `false` drains the backlog only when the action makes records stop matching the filter — a `delete`, or a `patch` of a filtered field (like `status` above). With an action that leaves the filter's fields untouched (an `increment`, say), each re-run processes the same first batch again.
+**Response:** `{ matched, affected, failed }` — when a `source.limit` is set and the match set exceeds it, the response adds `truncated: true` and `appliedLimit`. Re-running until the response no longer reports `truncated` drains the backlog only when the action makes records stop matching the filter — a `delete`, or a `patch` of a filtered field (like `status` above). With an action that leaves the filter's fields untouched (an `increment`, say), each re-run processes the same first batch again.
 
 ### Batch
 Apply many individual writes in a single request by calling a regular mutation operation in bulk with `executeBatch`. The operation's `access` rule is re-evaluated against each item's params — if any item fails authorization the whole batch is rejected before any writes happen. The response is `{ imported, failed }`.

--- a/docs/getting-started/working-with-databases.md
+++ b/docs/getting-started/working-with-databases.md
@@ -240,7 +240,7 @@ type = "string"
 required = true
 ```
 
-**Response:** `{ matched, affected, failed }` — when the definition sets a `source.limit`, the response also carries `truncated` and `appliedLimit`; if `truncated` is `true`, re-run until it returns `false`.
+**Response:** `{ matched, affected, failed }` — when the definition sets a `source.limit`, the response also carries `truncated` and `appliedLimit`. Re-running until `truncated` comes back `false` drains the backlog only when the action makes records stop matching the filter — a `delete`, or a `patch` of a filtered field (like `status` above). With an action that leaves the filter's fields untouched (an `increment`, say), each re-run processes the same first batch again.
 
 ### Batch
 Apply many individual writes in a single request by calling a regular mutation operation in bulk with `executeBatch`. The operation's `access` rule is re-evaluated against each item's params — if any item fails authorization the whole batch is rejected before any writes happen. The response is `{ imported, failed }`.

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.swift.md
@@ -285,7 +285,10 @@ databaseId = "{{ input.tasksDbId }}"
 operationName = "mark-overdue"      # NOTE: uses `operationName`, not `operation`
 [steps.params]
 now = "2026-04-27T00:00:00Z"
-# Output: { matched, updated, truncated? }
+# Output: { matched, affected, failed } — matched === affected + failed.
+# If the definition sets a `source.limit`, the response may add
+# `truncated: true` + `appliedLimit`; without one, a match over the
+# default cap (1000) fails the step instead of truncating.
 ```
 
 Workflows have no batch-write step kind. To apply a set of updates, run `forEach` over a `database.mutate` step (see `forEach` below), or use `database.applyToQuery` for query-driven updates.

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md
@@ -285,7 +285,10 @@ databaseId = "{{ input.tasksDbId }}"
 operationName = "mark-overdue"      # NOTE: uses `operationName`, not `operation`
 [steps.params]
 now = "2026-04-27T00:00:00Z"
-# Output: { matched, updated, truncated? }
+# Output: { matched, affected, failed } — matched === affected + failed.
+# If the definition sets a `source.limit`, the response may add
+# `truncated: true` + `appliedLimit`; without one, a match over the
+# default cap (1000) fails the step instead of truncating.
 ```
 
 Workflows have no batch-write step kind. To apply a set of updates, run `forEach` over a `database.mutate` step (see `forEach` below), or use `database.applyToQuery` for query-driven updates.

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.ts.md
@@ -285,7 +285,10 @@ databaseId = "{{ input.tasksDbId }}"
 operationName = "mark-overdue"      # NOTE: uses `operationName`, not `operation`
 [steps.params]
 now = "2026-04-27T00:00:00Z"
-# Output: { matched, updated, truncated? }
+# Output: { matched, affected, failed } — matched === affected + failed.
+# If the definition sets a `source.limit`, the response may add
+# `truncated: true` + `appliedLimit`; without one, a match over the
+# default cap (1000) fails the step instead of truncating.
 ```
 
 Workflows have no batch-write step kind. To apply a set of updates, run `forEach` over a `database.mutate` step (see `forEach` below), or use `database.applyToQuery` for query-driven updates.


### PR DESCRIPTION
## What the issue reported

The workflows guide's `database.applyToQuery` step example documented the output as `{ matched, updated, truncated? }`. A `runIf` gate written from that shape (`steps.publishTeacher.updated > 0`) failed with `No such key: updated` in a real app (primitive-seesaw).

## Verified against source

`library_repos/js-bao-wss/src/app-api/controllers/database-operations-controller.ts` (stamped submodule): the payload is `{ matched, affected, failed }` with the invariant `matched === affected + failed`. One refinement over the issue text: `truncated: true` + `appliedLimit` **do** exist, but only when the operation sets an explicit `source.limit` and the match set exceeds it — without an explicit limit, an over-cap match (default cap 1000) refuses to apply with a 400 rather than truncating. The field is absent (never `false`) when nothing was truncated.

## What changed

- `guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md` — the step example's output comment now states the real shape, the invariant, and the over-cap refusal (builds re-rendered).
- `docs/getting-started/working-with-databases.md` — the response line's "re-run until `truncated` is false" advice is qualified: the loop only drains the backlog when the action makes records stop matching the filter (a `delete`, or a `patch` of a filtered field); it also now states that `truncated`/`appliedLimit` appear only on actual truncation.

The databases agent guide already stated the correct shape and caveat; no edit needed there.

## Validation

- `pnpm check:examples` green (parity, TOML, 468 CLI invocations, sync-map, source stamp)
- `npx vitepress build docs` green
- docs-page-review + docs-sync-check run on both touched files; the one surviving finding (truncated-only-on-truncation precision) is fixed in this PR

Fixes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)