### PR TITLE
docs-next-sync: js-bao-wss c9d6fc0c..ae9f096d (bulkUpdate, ulid, resource.attrs, metadata tooling, projection strip, trigger fields, Config Vars)

### DIFF
--- a/docs-sources.json
+++ b/docs-sources.json
@@ -3,7 +3,7 @@
   "stampedAt": "2026-07-14",
   "libraries": {
     "js-bao-wss": {
-      "commit": "c9d6fc0c2cfc479ed0da9168f548887b8aadac3d",
+      "commit": "ae9f096d6c1a2e8665c65731bad6ff477bf60804",
       "npm": {
         "js-bao-wss-client": "2.0.4",
         "js-bao": "0.5.1",

--- a/docs/getting-started/admin-console.md
+++ b/docs/getting-started/admin-console.md
@@ -6,6 +6,7 @@ The Primitive Admin Console is a web-based dashboard for managing your apps, use
 
 ### App Configuration
 - View and update app settings (name, mode, allowed origins)
+- Manage [app secrets](./app-secrets.md) (values write-only — never displayed after saving) and non-secret [config vars](./app-secrets.md#config-vars) (values shown in plain text)
 - Configure authentication providers (Google OAuth credentials, Magic Link, OTP, Passkeys)
 - Manage email templates for authentication flows
 - Set invite-only mode for controlled access

--- a/docs/getting-started/app-secrets.md
+++ b/docs/getting-started/app-secrets.md
@@ -71,7 +71,7 @@ primitive vars list
 primitive vars delete ADMIN_GROUP_ID
 ```
 
-Unlike secrets, vars are readable: `list` shows every value, and a var may appear unmasked in debug traces. Never store a credential in a var.
+Unlike secrets, vars are readable: `list` shows every value, and a var may appear unmasked in debug traces. Never store a credential in a var. Vars (like secrets) can also be managed from the [Admin Console](./admin-console.md), where their values display in plain text.
 
 ::: warning The CEL `vars.*` variable is declared-only
 A CEL rule reads a var as `vars.<KEY>`, bound only to the keys the owning config **declares** — the same declared-only discipline as `secrets.*`. List them in the owning config's TOML alongside any declared secrets:

--- a/docs/getting-started/primitive-cli.md
+++ b/docs/getting-started/primitive-cli.md
@@ -332,6 +332,10 @@ Read and write [resource metadata](./resource-metadata.md) category values — c
 primitive metadata set user 01HXY... profile --data '{"tier":"pro"}'
 primitive metadata get user 01HXY... profile --json
 primitive metadata get-batch --resource user:01HXY...:profile,billing
+primitive metadata list user 01HXY...                # every stored category on a resource
+primitive metadata delete user 01HXY... profile      # idempotent
+primitive metadata categories list                   # inspect category definitions
+primitive metadata categories get user profile
 ```
 
 ### Integrations

--- a/docs/getting-started/resource-metadata.md
+++ b/docs/getting-started/resource-metadata.md
@@ -33,7 +33,15 @@ primitive sync push
 
 Field types are `string`, `number`, `boolean`, `date`, `id`, and `stringset`; `enum` is valid only on a `string` field. A category holds up to 100 keys and 16 KB of data, and writes are validated against the schema before they're stored.
 
-`readRule` and `writeRule` are CEL expressions evaluated against `user.*` (the caller) and `resource.*` (`resourceType`, `resourceId` — also reachable as `resource.id` — and `category`) — app-level owners and admins bypass both. The bypass is the app role only: holding a permission on the resource itself (being a database's owner or manager, say) grants no bypass — the rule is what authorizes resource-scoped callers. `writeRule` gates the write API; `readRule` gates the read API. Omit either and it defaults to deny.
+`readRule` and `writeRule` are CEL expressions evaluated against `user.*` (the caller) and `resource.*` (`resourceType`, `resourceId` — also reachable as `resource.id` — and `category`) — app-level owners and admins bypass both.
+
+When the metadata subject is a database, workflow, or collection, the rule can also read the resource's own columns through `resource.attrs` — for example, a creator-bootstrap rule that lets whoever created a database write its metadata:
+
+```toml novalidate
+writeRule = "user.userId == resource.attrs.createdBy"
+```
+
+Only those three resource types (and only a fixed set of columns per type) resolve; a rule that references `resource.attrs` on any other resource type, or a column outside the set, denies. The bypass is the app role only: holding a permission on the resource itself (being a database's owner or manager, say) grants no bypass — the rule is what authorizes resource-scoped callers. `writeRule` gates the write API; `readRule` gates the read API. Omit either and it defaults to deny.
 
 A category rule can also use the [identity context's](./access-control.md#the-identity-context) group-membership helpers, so access can be group-scoped instead of just self-scoped:
 
@@ -106,6 +114,30 @@ primitive metadata get-batch --resource user:01HXY...:profile,billing --resource
 ```
 
 A batch call covers up to 50 resources and 200 resource/category pairs total.
+
+### Listing and Deleting
+
+To see everything stored on one resource — say, while debugging why a rule isn't matching — list its categories in one call; to remove a category's data, delete it:
+
+```typescript
+const { categories } = await client.resourceMetadata.list("user", userId);
+// [{ category: "profile", data: {...}, schemaVersion }, ...] — only categories your readRule lets you see
+
+const { deleted } = await client.resourceMetadata.delete("user", userId, "profile");
+// deleted: false when nothing was stored — deleting an absent item is not an error
+```
+
+```bash
+primitive metadata list user 01HXY...
+primitive metadata delete user 01HXY... profile
+```
+
+`list` returns the categories the caller may read (each category's `readRule` applies, and app-level owners and admins see everything — the CLI reads as an admin, so it always shows all categories). The CLI can also inspect category *definitions* — schema, rules, version — without opening TOML files:
+
+```bash
+primitive metadata categories list
+primitive metadata categories get user profile
+```
 
 ## Using Metadata in Access Rules
 

--- a/docs/getting-started/workflows.md
+++ b/docs/getting-started/workflows.md
@@ -515,6 +515,7 @@ Every step has an `id` (unique within the workflow) and a `kind` (the step type)
 | `integration.call` | Call an external API via a configured integration |
 | `database.query` / `mutate` / `count` / `aggregate` / `pipeline` / `applyToQuery` | Run registered database operations |
 | `document.query` / `queryOne` / `count` / `save` / `patch` / `delete` | Read and write records in a document's models |
+| `document.bulkUpdate` | Apply creates, patches, and deletes across several models in one atomic write |
 | `document.resolveAlias` | Resolve a document alias to its id (or null) for conditional branching |
 | `group.addMember` / `removeMember` / `removeAll` / `checkMembership` / `listMembers` / `listUserMemberships` | Group membership operations |
 | `collection.addDocument` / `removeDocument` | Add a document to a [collection](./working-with-documents.md#collections) or remove one |
@@ -556,7 +557,7 @@ The step's result is the templated table itself — `steps.final` (and `outputs.
 
 ### `script`
 
-For data shaping that's more involved than a templated `transform` step — reshaping nested JSON, computing derived fields, filtering and mapping arrays — a `script` step runs a sandboxed [Rhai](https://rhai.rs/) script over its JSON input and returns JSON. Scripts are **deterministic and side-effect-free** (no network, no clock, no storage), so they're safe to retry and easy to test.
+For data shaping that's more involved than a templated `transform` step — reshaping nested JSON, computing derived fields, filtering and mapping arrays — a `script` step runs a sandboxed [Rhai](https://rhai.rs/) script over its JSON input and returns JSON. Scripts are **side-effect-free** (no network, no storage) and deterministic, so they're safe to retry and easy to test — with one deliberate exception: the `ulid()` builtin mints a fresh, sortable unique id on each call (for pre-minting record ids ahead of a `document.bulkUpdate` write), so a script that calls it returns different ids run to run, while a script that doesn't stays fully reproducible.
 
 A script body lives in your sync directory as `transforms/<name>.rhai` and is pushed with `primitive sync push`:
 
@@ -878,7 +879,22 @@ records = "{{ steps.rows.output.result.rows }}"   # each { id?, ...fields } — 
 
 `document.save` returns `{ saved, savedIds }` and `document.patch` returns `{ patched, patchedIds }` (each element of `records` needs an `id` for `patch`); `document.delete` returns `{ deleted }` (a non-existent id is a no-op, not an error). Re-running a batch save whose records had no `id` mints fresh ids each time rather than upserting the same ones — give records an explicit `id` if the workflow might retry.
 
-### Group Steps
+**Writing across models atomically.** Batch mode works on one model at a time, and a batch over 100 records commits chunk by chunk. When a write spans models and must land whole — create an account, adjust a ledger, retire a stale position, all or nothing — `document.bulkUpdate` applies an ordered list of `operations` across any of the document's models in a single transaction with a single change broadcast:
+
+```toml
+[[steps]]
+id = "apply-rebalance"
+kind = "document.bulkUpdate"
+documentId = "{{ outputs.doc.documentId }}"
+saveAs = "applied"
+operations = [
+  { model = "Account",  action = "create", id = "{{ input.newAccountId }}", fields = { name = "Growth", balance = 0 } },
+  { model = "Ledger",   action = "patch",  id = "{{ input.ledgerId }}", fields = { rebalancedAt = "{{ now }}" } },
+  { model = "Position", action = "delete", id = "{{ input.staleId }}" },
+]
+```
+
+Each operation names its `model`, an `action` (`create`, `patch`, or `delete` — that exact vocabulary), and an `id`; `create` and `patch` carry the record fields in `fields`. A `create` never mints its id server-side: the caller supplies a ULID (26 uppercase characters), typically from the <span v-pre>`{{ ulid }}`</span> [template helper](#built-in-helpers) or a script's `ulid()` builtin — which also lets one operation reference the id another operation in the same list just created. Up to 500 operations apply in listed order, all-or-nothing: a `create` whose id already exists or a `patch` whose id doesn't fails the whole blob and nothing commits. The step returns `{ applied, added, updated, deleted }`, where `added` and `updated` list `{ model, id }` per committed create and patch. Like the other document writes, caller-mode runs need `read-write` on the document, and `documentAlias` targeting works here too.
 
 `group.addMember`, `group.removeMember`, `group.removeAll`, `group.checkMembership`, `group.listMembers`, and `group.listUserMemberships` manage [groups](./users-and-groups.md) from a workflow:
 

--- a/docs/getting-started/working-with-databases.md
+++ b/docs/getting-started/working-with-databases.md
@@ -139,6 +139,8 @@ required = true
 
 **Response:** `{ data: [...records], hasMore: boolean, nextCursor?: string }`
 
+A `projection` in the definition controls which fields come back. The inclusion form `projection = { title = 1, status = 1 }` returns just those fields (plus `id`); the exclusion form `projection = { internalNotes = 0 }` strips the named fields on the server before the response is built, so an operation can expose a model while keeping sensitive columns from ever reaching the caller. `id` and `type` are always returned.
+
 A parameter can also be an array — declare `type = "array"` with a scalar `items` type, and callers pass a list for the filter to consume with `$in` / `$nin`:
 
 ```toml
@@ -585,7 +587,7 @@ Each change carries two discriminants: `op` — the underlying write — and `ch
 
 | `op` | `data` | `previousData` |
 |---|---|---|
-| `save` | The full submitted row | The pre-write row; `null` for a fresh insert |
+| `save` | The full row as persisted (the submitted row, with server-applied fields merged over it) | The pre-write row; `null` for a fresh insert |
 | `patch` | **The patched fields only**, at their new values | The pre-write row |
 | `increment` | The per-field increment **amounts** — not the resulting values | The pre-write row |
 | `addToSet` / `removeFromSet` | The values **added or removed** per field — not the resulting sets | The pre-write row |
@@ -593,7 +595,7 @@ Each change carries two discriminants: `op` — the underlying write — and `ch
 
 Everything in both columns passes through the subscription's `select` projection. An `applyToQuery` operation arrives as one `patch`/`increment`/set-op/`delete` change per matched record — there is no `applyToQuery` op on the wire. And because `data`'s shape follows `op`, an `enter` transition doesn't imply a full row: a patch that brings a row into the filter set delivers `changeType: "enter"` with only the changed fields.
 
-One addition to the table: when the type configures `timestamps`, the server-stamped fields ride along in `data` on `save` and `patch` at their persisted values (subject to `select`) — a patch's `data` is the patched fields plus the stamp. `increment` and the set ops don't stamp, so their frames carry no stamp fields.
+One addition to the table: server-applied fields — `timestamps` stamps, `autoPopulatedFields`, and trigger `set` values — ride along in `data` on `save` and `patch` at their persisted values (subject to `select`), and a server-applied value wins over what the caller submitted for the same field. A patch's `data` is the patched fields plus those server-applied fields. Subscription `filter` expressions also see them, so a filter can match on a trigger-computed field. `increment` and the set ops don't stamp, so their frames carry no server-applied fields.
 
 **Merge, don't assign.** Replacing a cached row with `change.data` on a patch silently blanks every field the write didn't touch. Key your cache on `change.id`, replace the row on `save`, merge the fields present in `data` on a `patch`, and drop the row on `delete`. For `increment` and the set ops, `data` is the *delta*, not the new value — derive the new value from `previousData` plus `data` (add the amount; union or subtract the set values), the pattern the example above follows. If your handler needs a field the write didn't include (say, a grouping key), read it from `previousData`.
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_APP_SECRETS.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_APP_SECRETS.md
@@ -54,7 +54,7 @@ Declare a var for CEL access the same way as a secret, in the owning config's to
 vars = ["ADMIN_GROUP_ID"]
 ```
 
-A rule reads it as `vars.<KEY>`, bound only to declared keys — an undeclared `vars.KEY` is absent at evaluation (denies closed), exactly like `secrets.*`. Vars bind in workflow CEL contexts (`runIf`, `switch` `when`, predicate expressions on batch/collect steps), database operation `access`/per-param `access`, database trigger CEL, and trigger stamp `value` expressions. There is no `{{vars.KEY}}` template-resolution form (vars are CEL-only, unlike secrets which also resolve in integration/webhook templates) and no client-side read API — `primitive vars list`/the admin API are the only read surfaces.
+A rule reads it as `vars.<KEY>`, bound only to declared keys — an undeclared `vars.KEY` is absent at evaluation (denies closed), exactly like `secrets.*`. Vars bind in workflow CEL contexts (`runIf`, `switch` `when`, predicate expressions on batch/collect steps), database operation `access`/per-param `access`, database trigger CEL, and trigger stamp `value` expressions. There is no `{{vars.KEY}}` template-resolution form (vars are CEL-only, unlike secrets which also resolve in integration/webhook templates) and no client-side read API — `primitive vars list`, the admin API, and the Admin Console's Config Vars view are the only read surfaces.
 
 ## Related guides
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_APP_SECRETS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_APP_SECRETS.template.md
@@ -54,7 +54,7 @@ Declare a var for CEL access the same way as a secret, in the owning config's to
 vars = ["ADMIN_GROUP_ID"]
 ```
 
-A rule reads it as `vars.<KEY>`, bound only to declared keys — an undeclared `vars.KEY` is absent at evaluation (denies closed), exactly like `secrets.*`. Vars bind in workflow CEL contexts (`runIf`, `switch` `when`, predicate expressions on batch/collect steps), database operation `access`/per-param `access`, database trigger CEL, and trigger stamp `value` expressions. There is no `{{vars.KEY}}` template-resolution form (vars are CEL-only, unlike secrets which also resolve in integration/webhook templates) and no client-side read API — `primitive vars list`/the admin API are the only read surfaces.
+A rule reads it as `vars.<KEY>`, bound only to declared keys — an undeclared `vars.KEY` is absent at evaluation (denies closed), exactly like `secrets.*`. Vars bind in workflow CEL contexts (`runIf`, `switch` `when`, predicate expressions on batch/collect steps), database operation `access`/per-param `access`, database trigger CEL, and trigger stamp `value` expressions. There is no `{{vars.KEY}}` template-resolution form (vars are CEL-only, unlike secrets which also resolve in integration/webhook templates) and no client-side read API — `primitive vars list`, the admin API, and the Admin Console's Config Vars view are the only read surfaces.
 
 ## Related guides
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.swift.md
@@ -783,6 +783,8 @@ required = true
 
 Definition fields: `filter` (required), `sort`, `limit` (1–1000), `projection`, `include`.
 
+`projection` values are exactly `1` (inclusion — returns the projected fields plus `id`) or `0` (exclusion — the named fields are stripped server-side before the response leaves the store, so exclusion withholds a column, it doesn't just shrink the payload). Validation, enforced both when the operation is saved and on the runtime request (400): inclusion and exclusion can't mix; an exclusion can't name `id` or `type` (system identity fields, always returned); and a query can't sort on a field its projection excludes (the sort value would leak through the pagination cursor).
+
 Callers can override `limit`, `cursor`, and `direction` at call time (effective limit is the lesser of definition and caller limits).
 
 **Response:** `{ data: [...], hasMore: boolean, nextCursor?: string, prevCursor?: string }` (`prevCursor` appears from the second page on)
@@ -1645,7 +1647,7 @@ public struct DatabaseChangeEvent {
     public let changeType: String?
     public let modelName: String
     public let id: String
-    public let data: Any?          // save → the FULL submitted row; patch → the patched fields' new values
+    public let data: Any?          // save → the full row as persisted (server-applied fields win); patch → the patched fields' new values
                                    // (both plus any `timestamps`-stamped fields at their persisted values);
                                    // increment/addToSet/removeFromSet → the op INPUT (amounts / values
                                    // added-or-removed), not the resulting values; nil on delete.
@@ -1655,7 +1657,7 @@ public struct DatabaseChangeEvent {
 }
 ```
 
-**The shape of `data` follows `op`, not `changeType`.** A `save` delivers the full row; a `patch` delivers **the patched fields only, at their new values**; `increment` delivers the per-field increment **amounts** and `addToSet`/`removeFromSet` deliver the values **added or removed** per field — the op *input*, not the resulting values; `delete` delivers no `data`. When the type configures `timestamps`, the stamped fields ride along in `data` on `save` and `patch` at their persisted server values (subject to `select`) — a patch's `data` is the patched fields plus the stamp; `increment` and the set ops don't stamp, so their frames carry none. The pre-write row rides in `previousData` on all of them. An `applyToQuery` operation arrives as one `patch`/`increment`/set-op/`delete` change per matched record — there is no `applyToQuery` op on the wire. Consequences:
+**The shape of `data` follows `op`, not `changeType`.** A `save` delivers the full row; a `patch` delivers **the patched fields only, at their new values**; `increment` delivers the per-field increment **amounts** and `addToSet`/`removeFromSet` deliver the values **added or removed** per field — the op *input*, not the resulting values; `delete` delivers no `data`. Server-applied fields — `timestamps` stamps, `autoPopulatedFields`, and trigger `set` values — ride along in `data` on `save` and `patch` at their persisted server values (subject to `select`), and a server-applied value wins over the caller's submission for the same field, so a trigger that overrides a submitted value delivers the trigger's value. They are visible to the subscription `filter` too, so a filter can match on a trigger-computed field. A patch's `data` is the patched fields plus those server-applied fields; `increment` and the set ops don't stamp, so their frames carry none. The pre-write row rides in `previousData` on all of them. An `applyToQuery` operation arrives as one `patch`/`increment`/set-op/`delete` change per matched record — there is no `applyToQuery` op on the wire. Consequences:
 
 - An `enter` transition does NOT imply a full row: a patch that brings a row into the filter set is `changeType: "enter"` with only the changed fields in `data`.
 - **Merge, don't assign.** Replacing a cached row with `change.data` on a non-`save` op silently blanks every field the write didn't touch. Key the cache on `change.id`; replace on `save`, merge the fields present in `data` on `patch`, remove on `delete`.

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.template.md
@@ -379,7 +379,7 @@ Codegen reads the database-type TOML from the auto-resolved sync directory (`.pr
 
 **Codegen result typing.** Result aliases are derived from each operation's `definition`, not just its `type`:
 
-- `query` with an inclusion `projection` → `QueryResult<Pick<Model, projectedFields | "id">>` (`id` is always returned). Exclusion, dynamic (`$params.*`), or nested-key projections → `QueryResult<Partial<Model>>` (excluded fields are still returned at runtime, so the type stays wide rather than promising removal). No `[models.*]` schema → `QueryResult<Record<string, unknown>>`.
+- `query` with an inclusion `projection` → `QueryResult<Pick<Model, projectedFields | "id">>` (`id` is always returned). Exclusion, dynamic (`$params.*`), or nested-key projections → `QueryResult<Partial<Model>>` (the runtime strips excluded fields server-side, but codegen can't narrow these cases statically, so the type stays wide). No `[models.*]` schema → `QueryResult<Record<string, unknown>>`.
 - `mutation` results type `results` as `MutationStepResult[]` (`{ op: "save" | "patch" | "delete" | "increment" | "addToSet" | "removeFromSet"; success: boolean; id: string; values?: Record<string, number>; error?: string }`) — every mutation op, whatever mix of step kinds it contains, types as the one `MutationResult` shape.
 - `pipeline` with `return = "<step>"` → that step's result type: a query step gets `QueryResult<…>` (projection rules above), a count step `CountResult`, an aggregate step `AggregateResult`. `return = "all"` (or no `return`) stays the generic `PipelineResult` (`{ steps: Record<string, unknown> }`) — declare a local type there if a call site needs precision.
 
@@ -782,6 +782,8 @@ required = true
 ```
 
 Definition fields: `filter` (required), `sort`, `limit` (1–1000), `projection`, `include`.
+
+`projection` values are exactly `1` (inclusion — returns the projected fields plus `id`) or `0` (exclusion — the named fields are stripped server-side before the response leaves the store, so exclusion withholds a column, it doesn't just shrink the payload). Validation, enforced both when the operation is saved and on the runtime request (400): inclusion and exclusion can't mix; an exclusion can't name `id` or `type` (system identity fields, always returned); and a query can't sort on a field its projection excludes (the sort value would leak through the pagination cursor).
 
 Callers can override `limit`, `cursor`, and `direction` at call time (effective limit is the lesser of definition and caller limits).
 
@@ -1433,7 +1435,7 @@ interface DatabaseChangeEvent {
   changeType?: "enter" | "update" | "leave";
   modelName: string;
   id: string;
-  data?: any;          // save → the FULL submitted row; patch → the patched fields' new values
+  data?: any;          // save → the full row as persisted (server-applied fields win); patch → the patched fields' new values
                        // (both plus any `timestamps`-stamped fields at their persisted values);
                        // increment/addToSet/removeFromSet → the op INPUT (amounts / values
                        // added-or-removed), not the resulting values; null on delete.
@@ -1470,7 +1472,7 @@ public struct DatabaseChangeEvent {
     public let changeType: String?
     public let modelName: String
     public let id: String
-    public let data: Any?          // save → the FULL submitted row; patch → the patched fields' new values
+    public let data: Any?          // save → the full row as persisted (server-applied fields win); patch → the patched fields' new values
                                    // (both plus any `timestamps`-stamped fields at their persisted values);
                                    // increment/addToSet/removeFromSet → the op INPUT (amounts / values
                                    // added-or-removed), not the resulting values; nil on delete.
@@ -1481,7 +1483,7 @@ public struct DatabaseChangeEvent {
 ```
 {{/lang}}
 
-**The shape of `data` follows `op`, not `changeType`.** A `save` delivers the full row; a `patch` delivers **the patched fields only, at their new values**; `increment` delivers the per-field increment **amounts** and `addToSet`/`removeFromSet` deliver the values **added or removed** per field — the op *input*, not the resulting values; `delete` delivers no `data`. When the type configures `timestamps`, the stamped fields ride along in `data` on `save` and `patch` at their persisted server values (subject to `select`) — a patch's `data` is the patched fields plus the stamp; `increment` and the set ops don't stamp, so their frames carry none. The pre-write row rides in `previousData` on all of them. An `applyToQuery` operation arrives as one `patch`/`increment`/set-op/`delete` change per matched record — there is no `applyToQuery` op on the wire. Consequences:
+**The shape of `data` follows `op`, not `changeType`.** A `save` delivers the full row; a `patch` delivers **the patched fields only, at their new values**; `increment` delivers the per-field increment **amounts** and `addToSet`/`removeFromSet` deliver the values **added or removed** per field — the op *input*, not the resulting values; `delete` delivers no `data`. Server-applied fields — `timestamps` stamps, `autoPopulatedFields`, and trigger `set` values — ride along in `data` on `save` and `patch` at their persisted server values (subject to `select`), and a server-applied value wins over the caller's submission for the same field, so a trigger that overrides a submitted value delivers the trigger's value. They are visible to the subscription `filter` too, so a filter can match on a trigger-computed field. A patch's `data` is the patched fields plus those server-applied fields; `increment` and the set ops don't stamp, so their frames carry none. The pre-write row rides in `previousData` on all of them. An `applyToQuery` operation arrives as one `patch`/`increment`/set-op/`delete` change per matched record — there is no `applyToQuery` op on the wire. Consequences:
 
 - An `enter` transition does NOT imply a full row: a patch that brings a row into the filter set is `changeType: "enter"` with only the changed fields in `data`.
 - **Merge, don't assign.** Replacing a cached row with `change.data` on a non-`save` op silently blanks every field the write didn't touch. Key the cache on `change.id`; replace on `save`, merge the fields present in `data` on `patch`, remove on `delete`.

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DATABASES.ts.md
@@ -407,7 +407,7 @@ Codegen reads the database-type TOML from the auto-resolved sync directory (`.pr
 
 **Codegen result typing.** Result aliases are derived from each operation's `definition`, not just its `type`:
 
-- `query` with an inclusion `projection` → `QueryResult<Pick<Model, projectedFields | "id">>` (`id` is always returned). Exclusion, dynamic (`$params.*`), or nested-key projections → `QueryResult<Partial<Model>>` (excluded fields are still returned at runtime, so the type stays wide rather than promising removal). No `[models.*]` schema → `QueryResult<Record<string, unknown>>`.
+- `query` with an inclusion `projection` → `QueryResult<Pick<Model, projectedFields | "id">>` (`id` is always returned). Exclusion, dynamic (`$params.*`), or nested-key projections → `QueryResult<Partial<Model>>` (the runtime strips excluded fields server-side, but codegen can't narrow these cases statically, so the type stays wide). No `[models.*]` schema → `QueryResult<Record<string, unknown>>`.
 - `mutation` results type `results` as `MutationStepResult[]` (`{ op: "save" | "patch" | "delete" | "increment" | "addToSet" | "removeFromSet"; success: boolean; id: string; values?: Record<string, number>; error?: string }`) — every mutation op, whatever mix of step kinds it contains, types as the one `MutationResult` shape.
 - `pipeline` with `return = "<step>"` → that step's result type: a query step gets `QueryResult<…>` (projection rules above), a count step `CountResult`, an aggregate step `AggregateResult`. `return = "all"` (or no `return`) stays the generic `PipelineResult` (`{ steps: Record<string, unknown> }`) — declare a local type there if a call site needs precision.
 
@@ -806,6 +806,8 @@ required = true
 ```
 
 Definition fields: `filter` (required), `sort`, `limit` (1–1000), `projection`, `include`.
+
+`projection` values are exactly `1` (inclusion — returns the projected fields plus `id`) or `0` (exclusion — the named fields are stripped server-side before the response leaves the store, so exclusion withholds a column, it doesn't just shrink the payload). Validation, enforced both when the operation is saved and on the runtime request (400): inclusion and exclusion can't mix; an exclusion can't name `id` or `type` (system identity fields, always returned); and a query can't sort on a field its projection excludes (the sort value would leak through the pagination cursor).
 
 Callers can override `limit`, `cursor`, and `direction` at call time (effective limit is the lesser of definition and caller limits).
 
@@ -1685,7 +1687,7 @@ interface DatabaseChangeEvent {
   changeType?: "enter" | "update" | "leave";
   modelName: string;
   id: string;
-  data?: any;          // save → the FULL submitted row; patch → the patched fields' new values
+  data?: any;          // save → the full row as persisted (server-applied fields win); patch → the patched fields' new values
                        // (both plus any `timestamps`-stamped fields at their persisted values);
                        // increment/addToSet/removeFromSet → the op INPUT (amounts / values
                        // added-or-removed), not the resulting values; null on delete.
@@ -1695,7 +1697,7 @@ interface DatabaseChangeEvent {
 }
 ```
 
-**The shape of `data` follows `op`, not `changeType`.** A `save` delivers the full row; a `patch` delivers **the patched fields only, at their new values**; `increment` delivers the per-field increment **amounts** and `addToSet`/`removeFromSet` deliver the values **added or removed** per field — the op *input*, not the resulting values; `delete` delivers no `data`. When the type configures `timestamps`, the stamped fields ride along in `data` on `save` and `patch` at their persisted server values (subject to `select`) — a patch's `data` is the patched fields plus the stamp; `increment` and the set ops don't stamp, so their frames carry none. The pre-write row rides in `previousData` on all of them. An `applyToQuery` operation arrives as one `patch`/`increment`/set-op/`delete` change per matched record — there is no `applyToQuery` op on the wire. Consequences:
+**The shape of `data` follows `op`, not `changeType`.** A `save` delivers the full row; a `patch` delivers **the patched fields only, at their new values**; `increment` delivers the per-field increment **amounts** and `addToSet`/`removeFromSet` deliver the values **added or removed** per field — the op *input*, not the resulting values; `delete` delivers no `data`. Server-applied fields — `timestamps` stamps, `autoPopulatedFields`, and trigger `set` values — ride along in `data` on `save` and `patch` at their persisted server values (subject to `select`), and a server-applied value wins over the caller's submission for the same field, so a trigger that overrides a submitted value delivers the trigger's value. They are visible to the subscription `filter` too, so a filter can match on a trigger-computed field. A patch's `data` is the patched fields plus those server-applied fields; `increment` and the set ops don't stamp, so their frames carry none. The pre-write row rides in `previousData` on all of them. An `applyToQuery` operation arrives as one `patch`/`increment`/set-op/`delete` change per matched record — there is no `applyToQuery` op on the wire. Consequences:
 
 - An `enter` transition does NOT imply a full row: a patch that brings a row into the filter set is `changeType: "enter"` with only the changed fields in `data`.
 - **Merge, don't assign.** Replacing a cached row with `change.data` on a non-`save` op silently blanks every field the write didn't touch. Key the cache on `change.id`; replace on `save`, merge the fields present in `data` on `patch`, remove on `delete`.

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_RESOURCE_METADATA.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_RESOURCE_METADATA.swift.md
@@ -32,13 +32,13 @@ primitive sync push
 - **Field types:** `string`, `number`, `boolean`, `date`, `id`, `stringset`. `enum` (string array) is valid only on a `string` field; other supported constraints are `required`, `maxLength`, `maxCount`.
 - **Category name `attrs` is reserved** — it's the read-only projected category (see **`md.self.attrs`** below), not a category you define.
 - **Limits:** up to 100 keys per category, 16 KB per category item.
-- **`readRule`/`writeRule` context:** `user.userId`, `user.role` (the caller), `resource.resourceType`, `resource.resourceId` (also bound as `resource.id`), `resource.category` — plus `workflow.workflowKey` when the call originates from a `metadata.write`/`metadata.read` step (so `fromWorkflow('key')` works). The membership helpers `isMemberOf`/`memberGroups`/`hasRole` are also wired, so a rule can be group-scoped (`isMemberOf('class-teachers', resource.id)`) instead of only self-scoped; memberships load once, only when the rule references a membership helper (`hasRole` needs no load — it reads only `user.role`). `hasCollectionAccess` is rejected at save time in a category rule (collection-scoped only; it can never resolve here). An **app-level** owner or admin always bypasses both rules; a resource-level permission (e.g. a database's `owner`/`manager` grant) never bypasses — the rule itself is what authorizes resource-scoped callers. Omitting either rule defaults to deny.
-- **Category authoring is admin-scoped** — define and update categories via TOML sync, or directly through the admin-gated `metadata-categories` REST route. `client.resourceMetadata` covers values only (`get`/`set`/`getBatch`).
+- **`readRule`/`writeRule` context:** `user.userId`, `user.role` (the caller), `resource.resourceType`, `resource.resourceId` (also bound as `resource.id`), `resource.category` — plus `workflow.workflowKey` when the call originates from a `metadata.write`/`metadata.read` step (so `fromWorkflow('key')` works). When the subject is a `database`, `workflow`, or `collection`, the rule can also read the resource's own columns via **`resource.attrs.<column>`** — `database`: `databaseId`, `databaseType`, `createdBy`; `workflow`: `workflowId`, `workflowKey`, `runAs`, `createdBy`; `collection`: `collectionId`, `collectionType`, `contextId`, `name`, `createdBy`. The canonical use is creator bootstrap: `writeRule = "user.userId == resource.attrs.createdBy"`. The subject row loads lazily (a rule that never references `resource.attrs` issues no extra read) and the binding fails closed: any other resource type, an unmapped column, or a missing row denies. The membership helpers `isMemberOf`/`memberGroups`/`hasRole` are also wired, so a rule can be group-scoped (`isMemberOf('class-teachers', resource.id)`) instead of only self-scoped; memberships load once, only when the rule references a membership helper (`hasRole` needs no load — it reads only `user.role`). `hasCollectionAccess` is rejected at save time in a category rule (collection-scoped only; it can never resolve here). An **app-level** owner or admin always bypasses both rules; a resource-level permission (e.g. a database's `owner`/`manager` grant) never bypasses — the rule itself is what authorizes resource-scoped callers. Omitting either rule defaults to deny.
+- **Category authoring is admin-scoped** — define and update categories via TOML sync, or directly through the admin-gated `metadata-categories` REST route. `client.resourceMetadata` covers values only (`get`/`set`/`getBatch`/`list`/`delete`); the CLI's read-only `primitive metadata categories list`/`get` inspect the definitions without touching TOML.
 - **A category rule can declare its own `metadataManifest`** (same `self`/`paths`/`secrets` shape as any other owning config) so it can reach the resource's *other* categories or declared secrets — see "A category rule's own manifest" below. Without one, the rule sees no `md`/`secrets` at all (unchanged from the base case).
 
-## Values: read, write, batch read
+## Values: read, write, batch read, list, delete
 
-`get`/`set` take `(resourceType, resourceId, category)` positionally; `set` is a **full replace**, not a merge.
+`get`/`set`/`delete` take `(resourceType, resourceId, category)` positionally, `list` takes `(resourceType, resourceId)`; `set` is a **full replace**, not a merge.
 
 
 ```bash
@@ -47,6 +47,10 @@ primitive metadata set user 01HXY... profile --data-file ./profile.json
 primitive metadata get user 01HXY... profile --json
 primitive metadata get-batch --resource user:01HXY...:profile,billing --resource user:01HZQ...:profile
 primitive metadata get-batch --requests '[{"resourceType":"user","resourceId":"01HXY...","categories":["profile"]}]'
+primitive metadata list user 01HXY...                # all stored categories (CLI reads as admin → shows everything)
+primitive metadata delete user 01HXY... profile      # idempotent
+primitive metadata categories list                   # read-only inspection of category definitions
+primitive metadata categories get user profile      # adds the full schema JSON
 ```
 
 - Batch: up to 50 resources, 200 expanded resource/category pairs per call — over either limit fails the **whole** call with `400 BATCH_TOO_LARGE` (checked before any read). Within limits the call is always `200`; per-item problems (missing category → `404 NOT_FOUND`, denied `readRule` → `403 FORBIDDEN`) surface inside `results[].categories[cat]`, never as a call-level failure.

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_RESOURCE_METADATA.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_RESOURCE_METADATA.template.md
@@ -32,13 +32,13 @@ primitive sync push
 - **Field types:** `string`, `number`, `boolean`, `date`, `id`, `stringset`. `enum` (string array) is valid only on a `string` field; other supported constraints are `required`, `maxLength`, `maxCount`.
 - **Category name `attrs` is reserved** — it's the read-only projected category (see **`md.self.attrs`** below), not a category you define.
 - **Limits:** up to 100 keys per category, 16 KB per category item.
-- **`readRule`/`writeRule` context:** `user.userId`, `user.role` (the caller), `resource.resourceType`, `resource.resourceId` (also bound as `resource.id`), `resource.category` — plus `workflow.workflowKey` when the call originates from a `metadata.write`/`metadata.read` step (so `fromWorkflow('key')` works). The membership helpers `isMemberOf`/`memberGroups`/`hasRole` are also wired, so a rule can be group-scoped (`isMemberOf('class-teachers', resource.id)`) instead of only self-scoped; memberships load once, only when the rule references a membership helper (`hasRole` needs no load — it reads only `user.role`). `hasCollectionAccess` is rejected at save time in a category rule (collection-scoped only; it can never resolve here). An **app-level** owner or admin always bypasses both rules; a resource-level permission (e.g. a database's `owner`/`manager` grant) never bypasses — the rule itself is what authorizes resource-scoped callers. Omitting either rule defaults to deny.
-- **Category authoring is admin-scoped** — define and update categories via TOML sync, or directly through the admin-gated `metadata-categories` REST route. `client.resourceMetadata` covers values only (`get`/`set`/`getBatch`).
+- **`readRule`/`writeRule` context:** `user.userId`, `user.role` (the caller), `resource.resourceType`, `resource.resourceId` (also bound as `resource.id`), `resource.category` — plus `workflow.workflowKey` when the call originates from a `metadata.write`/`metadata.read` step (so `fromWorkflow('key')` works). When the subject is a `database`, `workflow`, or `collection`, the rule can also read the resource's own columns via **`resource.attrs.<column>`** — `database`: `databaseId`, `databaseType`, `createdBy`; `workflow`: `workflowId`, `workflowKey`, `runAs`, `createdBy`; `collection`: `collectionId`, `collectionType`, `contextId`, `name`, `createdBy`. The canonical use is creator bootstrap: `writeRule = "user.userId == resource.attrs.createdBy"`. The subject row loads lazily (a rule that never references `resource.attrs` issues no extra read) and the binding fails closed: any other resource type, an unmapped column, or a missing row denies. The membership helpers `isMemberOf`/`memberGroups`/`hasRole` are also wired, so a rule can be group-scoped (`isMemberOf('class-teachers', resource.id)`) instead of only self-scoped; memberships load once, only when the rule references a membership helper (`hasRole` needs no load — it reads only `user.role`). `hasCollectionAccess` is rejected at save time in a category rule (collection-scoped only; it can never resolve here). An **app-level** owner or admin always bypasses both rules; a resource-level permission (e.g. a database's `owner`/`manager` grant) never bypasses — the rule itself is what authorizes resource-scoped callers. Omitting either rule defaults to deny.
+- **Category authoring is admin-scoped** — define and update categories via TOML sync, or directly through the admin-gated `metadata-categories` REST route. `client.resourceMetadata` covers values only (`get`/`set`/`getBatch`/`list`/`delete`); the CLI's read-only `primitive metadata categories list`/`get` inspect the definitions without touching TOML.
 - **A category rule can declare its own `metadataManifest`** (same `self`/`paths`/`secrets` shape as any other owning config) so it can reach the resource's *other* categories or declared secrets — see "A category rule's own manifest" below. Without one, the rule sees no `md`/`secrets` at all (unchanged from the base case).
 
-## Values: read, write, batch read
+## Values: read, write, batch read, list, delete
 
-`get`/`set` take `(resourceType, resourceId, category)` positionally; `set` is a **full replace**, not a merge.
+`get`/`set`/`delete` take `(resourceType, resourceId, category)` positionally, `list` takes `(resourceType, resourceId)`; `set` is a **full replace**, not a merge.
 
 {{#lang ts}}
 ```typescript
@@ -59,6 +59,14 @@ const { results } = await client.resourceMetadata.getBatch({
 //               | { ok: false, status, code, message } } }
 // A whole-resource failure (e.g. a malformed id) instead returns
 // { resourceType, resourceId, ok: false, status, code, message } with no `categories`.
+
+const { categories } = await client.resourceMetadata.list("user", userId);
+// -> { resourceType, resourceId, categories: [{ category, data, schemaVersion }, ...] }
+// Only categories whose readRule permits the caller are returned (owner/admin sees all);
+// a resource with no stored metadata returns an empty array, not an error.
+
+const { deleted } = await client.resourceMetadata.delete("user", userId, "profile");
+// -> { resourceType, resourceId, category, deleted } — idempotent: absent item → deleted: false, not a 404.
 ```
 {{/lang}}
 
@@ -68,6 +76,10 @@ primitive metadata set user 01HXY... profile --data-file ./profile.json
 primitive metadata get user 01HXY... profile --json
 primitive metadata get-batch --resource user:01HXY...:profile,billing --resource user:01HZQ...:profile
 primitive metadata get-batch --requests '[{"resourceType":"user","resourceId":"01HXY...","categories":["profile"]}]'
+primitive metadata list user 01HXY...                # all stored categories (CLI reads as admin → shows everything)
+primitive metadata delete user 01HXY... profile      # idempotent
+primitive metadata categories list                   # read-only inspection of category definitions
+primitive metadata categories get user profile      # adds the full schema JSON
 ```
 
 - Batch: up to 50 resources, 200 expanded resource/category pairs per call — over either limit fails the **whole** call with `400 BATCH_TOO_LARGE` (checked before any read). Within limits the call is always `200`; per-item problems (missing category → `404 NOT_FOUND`, denied `readRule` → `403 FORBIDDEN`) surface inside `results[].categories[cat]`, never as a call-level failure.

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_RESOURCE_METADATA.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_RESOURCE_METADATA.ts.md
@@ -32,13 +32,13 @@ primitive sync push
 - **Field types:** `string`, `number`, `boolean`, `date`, `id`, `stringset`. `enum` (string array) is valid only on a `string` field; other supported constraints are `required`, `maxLength`, `maxCount`.
 - **Category name `attrs` is reserved** — it's the read-only projected category (see **`md.self.attrs`** below), not a category you define.
 - **Limits:** up to 100 keys per category, 16 KB per category item.
-- **`readRule`/`writeRule` context:** `user.userId`, `user.role` (the caller), `resource.resourceType`, `resource.resourceId` (also bound as `resource.id`), `resource.category` — plus `workflow.workflowKey` when the call originates from a `metadata.write`/`metadata.read` step (so `fromWorkflow('key')` works). The membership helpers `isMemberOf`/`memberGroups`/`hasRole` are also wired, so a rule can be group-scoped (`isMemberOf('class-teachers', resource.id)`) instead of only self-scoped; memberships load once, only when the rule references a membership helper (`hasRole` needs no load — it reads only `user.role`). `hasCollectionAccess` is rejected at save time in a category rule (collection-scoped only; it can never resolve here). An **app-level** owner or admin always bypasses both rules; a resource-level permission (e.g. a database's `owner`/`manager` grant) never bypasses — the rule itself is what authorizes resource-scoped callers. Omitting either rule defaults to deny.
-- **Category authoring is admin-scoped** — define and update categories via TOML sync, or directly through the admin-gated `metadata-categories` REST route. `client.resourceMetadata` covers values only (`get`/`set`/`getBatch`).
+- **`readRule`/`writeRule` context:** `user.userId`, `user.role` (the caller), `resource.resourceType`, `resource.resourceId` (also bound as `resource.id`), `resource.category` — plus `workflow.workflowKey` when the call originates from a `metadata.write`/`metadata.read` step (so `fromWorkflow('key')` works). When the subject is a `database`, `workflow`, or `collection`, the rule can also read the resource's own columns via **`resource.attrs.<column>`** — `database`: `databaseId`, `databaseType`, `createdBy`; `workflow`: `workflowId`, `workflowKey`, `runAs`, `createdBy`; `collection`: `collectionId`, `collectionType`, `contextId`, `name`, `createdBy`. The canonical use is creator bootstrap: `writeRule = "user.userId == resource.attrs.createdBy"`. The subject row loads lazily (a rule that never references `resource.attrs` issues no extra read) and the binding fails closed: any other resource type, an unmapped column, or a missing row denies. The membership helpers `isMemberOf`/`memberGroups`/`hasRole` are also wired, so a rule can be group-scoped (`isMemberOf('class-teachers', resource.id)`) instead of only self-scoped; memberships load once, only when the rule references a membership helper (`hasRole` needs no load — it reads only `user.role`). `hasCollectionAccess` is rejected at save time in a category rule (collection-scoped only; it can never resolve here). An **app-level** owner or admin always bypasses both rules; a resource-level permission (e.g. a database's `owner`/`manager` grant) never bypasses — the rule itself is what authorizes resource-scoped callers. Omitting either rule defaults to deny.
+- **Category authoring is admin-scoped** — define and update categories via TOML sync, or directly through the admin-gated `metadata-categories` REST route. `client.resourceMetadata` covers values only (`get`/`set`/`getBatch`/`list`/`delete`); the CLI's read-only `primitive metadata categories list`/`get` inspect the definitions without touching TOML.
 - **A category rule can declare its own `metadataManifest`** (same `self`/`paths`/`secrets` shape as any other owning config) so it can reach the resource's *other* categories or declared secrets — see "A category rule's own manifest" below. Without one, the rule sees no `md`/`secrets` at all (unchanged from the base case).
 
-## Values: read, write, batch read
+## Values: read, write, batch read, list, delete
 
-`get`/`set` take `(resourceType, resourceId, category)` positionally; `set` is a **full replace**, not a merge.
+`get`/`set`/`delete` take `(resourceType, resourceId, category)` positionally, `list` takes `(resourceType, resourceId)`; `set` is a **full replace**, not a merge.
 
 ```typescript
 await client.resourceMetadata.set("user", userId, "profile", { tier: "pro", displayName: "Ada" });
@@ -58,6 +58,14 @@ const { results } = await client.resourceMetadata.getBatch({
 //               | { ok: false, status, code, message } } }
 // A whole-resource failure (e.g. a malformed id) instead returns
 // { resourceType, resourceId, ok: false, status, code, message } with no `categories`.
+
+const { categories } = await client.resourceMetadata.list("user", userId);
+// -> { resourceType, resourceId, categories: [{ category, data, schemaVersion }, ...] }
+// Only categories whose readRule permits the caller are returned (owner/admin sees all);
+// a resource with no stored metadata returns an empty array, not an error.
+
+const { deleted } = await client.resourceMetadata.delete("user", userId, "profile");
+// -> { resourceType, resourceId, category, deleted } — idempotent: absent item → deleted: false, not a 404.
 ```
 
 ```bash
@@ -66,6 +74,10 @@ primitive metadata set user 01HXY... profile --data-file ./profile.json
 primitive metadata get user 01HXY... profile --json
 primitive metadata get-batch --resource user:01HXY...:profile,billing --resource user:01HZQ...:profile
 primitive metadata get-batch --requests '[{"resourceType":"user","resourceId":"01HXY...","categories":["profile"]}]'
+primitive metadata list user 01HXY...                # all stored categories (CLI reads as admin → shows everything)
+primitive metadata delete user 01HXY... profile      # idempotent
+primitive metadata categories list                   # read-only inspection of category definitions
+primitive metadata categories get user profile      # adds the full schema JSON
 ```
 
 - Batch: up to 50 resources, 200 expanded resource/category pairs per call — over either limit fails the **whole** call with `400 BATCH_TOO_LARGE` (checked before any read). Within limits the call is always `200`; per-item problems (missing category → `404 NOT_FOUND`, denied `readRule` → `403 FORBIDDEN`) surface inside `results[].categories[cat]`, never as a call-level failure.

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_SCRIPTS.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_SCRIPTS.md
@@ -2,7 +2,7 @@
 
 A **script** is a sandboxed [Rhai](https://rhai.rs/) program that transforms JSON and returns JSON. Scripts are the escape hatch for data shaping too involved for a templated `transform` step — nested reshaping, derived fields, array map/filter/reduce, parsing JSON-string columns. They run inside [workflows](AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.md) as `script` steps.
 
-The sandbox is **deterministic and side-effect-free**: no network, no clock, no storage, no randomness. The same input always produces the same output, so a script step is safe to retry and reproducible to test.
+The sandbox is **side-effect-free** — no network, no storage — and deterministic with one deliberate exception: the `ulid()` builtin (see below) reads the clock and randomness to mint ids. A script that never calls `ulid()` always produces the same output for the same input, so it is safe to retry and reproducible to test; a script that calls it is intentionally non-reproducible in exactly those id values.
 
 ## The Script model
 
@@ -78,6 +78,18 @@ let config  = parse_json(input.configJson);    // "{\"limit\": 10}" → #{ "limi
 
 Input must be **strict JSON**. Trailing commas, `//` or `/* */` comments, single-quoted strings, and hex literals are rejected. Invalid input fails the step with a non-retryable `SCRIPT_RUNTIME_ERROR` carrying a positioned message — `parse_json: invalid JSON at line N column M: …` — and, when the input matches one of those non-standard forms, a hint pointing at strict JSON. Map keys are sorted at output, so a parsed-then-returned object is byte-stable.
 
+## `ulid()`
+
+`ulid()` (zero-arg) returns a fresh 26-character uppercase Crockford-base32 ULID string — a 48-bit millisecond timestamp prefix plus 80 bits of randomness, matching the `^[0-9A-HJKMNP-TV-Z]{26}$` format the `document.bulkUpdate` step requires for `create` ids. Its purpose is pre-minting record ids when a script builds a `document.bulkUpdate` `operations` array, so cross-record references can be wired without a server round-trip:
+
+```
+rows.map(|row| #{ id: ulid(), model: "Holding", action: "create", fields: row })
+```
+
+- Ids from calls within one invocation share the timestamp prefix and differ in the random suffix; there is **no monotonic ordering guarantee** between successive calls.
+- This is the sandbox's one non-deterministic surface (clock + randomness). In a durable workflow run, step-output memoization keeps minted ids stable across that run's retries.
+- For a statically-known number of ids, minting with the <span v-pre>`{{ ulid }}`</span> template helper in the step's `with` table keeps the script itself fully deterministic.
+
 ## Per-step limits
 
 Every run is bounded. A step may **lower** the ceilings with a `limits` table; requested values are clamped at the app ceiling and never raised:
@@ -148,7 +160,7 @@ primitive workflows tests create <workflow-id> --name "normalize: drops zero-qty
 primitive workflows tests run-all <workflow-id>
 ```
 
-Because the sandbox has no clock, network, or randomness, a passing case stays passing — there is no flakiness to chase.
+Because the sandbox has no network and — outside `ulid()` — no clock or randomness, a passing case stays passing; only assertions on `ulid()`-minted id *values* would flake, so assert on shape or count for those.
 
 ## Related
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_SCRIPTS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_SCRIPTS.template.md
@@ -2,7 +2,7 @@
 
 A **script** is a sandboxed [Rhai](https://rhai.rs/) program that transforms JSON and returns JSON. Scripts are the escape hatch for data shaping too involved for a templated `transform` step — nested reshaping, derived fields, array map/filter/reduce, parsing JSON-string columns. They run inside [workflows](AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.md) as `script` steps.
 
-The sandbox is **deterministic and side-effect-free**: no network, no clock, no storage, no randomness. The same input always produces the same output, so a script step is safe to retry and reproducible to test.
+The sandbox is **side-effect-free** — no network, no storage — and deterministic with one deliberate exception: the `ulid()` builtin (see below) reads the clock and randomness to mint ids. A script that never calls `ulid()` always produces the same output for the same input, so it is safe to retry and reproducible to test; a script that calls it is intentionally non-reproducible in exactly those id values.
 
 ## The Script model
 
@@ -78,6 +78,18 @@ let config  = parse_json(input.configJson);    // "{\"limit\": 10}" → #{ "limi
 
 Input must be **strict JSON**. Trailing commas, `//` or `/* */` comments, single-quoted strings, and hex literals are rejected. Invalid input fails the step with a non-retryable `SCRIPT_RUNTIME_ERROR` carrying a positioned message — `parse_json: invalid JSON at line N column M: …` — and, when the input matches one of those non-standard forms, a hint pointing at strict JSON. Map keys are sorted at output, so a parsed-then-returned object is byte-stable.
 
+## `ulid()`
+
+`ulid()` (zero-arg) returns a fresh 26-character uppercase Crockford-base32 ULID string — a 48-bit millisecond timestamp prefix plus 80 bits of randomness, matching the `^[0-9A-HJKMNP-TV-Z]{26}$` format the `document.bulkUpdate` step requires for `create` ids. Its purpose is pre-minting record ids when a script builds a `document.bulkUpdate` `operations` array, so cross-record references can be wired without a server round-trip:
+
+```
+rows.map(|row| #{ id: ulid(), model: "Holding", action: "create", fields: row })
+```
+
+- Ids from calls within one invocation share the timestamp prefix and differ in the random suffix; there is **no monotonic ordering guarantee** between successive calls.
+- This is the sandbox's one non-deterministic surface (clock + randomness). In a durable workflow run, step-output memoization keeps minted ids stable across that run's retries.
+- For a statically-known number of ids, minting with the <span v-pre>`{{ ulid }}`</span> template helper in the step's `with` table keeps the script itself fully deterministic.
+
 ## Per-step limits
 
 Every run is bounded. A step may **lower** the ceilings with a `limits` table; requested values are clamped at the app ceiling and never raised:
@@ -148,7 +160,7 @@ primitive workflows tests create <workflow-id> --name "normalize: drops zero-qty
 primitive workflows tests run-all <workflow-id>
 ```
 
-Because the sandbox has no clock, network, or randomness, a passing case stays passing — there is no flakiness to chase.
+Because the sandbox has no network and — outside `ulid()` — no clock or randomness, a passing case stays passing; only assertions on `ulid()`-minted id *values* would flake, so assert on shape or count for those.
 
 ## Related
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.swift.md
@@ -293,7 +293,7 @@ now = "2026-04-27T00:00:00Z"
 # default cap (1000) fails the step instead of truncating.
 ```
 
-Workflows have no batch-write step kind. To apply a set of updates, run `forEach` over a `database.mutate` step (see `forEach` below), or use `database.applyToQuery` for query-driven updates.
+Workflows have no *database* batch-write step kind. To apply a set of database updates, run `forEach` over a `database.mutate` step (see `forEach` below), or use `database.applyToQuery` for query-driven updates. (Document writes are different: see `document.save`/`patch`/`delete` batch mode and `document.bulkUpdate` below.)
 
 ### `document.query` / `queryOne` / `count` / `save` / `patch` / `delete`
 
@@ -413,6 +413,43 @@ Rules and edge cases:
 - **Batch failures are non-retryable** — a validation or constraint failure fails the run immediately rather than retrying.
 - **Id-less batch `save` and retries.** An omitted `id` mints a fresh ULID server-side on every attempt — retrying a batch save whose records had no `id` (e.g. after a transient error) creates duplicates rather than upserting the originals. Supply explicit ids, or make the workflow idempotent some other way, if the step might retry.
 - **Projection freshness.** A batch marks the document's query projection dirty once (rebuilt on the next read) instead of updating it inline per record — the first `document.query`/`count` after a batch pays one rebuild rather than N inline upserts. Single-record writes still update the projection inline.
+
+### `document.bulkUpdate` — multi-model atomic write (`operations`)
+
+Batch mode is per-model and per-chunk atomic; `document.bulkUpdate` is the whole-blob atomic form: an ordered `operations` array spanning **any of the document's models**, applied in one transaction with one persist and one change broadcast. All-or-nothing across the entire list — a mid-list failure rolls back everything before it.
+
+Takes `documentId` **or** `documentAlias` (same alias rules as the other document steps); no step-level `modelName` — each operation names its own `model`:
+
+```toml
+[[steps]]
+id = "apply-rebalance"
+kind = "document.bulkUpdate"
+documentId = "{{ outputs.doc.documentId }}"
+saveAs = "applied"
+operations = [
+  { model = "Account",  action = "create", id = "{{ input.newAccountId }}", fields = { name = "Growth", balance = 0 } },
+  { model = "Ledger",   action = "patch",  id = "{{ input.ledgerId }}", fields = { rebalancedAt = "{{ now }}" } },
+  { model = "Position", action = "delete", id = "{{ input.staleId }}" },
+]
+```
+
+Operation shape: `{ model, action, id, fields? }`. The `action` vocabulary is exactly `create` | `patch` | `delete` — not add/update/save.
+
+| `action` | `id` | Semantics |
+|---|---|---|
+| `create` | **required, caller-supplied ULID** (must match `^[0-9A-HJKMNP-TV-Z]{26}$` — 26 uppercase Crockford chars) | Strict create — fails if the id already exists. The server never mints ids for this step. |
+| `patch` | required, non-empty string | Merges `fields` — fails if the id doesn't exist. |
+| `delete` | required, non-empty string | Removes the record; an id that doesn't exist is a no-op (contributes 0 to `deleted`). |
+
+Output: `{ applied, added, updated, deleted }` — `added`/`updated` list `{ model, id }` per committed create/patch in input order; `deleted` is the count actually removed.
+
+Rules and edge cases:
+
+- **Cap = 500 operations**, a separate constant from batch mode's 100-record chunk — and **never chunked** (chunking would break the atomicity that is this step's point). Over 500 is rejected non-retryably before any write.
+- **Mint create ids with <span v-pre>`{{ ulid }}`</span>** (template helper) for statically-known counts, or the script `ulid()` builtin when a script builds the operations array dynamically — pre-minting is what lets a later operation in the same blob reference a record an earlier operation creates.
+- **Validation-first, then fail-fast.** A structural pass (shape, cap, ULID well-formedness, known `action`) runs before any write; failures are non-retryable and name the offending operation index and model. State-dependent failures (create-collision, patch-miss, unique-index violation) abort inside the transaction — nothing commits — and are also non-retryable. Transient storage/broadcast failures stay retryable.
+- **Operations apply in listed order** within the one transaction.
+- **Caller-mode ACL is checked once** at write level: the caller needs `read-write` on the document; denial is non-retryable and nothing commits. An empty `operations` array is a clean no-op.
 
 ### `group.addMember` / `removeMember` / `removeAll` / `checkMembership` / `listMembers` / `listUserMemberships`
 
@@ -690,7 +727,7 @@ saveAs = "billingUpgrades"
 
 ### `script`
 
-Runs a sandboxed [Rhai](https://rhai.rs/) script over JSON input and returns JSON. Use it for transforms too involved for a templated `transform` step (nested reshaping, derived fields, array map/filter/reduce). The sandbox is **deterministic and side-effect-free** — no network, clock, or storage access — so script steps are safe to retry and easy to test. The [Scripts guide](AGENT_GUIDE_TO_PRIMITIVE_SCRIPTS.md) covers the script model, input/output contract, limits, error codes, and gotchas in full; this section is the step-level reference.
+Runs a sandboxed [Rhai](https://rhai.rs/) script over JSON input and returns JSON. Use it for transforms too involved for a templated `transform` step (nested reshaping, derived fields, array map/filter/reduce). The sandbox is **side-effect-free** — no network or storage access — and deterministic except for the `ulid()` builtin (mints fresh record ids, e.g. for `document.bulkUpdate` creates), so script steps are safe to retry and easy to test. The [Scripts guide](AGENT_GUIDE_TO_PRIMITIVE_SCRIPTS.md) covers the script model, input/output contract, limits, error codes, and gotchas in full; this section is the step-level reference.
 
 ```toml
 [[steps]]
@@ -936,7 +973,7 @@ When a parallel `forEach` batch's combined output exceeds the inline size limit 
 
 ### Batch database updates
 
-Workflows have no batch-write step kind — a set of database updates is a `forEach` over a `database.mutate` step (add `concurrency` to parallelize):
+Workflows have no *database* batch-write step kind — a set of database updates is a `forEach` over a `database.mutate` step (add `concurrency` to parallelize):
 
 ```toml
 [[steps]]

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md
@@ -293,7 +293,7 @@ now = "2026-04-27T00:00:00Z"
 # default cap (1000) fails the step instead of truncating.
 ```
 
-Workflows have no batch-write step kind. To apply a set of updates, run `forEach` over a `database.mutate` step (see `forEach` below), or use `database.applyToQuery` for query-driven updates.
+Workflows have no *database* batch-write step kind. To apply a set of database updates, run `forEach` over a `database.mutate` step (see `forEach` below), or use `database.applyToQuery` for query-driven updates. (Document writes are different: see `document.save`/`patch`/`delete` batch mode and `document.bulkUpdate` below.)
 
 ### `document.query` / `queryOne` / `count` / `save` / `patch` / `delete`
 
@@ -413,6 +413,43 @@ Rules and edge cases:
 - **Batch failures are non-retryable** — a validation or constraint failure fails the run immediately rather than retrying.
 - **Id-less batch `save` and retries.** An omitted `id` mints a fresh ULID server-side on every attempt — retrying a batch save whose records had no `id` (e.g. after a transient error) creates duplicates rather than upserting the originals. Supply explicit ids, or make the workflow idempotent some other way, if the step might retry.
 - **Projection freshness.** A batch marks the document's query projection dirty once (rebuilt on the next read) instead of updating it inline per record — the first `document.query`/`count` after a batch pays one rebuild rather than N inline upserts. Single-record writes still update the projection inline.
+
+### `document.bulkUpdate` — multi-model atomic write (`operations`)
+
+Batch mode is per-model and per-chunk atomic; `document.bulkUpdate` is the whole-blob atomic form: an ordered `operations` array spanning **any of the document's models**, applied in one transaction with one persist and one change broadcast. All-or-nothing across the entire list — a mid-list failure rolls back everything before it.
+
+Takes `documentId` **or** `documentAlias` (same alias rules as the other document steps); no step-level `modelName` — each operation names its own `model`:
+
+```toml
+[[steps]]
+id = "apply-rebalance"
+kind = "document.bulkUpdate"
+documentId = "{{ outputs.doc.documentId }}"
+saveAs = "applied"
+operations = [
+  { model = "Account",  action = "create", id = "{{ input.newAccountId }}", fields = { name = "Growth", balance = 0 } },
+  { model = "Ledger",   action = "patch",  id = "{{ input.ledgerId }}", fields = { rebalancedAt = "{{ now }}" } },
+  { model = "Position", action = "delete", id = "{{ input.staleId }}" },
+]
+```
+
+Operation shape: `{ model, action, id, fields? }`. The `action` vocabulary is exactly `create` | `patch` | `delete` — not add/update/save.
+
+| `action` | `id` | Semantics |
+|---|---|---|
+| `create` | **required, caller-supplied ULID** (must match `^[0-9A-HJKMNP-TV-Z]{26}$` — 26 uppercase Crockford chars) | Strict create — fails if the id already exists. The server never mints ids for this step. |
+| `patch` | required, non-empty string | Merges `fields` — fails if the id doesn't exist. |
+| `delete` | required, non-empty string | Removes the record; an id that doesn't exist is a no-op (contributes 0 to `deleted`). |
+
+Output: `{ applied, added, updated, deleted }` — `added`/`updated` list `{ model, id }` per committed create/patch in input order; `deleted` is the count actually removed.
+
+Rules and edge cases:
+
+- **Cap = 500 operations**, a separate constant from batch mode's 100-record chunk — and **never chunked** (chunking would break the atomicity that is this step's point). Over 500 is rejected non-retryably before any write.
+- **Mint create ids with <span v-pre>`{{ ulid }}`</span>** (template helper) for statically-known counts, or the script `ulid()` builtin when a script builds the operations array dynamically — pre-minting is what lets a later operation in the same blob reference a record an earlier operation creates.
+- **Validation-first, then fail-fast.** A structural pass (shape, cap, ULID well-formedness, known `action`) runs before any write; failures are non-retryable and name the offending operation index and model. State-dependent failures (create-collision, patch-miss, unique-index violation) abort inside the transaction — nothing commits — and are also non-retryable. Transient storage/broadcast failures stay retryable.
+- **Operations apply in listed order** within the one transaction.
+- **Caller-mode ACL is checked once** at write level: the caller needs `read-write` on the document; denial is non-retryable and nothing commits. An empty `operations` array is a clean no-op.
 
 ### `group.addMember` / `removeMember` / `removeAll` / `checkMembership` / `listMembers` / `listUserMemberships`
 
@@ -690,7 +727,7 @@ saveAs = "billingUpgrades"
 
 ### `script`
 
-Runs a sandboxed [Rhai](https://rhai.rs/) script over JSON input and returns JSON. Use it for transforms too involved for a templated `transform` step (nested reshaping, derived fields, array map/filter/reduce). The sandbox is **deterministic and side-effect-free** — no network, clock, or storage access — so script steps are safe to retry and easy to test. The [Scripts guide](AGENT_GUIDE_TO_PRIMITIVE_SCRIPTS.md) covers the script model, input/output contract, limits, error codes, and gotchas in full; this section is the step-level reference.
+Runs a sandboxed [Rhai](https://rhai.rs/) script over JSON input and returns JSON. Use it for transforms too involved for a templated `transform` step (nested reshaping, derived fields, array map/filter/reduce). The sandbox is **side-effect-free** — no network or storage access — and deterministic except for the `ulid()` builtin (mints fresh record ids, e.g. for `document.bulkUpdate` creates), so script steps are safe to retry and easy to test. The [Scripts guide](AGENT_GUIDE_TO_PRIMITIVE_SCRIPTS.md) covers the script model, input/output contract, limits, error codes, and gotchas in full; this section is the step-level reference.
 
 ```toml
 [[steps]]
@@ -936,7 +973,7 @@ When a parallel `forEach` batch's combined output exceeds the inline size limit 
 
 ### Batch database updates
 
-Workflows have no batch-write step kind — a set of database updates is a `forEach` over a `database.mutate` step (add `concurrency` to parallelize):
+Workflows have no *database* batch-write step kind — a set of database updates is a `forEach` over a `database.mutate` step (add `concurrency` to parallelize):
 
 ```toml
 [[steps]]

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.ts.md
@@ -293,7 +293,7 @@ now = "2026-04-27T00:00:00Z"
 # default cap (1000) fails the step instead of truncating.
 ```
 
-Workflows have no batch-write step kind. To apply a set of updates, run `forEach` over a `database.mutate` step (see `forEach` below), or use `database.applyToQuery` for query-driven updates.
+Workflows have no *database* batch-write step kind. To apply a set of database updates, run `forEach` over a `database.mutate` step (see `forEach` below), or use `database.applyToQuery` for query-driven updates. (Document writes are different: see `document.save`/`patch`/`delete` batch mode and `document.bulkUpdate` below.)
 
 ### `document.query` / `queryOne` / `count` / `save` / `patch` / `delete`
 
@@ -413,6 +413,43 @@ Rules and edge cases:
 - **Batch failures are non-retryable** — a validation or constraint failure fails the run immediately rather than retrying.
 - **Id-less batch `save` and retries.** An omitted `id` mints a fresh ULID server-side on every attempt — retrying a batch save whose records had no `id` (e.g. after a transient error) creates duplicates rather than upserting the originals. Supply explicit ids, or make the workflow idempotent some other way, if the step might retry.
 - **Projection freshness.** A batch marks the document's query projection dirty once (rebuilt on the next read) instead of updating it inline per record — the first `document.query`/`count` after a batch pays one rebuild rather than N inline upserts. Single-record writes still update the projection inline.
+
+### `document.bulkUpdate` — multi-model atomic write (`operations`)
+
+Batch mode is per-model and per-chunk atomic; `document.bulkUpdate` is the whole-blob atomic form: an ordered `operations` array spanning **any of the document's models**, applied in one transaction with one persist and one change broadcast. All-or-nothing across the entire list — a mid-list failure rolls back everything before it.
+
+Takes `documentId` **or** `documentAlias` (same alias rules as the other document steps); no step-level `modelName` — each operation names its own `model`:
+
+```toml
+[[steps]]
+id = "apply-rebalance"
+kind = "document.bulkUpdate"
+documentId = "{{ outputs.doc.documentId }}"
+saveAs = "applied"
+operations = [
+  { model = "Account",  action = "create", id = "{{ input.newAccountId }}", fields = { name = "Growth", balance = 0 } },
+  { model = "Ledger",   action = "patch",  id = "{{ input.ledgerId }}", fields = { rebalancedAt = "{{ now }}" } },
+  { model = "Position", action = "delete", id = "{{ input.staleId }}" },
+]
+```
+
+Operation shape: `{ model, action, id, fields? }`. The `action` vocabulary is exactly `create` | `patch` | `delete` — not add/update/save.
+
+| `action` | `id` | Semantics |
+|---|---|---|
+| `create` | **required, caller-supplied ULID** (must match `^[0-9A-HJKMNP-TV-Z]{26}$` — 26 uppercase Crockford chars) | Strict create — fails if the id already exists. The server never mints ids for this step. |
+| `patch` | required, non-empty string | Merges `fields` — fails if the id doesn't exist. |
+| `delete` | required, non-empty string | Removes the record; an id that doesn't exist is a no-op (contributes 0 to `deleted`). |
+
+Output: `{ applied, added, updated, deleted }` — `added`/`updated` list `{ model, id }` per committed create/patch in input order; `deleted` is the count actually removed.
+
+Rules and edge cases:
+
+- **Cap = 500 operations**, a separate constant from batch mode's 100-record chunk — and **never chunked** (chunking would break the atomicity that is this step's point). Over 500 is rejected non-retryably before any write.
+- **Mint create ids with <span v-pre>`{{ ulid }}`</span>** (template helper) for statically-known counts, or the script `ulid()` builtin when a script builds the operations array dynamically — pre-minting is what lets a later operation in the same blob reference a record an earlier operation creates.
+- **Validation-first, then fail-fast.** A structural pass (shape, cap, ULID well-formedness, known `action`) runs before any write; failures are non-retryable and name the offending operation index and model. State-dependent failures (create-collision, patch-miss, unique-index violation) abort inside the transaction — nothing commits — and are also non-retryable. Transient storage/broadcast failures stay retryable.
+- **Operations apply in listed order** within the one transaction.
+- **Caller-mode ACL is checked once** at write level: the caller needs `read-write` on the document; denial is non-retryable and nothing commits. An empty `operations` array is a clean no-op.
 
 ### `group.addMember` / `removeMember` / `removeAll` / `checkMembership` / `listMembers` / `listUserMemberships`
 
@@ -690,7 +727,7 @@ saveAs = "billingUpgrades"
 
 ### `script`
 
-Runs a sandboxed [Rhai](https://rhai.rs/) script over JSON input and returns JSON. Use it for transforms too involved for a templated `transform` step (nested reshaping, derived fields, array map/filter/reduce). The sandbox is **deterministic and side-effect-free** — no network, clock, or storage access — so script steps are safe to retry and easy to test. The [Scripts guide](AGENT_GUIDE_TO_PRIMITIVE_SCRIPTS.md) covers the script model, input/output contract, limits, error codes, and gotchas in full; this section is the step-level reference.
+Runs a sandboxed [Rhai](https://rhai.rs/) script over JSON input and returns JSON. Use it for transforms too involved for a templated `transform` step (nested reshaping, derived fields, array map/filter/reduce). The sandbox is **side-effect-free** — no network or storage access — and deterministic except for the `ulid()` builtin (mints fresh record ids, e.g. for `document.bulkUpdate` creates), so script steps are safe to retry and easy to test. The [Scripts guide](AGENT_GUIDE_TO_PRIMITIVE_SCRIPTS.md) covers the script model, input/output contract, limits, error codes, and gotchas in full; this section is the step-level reference.
 
 ```toml
 [[steps]]
@@ -936,7 +973,7 @@ When a parallel `forEach` batch's combined output exceeds the inline size limit 
 
 ### Batch database updates
 
-Workflows have no batch-write step kind — a set of database updates is a `forEach` over a `database.mutate` step (add `concurrency` to parallelize):
+Workflows have no *database* batch-write step kind — a set of database updates is a `forEach` over a `database.mutate` step (add `concurrency` to parallelize):
 
 ```toml
 [[steps]]


### PR DESCRIPTION
Interactive docs-next-sync pass truing `next` against js-bao-wss main tip `ae9f096d` (37 commits since the 2026-07-14 stamp; the other two libraries had no new commits).

## Disposition table

| Library change | Class | Disposition |
|---|---|---|
| #1532/#1517 — `document.bulkUpdate` step, Rhai `ulid()` builtin, CLI allowlist | New capability | Updated `workflows.md` (step-reference row + "Writing across models atomically" section, script determinism carve-out) and the workflows guide (full `document.bulkUpdate` section, scoped the two "no batch-write step kind" claims to *database*); scripts guide gains a `ulid()` section and loses its now-overbroad "no clock, no randomness" claims |
| #1556/#1402 — metadata debug tooling (CLI `metadata list/delete/categories`, client `resourceMetadata.list()/delete()`) | New capability (JS/CLI-only) | Updated `resource-metadata.md` ("Listing and Deleting"), `primitive-cli.md`, and the resource-metadata guide (client code in the ts lang block, CLI shared); commented on js-bao-wss#1373 — the tracked Swift parity gap now also covers list/delete |
| #1527/#1521 — `resource.attrs` in metadata category rules | New capability (language-neutral) | Updated `resource-metadata.md` and the guide's rule-context inventory (per-type column sets, lazy load, fails closed) |
| #1493/#1456 — exclusion projections stripped server-side | Factual change | Guide's "excluded fields are still returned at runtime" was now false — fixed; documented the least-privilege capability and the two new 400s (exclude `id`/`type`; sort on an excluded field) in `working-with-databases.md` + guide. Codegen still emits `Partial<M>` (verified at HEAD), so the typing claims stand; filed js-bao-wss#1563 for the now-unblocked `Omit` narrowing |
| #1502/#1476 — trigger-computed fields in `db.change` events | Factual change | Generalized the change-payload docs: server-applied fields (`timestamps`, `autoPopulatedFields`, trigger `set` values) ride along at persisted values, visible to `filter`, server value wins (`working-with-databases.md` + databases guide) |
| #1529/#1369 — web-admin Config Vars view | New capability (console) | Added to `admin-console.md` (with the pre-existing but undocumented Secrets view), noted the console surface in `app-secrets.md` and the secrets guide. Did **not** adopt the view's `{{vars.KEY}}` claim — the template resolver has no `vars` binding (that's open js-bao-wss#1423); filed js-bao-wss#1562 for the misleading UI copy |
| #1537/#1522 — unified LoadManifest | Internal (byte-identical CEL contexts, verified) | No change |
| #1535/#1411 — CF error shapes in dispatch probe/429 classifier | Internal | No change |
| #1553 — feedback-loop limit 3→5 | Internal (repo automation) | No change |
| #1550 — my-inbox skill | Internal | No change |
| #1538 — pl-dispatcher skill | Internal | No change |
| #1548 — client typing audit report | Internal | No change |

## Issues

- Filed: js-bao-wss#1562 (AppVarsView `{{vars.KEY}}` copy ahead of #1423), js-bao-wss#1563 (db-codegen `Omit` narrowing unblocked by #1456)
- Commented: js-bao-wss#1373 (Swift resourceMetadata parity — surface grew with `list`/`delete`)
- Still deferred: docs #271 (gated on js-bao-wss#1451), docs #265 (gated on js-bao-wss#1470) — neither blocker is in this window

## Gates

- `pnpm check:examples` ✅ (TS + Swift corpus compiled against the new submodule source; 489 CLI invocations validated; stamp gate green)
- `npx vitepress build docs` ✅

Also drained from `main`: commit 6ae29506 (TOML editorial standard) was already on `next` in fuller form — skipped as superseded, verified by content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)