### PR TITLE
Fix two dead cross-guide anchors (set-audit findings)

### DIFF
--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_INVITATIONS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_INVITATIONS.swift.md
@@ -226,7 +226,7 @@ The accept call (shown in [Accept an invite token](#accept-an-invite-token) abov
 
 ## Deferred Grants
 
-Deferred grants bridge "I have an email" and "they're in the app." When you share a document, add someone to a group, or add them to a collection **by email** and that email isn't yet a user, the platform mints (or reuses) an `AppInvitation` and records the pending grant. The grant-side mechanics live with each resource (documents in the [Documents guide](AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.md#document-sharing), groups in the [Users and Groups guide](AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.md#managing-members)); the resolution lifecycle is below.
+Deferred grants bridge "I have an email" and "they're in the app." When you share a document, add someone to a group, or add them to a collection **by email** and that email isn't yet a user, the platform mints (or reuses) an `AppInvitation` and records the pending grant. The grant-side mechanics live with each resource (documents in the [Documents guide](AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.md#sharing-documents), groups in the [Users and Groups guide](AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.md#managing-members)); the resolution lifecycle is below.
 
 ### Lifecycle
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_INVITATIONS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_INVITATIONS.template.md
@@ -203,7 +203,7 @@ The accept call (shown in [Accept an invite token](#accept-an-invite-token) abov
 
 ## Deferred Grants
 
-Deferred grants bridge "I have an email" and "they're in the app." When you share a document, add someone to a group, or add them to a collection **by email** and that email isn't yet a user, the platform mints (or reuses) an `AppInvitation` and records the pending grant. The grant-side mechanics live with each resource (documents in the [Documents guide](AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.md#document-sharing), groups in the [Users and Groups guide](AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.md#managing-members)); the resolution lifecycle is below.
+Deferred grants bridge "I have an email" and "they're in the app." When you share a document, add someone to a group, or add them to a collection **by email** and that email isn't yet a user, the platform mints (or reuses) an `AppInvitation` and records the pending grant. The grant-side mechanics live with each resource (documents in the [Documents guide](AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.md#sharing-documents), groups in the [Users and Groups guide](AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.md#managing-members)); the resolution lifecycle is below.
 
 ### Lifecycle
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_INVITATIONS.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_INVITATIONS.ts.md
@@ -221,7 +221,7 @@ The accept call (shown in [Accept an invite token](#accept-an-invite-token) abov
 
 ## Deferred Grants
 
-Deferred grants bridge "I have an email" and "they're in the app." When you share a document, add someone to a group, or add them to a collection **by email** and that email isn't yet a user, the platform mints (or reuses) an `AppInvitation` and records the pending grant. The grant-side mechanics live with each resource (documents in the [Documents guide](AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.md#document-sharing), groups in the [Users and Groups guide](AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.md#managing-members)); the resolution lifecycle is below.
+Deferred grants bridge "I have an email" and "they're in the app." When you share a document, add someone to a group, or add them to a collection **by email** and that email isn't yet a user, the platform mints (or reuses) an `AppInvitation` and records the pending grant. The grant-side mechanics live with each resource (documents in the [Documents guide](AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.md#sharing-documents), groups in the [Users and Groups guide](AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.md#managing-members)); the resolution lifecycle is below.
 
 ### Lifecycle
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.swift.md
@@ -748,7 +748,7 @@ Then push with `primitive sync push`. The SDK equivalents are `client.collection
 
 ## Common Patterns
 
-For full app architecture examples showing how groups fit alongside documents and databases, see the [Data Modeling guide](AGENT_GUIDE_TO_PRIMITIVE_DATA_MODELING.md#example-app-architectures).
+For full app architecture examples showing how groups fit alongside documents and databases, see the [Data Modeling guide](AGENT_GUIDE_TO_PRIMITIVE_DATA_MODELING.md#worked-architectures).
 
 ### Team-based workspace access
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.template.md
@@ -552,7 +552,7 @@ Then push with `primitive sync push`. The SDK equivalents are `client.collection
 
 ## Common Patterns
 
-For full app architecture examples showing how groups fit alongside documents and databases, see the [Data Modeling guide](AGENT_GUIDE_TO_PRIMITIVE_DATA_MODELING.md#example-app-architectures).
+For full app architecture examples showing how groups fit alongside documents and databases, see the [Data Modeling guide](AGENT_GUIDE_TO_PRIMITIVE_DATA_MODELING.md#worked-architectures).
 
 ### Team-based workspace access
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.ts.md
@@ -729,7 +729,7 @@ Then push with `primitive sync push`. The SDK equivalents are `client.collection
 
 ## Common Patterns
 
-For full app architecture examples showing how groups fit alongside documents and databases, see the [Data Modeling guide](AGENT_GUIDE_TO_PRIMITIVE_DATA_MODELING.md#example-app-architectures).
+For full app architecture examples showing how groups fit alongside documents and databases, see the [Data Modeling guide](AGENT_GUIDE_TO_PRIMITIVE_DATA_MODELING.md#worked-architectures).
 
 ### Team-based workspace access
 


### PR DESCRIPTION
The post-sweep docs-set-audit found two pre-existing dead cross-guide anchors (both broken for any agent following them):

- `AGENT_GUIDE_TO_PRIMITIVE_INVITATIONS.template.md:206` linked `AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.md#document-sharing`; the real heading is `## Sharing Documents` (`#sharing-documents`).
- `AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.template.md:555` linked `AGENT_GUIDE_TO_PRIMITIVE_DATA_MODELING.md#example-app-architectures`; the real heading is `## Worked architectures` (`#worked-architectures`).

Template edits + re-rendered builds. `pnpm check:examples` and `npx vitepress build docs` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)