### PR TITLE
docs-next-sync: js-bao-wss changes (automated, 2026-07-15)

### DIFF
--- a/docs-sources.json
+++ b/docs-sources.json
@@ -1,9 +1,9 @@
 {
   "channel": "next",
-  "stampedAt": "2026-07-14",
+  "stampedAt": "2026-07-15",
   "libraries": {
     "js-bao-wss": {
-      "commit": "ae9f096d6c1a2e8665c65731bad6ff477bf60804",
+      "commit": "2bc33033d46bd6ae01f38bc82d590933b3f5bc94",
       "npm": {
         "js-bao-wss-client": "2.0.4",
         "js-bao": "0.5.1",

--- a/docs/getting-started/primitive-cli.md
+++ b/docs/getting-started/primitive-cli.md
@@ -397,10 +397,10 @@ primitive webhooks list                    # shows each webhook's ID
 primitive webhooks get <webhook-id>
 primitive webhooks events <webhook-id>      # recent deliveries (accepted/rejected/duplicate)
 primitive webhooks rotate-secret <webhook-id>
-primitive webhooks test <webhook-id>
+primitive webhooks test <webhook-id> --payload '{"type":"charge.succeeded","data":{"id":"ch_1"}}'
 ```
 
-See [Inbound Webhooks](./workflows.md#via-inbound-webhooks).
+`--payload` is delivered and signed exactly as given — pass the event object directly, not wrapped in `{"payload": ...}`. Omit it to send a canned `webhook.test` ping instead. See [Inbound Webhooks](./workflows.md#via-inbound-webhooks).
 
 ### Cron Triggers
 

--- a/docs/getting-started/workflows.md
+++ b/docs/getting-started/workflows.md
@@ -332,7 +332,10 @@ Inspect webhooks and their recent deliveries (accepted, rejected, duplicate) fro
 primitive webhooks list                  # shows each webhook's ID
 primitive webhooks events <webhook-id>
 primitive webhooks rotate-secret <webhook-id>
+primitive webhooks test <webhook-id> --payload '{"type":"charge.succeeded","data":{"id":"ch_1"}}'
 ```
+
+`--payload` is delivered and signed exactly as given — pass the event object directly, not wrapped in `{"payload": ...}`. Omit it to send a canned `webhook.test` ping instead.
 
 ## Controlling Access to Workflows
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.swift.md
@@ -968,7 +968,9 @@ Update a document's title, thumbnail, and presentation metadata — see [Update 
 
 ### Deleting Documents
 
-Delete a document (it must be closed first, or pass `forceCloseIfOpen: true`) — see the compiled call below. Root documents cannot be deleted. Deletion requires **direct `owner` permission** on the document or the app `owner` role — group- or collection-derived permission never qualifies, and `read-write` editors can delete records and content but not the document itself.
+Delete a document (it must be closed first, or pass `forceCloseIfOpen: true`) — see the compiled call below. Root documents cannot be deleted. Deletion requires **direct `owner` permission** on the document or the app `owner` role — group-derived permission never qualifies, and `read-write` editors can delete records and content but not the document itself.
+
+The one exception: if the caller is neither the owner nor an app owner, the platform falls back to checking every collection the document belongs to and allows the delete if **any** one collection's `document.delete` CEL rule passes. That rule defaults to `"false"` (deny) — see [Rule Sets for Collection Management](AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.md#rule-sets-for-collection-management) — so deletion never widens past owner/app-owner unless an app explicitly configures it. Because that rule is evaluated per collection, adding a document to a collection can extend who is able to delete it; configure `document.add` and `document.delete` together with that reach in mind.
 
 ```swift
   // Must be closed first

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.template.md
@@ -1264,7 +1264,9 @@ Pass `null` to clear `thumbnailBlobId` or `metadata`.
 
 ### Deleting Documents
 
-Delete a document (it must be closed first, or pass `forceCloseIfOpen: true`) — see the compiled call below. Root documents cannot be deleted. Deletion requires **direct `owner` permission** on the document or the app `owner` role — group- or collection-derived permission never qualifies, and `read-write` editors can delete records and content but not the document itself.
+Delete a document (it must be closed first, or pass `forceCloseIfOpen: true`) — see the compiled call below. Root documents cannot be deleted. Deletion requires **direct `owner` permission** on the document or the app `owner` role — group-derived permission never qualifies, and `read-write` editors can delete records and content but not the document itself.
+
+The one exception: if the caller is neither the owner nor an app owner, the platform falls back to checking every collection the document belongs to and allows the delete if **any** one collection's `document.delete` CEL rule passes. That rule defaults to `"false"` (deny) — see [Rule Sets for Collection Management](AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.md#rule-sets-for-collection-management) — so deletion never widens past owner/app-owner unless an app explicitly configures it. Because that rule is evaluated per collection, adding a document to a collection can extend who is able to delete it; configure `document.add` and `document.delete` together with that reach in mind.
 
 {{ example: documents/delete-document }}
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.ts.md
@@ -1347,7 +1347,9 @@ Pass `null` to clear `thumbnailBlobId` or `metadata`.
 
 ### Deleting Documents
 
-Delete a document (it must be closed first, or pass `forceCloseIfOpen: true`) — see the compiled call below. Root documents cannot be deleted. Deletion requires **direct `owner` permission** on the document or the app `owner` role — group- or collection-derived permission never qualifies, and `read-write` editors can delete records and content but not the document itself.
+Delete a document (it must be closed first, or pass `forceCloseIfOpen: true`) — see the compiled call below. Root documents cannot be deleted. Deletion requires **direct `owner` permission** on the document or the app `owner` role — group-derived permission never qualifies, and `read-write` editors can delete records and content but not the document itself.
+
+The one exception: if the caller is neither the owner nor an app owner, the platform falls back to checking every collection the document belongs to and allows the delete if **any** one collection's `document.delete` CEL rule passes. That rule defaults to `"false"` (deny) — see [Rule Sets for Collection Management](AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.md#rule-sets-for-collection-management) — so deletion never widens past owner/app-owner unless an app explicitly configures it. Because that rule is evaluated per collection, adding a document to a collection can extend who is able to delete it; configure `document.add` and `document.delete` together with that reach in mind.
 
 ```typescript
   // Must be closed first

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.swift.md
@@ -680,7 +680,7 @@ Collections (see the [Documents guide](AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.md#col
 **Resource type:** `collection`. **Categories and operations:**
 
 - `category: "collection"` — `create`, `edit`, `delete`, `get` (the read op, parallel to `group.get`; use `get` in TOML configs).
-- `category: "document"` — `add`, `remove`, `list` (controls which documents the collection can hold).
+- `category: "document"` — `add`, `remove`, `delete`, `list` (controls which documents the collection can hold, plus authorization for deleting a member document outright — see [Deleting Documents](AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.md#deleting-documents)).
 - `category: "member"` — `add`, `remove`, `list`.
 
 **Default rule set:** A collection type with no `CollectionTypeConfig` row falls back to:
@@ -691,11 +691,14 @@ Collections (see the [Documents guide](AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.md#col
 | `collection.edit` / `delete` | `user.userId == collection.createdBy` | Creator only |
 | `collection.get` | `user.userId == collection.createdBy \|\| hasCollectionAccess(collection.collectionId)` | Creator or collection member (direct or via `CollectionGroupPermission`) |
 | `document.add` / `remove` | `user.userId == collection.createdBy` | Creator only |
+| `document.delete` | `"false"` | Denied. Unlike every other write op above, NOT creator-only — an app must explicitly configure this op to let a non-owner/non-app-owner delete a member document at all |
 | `document.list` | `user.userId == collection.createdBy \|\| hasCollectionAccess(collection.collectionId)` | Creator or collection member |
 | `member.add` / `remove` | `user.userId == collection.createdBy` | Creator only |
 | `member.list` | `user.userId == collection.createdBy \|\| hasCollectionAccess(collection.collectionId)` | Creator or collection member |
 
 Per-op fallback applies — configured ops always win, missing ops resolve against this table. A `CollectionTypeConfig` row whose `ruleSetId` is null is an explicit opt-out and denies everything except admin/owner. A non-creator reader/writer removing their own membership via `member.remove` is denied (403) unless the rule set grants it.
+
+`document.delete` is distinct from `document.remove`: `remove` only detaches a document from this collection, while `delete` authorizes destroying the whole document (`client.documents.delete`) when the caller isn't the document's owner or the app owner — the delete endpoint checks every collection containing the document and allows the delete if any one collection's `document.delete` rule passes. Because that check runs per collection, granting `document.add` on a collection can extend who is able to delete documents placed in it — configure `document.add` and `document.delete` together with that reach in mind.
 
 ### CEL context for collection rule sets
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.template.md
@@ -484,7 +484,7 @@ Collections (see the [Documents guide](AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.md#col
 **Resource type:** `collection`. **Categories and operations:**
 
 - `category: "collection"` — `create`, `edit`, `delete`, `get` (the read op, parallel to `group.get`; use `get` in TOML configs).
-- `category: "document"` — `add`, `remove`, `list` (controls which documents the collection can hold).
+- `category: "document"` — `add`, `remove`, `delete`, `list` (controls which documents the collection can hold, plus authorization for deleting a member document outright — see [Deleting Documents](AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.md#deleting-documents)).
 - `category: "member"` — `add`, `remove`, `list`.
 
 **Default rule set:** A collection type with no `CollectionTypeConfig` row falls back to:
@@ -495,11 +495,14 @@ Collections (see the [Documents guide](AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.md#col
 | `collection.edit` / `delete` | `user.userId == collection.createdBy` | Creator only |
 | `collection.get` | `user.userId == collection.createdBy \|\| hasCollectionAccess(collection.collectionId)` | Creator or collection member (direct or via `CollectionGroupPermission`) |
 | `document.add` / `remove` | `user.userId == collection.createdBy` | Creator only |
+| `document.delete` | `"false"` | Denied. Unlike every other write op above, NOT creator-only — an app must explicitly configure this op to let a non-owner/non-app-owner delete a member document at all |
 | `document.list` | `user.userId == collection.createdBy \|\| hasCollectionAccess(collection.collectionId)` | Creator or collection member |
 | `member.add` / `remove` | `user.userId == collection.createdBy` | Creator only |
 | `member.list` | `user.userId == collection.createdBy \|\| hasCollectionAccess(collection.collectionId)` | Creator or collection member |
 
 Per-op fallback applies — configured ops always win, missing ops resolve against this table. A `CollectionTypeConfig` row whose `ruleSetId` is null is an explicit opt-out and denies everything except admin/owner. A non-creator reader/writer removing their own membership via `member.remove` is denied (403) unless the rule set grants it.
+
+`document.delete` is distinct from `document.remove`: `remove` only detaches a document from this collection, while `delete` authorizes destroying the whole document (`client.documents.delete`) when the caller isn't the document's owner or the app owner — the delete endpoint checks every collection containing the document and allows the delete if any one collection's `document.delete` rule passes. Because that check runs per collection, granting `document.add` on a collection can extend who is able to delete documents placed in it — configure `document.add` and `document.delete` together with that reach in mind.
 
 ### CEL context for collection rule sets
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.ts.md
@@ -661,7 +661,7 @@ Collections (see the [Documents guide](AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.md#col
 **Resource type:** `collection`. **Categories and operations:**
 
 - `category: "collection"` — `create`, `edit`, `delete`, `get` (the read op, parallel to `group.get`; use `get` in TOML configs).
-- `category: "document"` — `add`, `remove`, `list` (controls which documents the collection can hold).
+- `category: "document"` — `add`, `remove`, `delete`, `list` (controls which documents the collection can hold, plus authorization for deleting a member document outright — see [Deleting Documents](AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.md#deleting-documents)).
 - `category: "member"` — `add`, `remove`, `list`.
 
 **Default rule set:** A collection type with no `CollectionTypeConfig` row falls back to:
@@ -672,11 +672,14 @@ Collections (see the [Documents guide](AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.md#col
 | `collection.edit` / `delete` | `user.userId == collection.createdBy` | Creator only |
 | `collection.get` | `user.userId == collection.createdBy \|\| hasCollectionAccess(collection.collectionId)` | Creator or collection member (direct or via `CollectionGroupPermission`) |
 | `document.add` / `remove` | `user.userId == collection.createdBy` | Creator only |
+| `document.delete` | `"false"` | Denied. Unlike every other write op above, NOT creator-only — an app must explicitly configure this op to let a non-owner/non-app-owner delete a member document at all |
 | `document.list` | `user.userId == collection.createdBy \|\| hasCollectionAccess(collection.collectionId)` | Creator or collection member |
 | `member.add` / `remove` | `user.userId == collection.createdBy` | Creator only |
 | `member.list` | `user.userId == collection.createdBy \|\| hasCollectionAccess(collection.collectionId)` | Creator or collection member |
 
 Per-op fallback applies — configured ops always win, missing ops resolve against this table. A `CollectionTypeConfig` row whose `ruleSetId` is null is an explicit opt-out and denies everything except admin/owner. A non-creator reader/writer removing their own membership via `member.remove` is denied (403) unless the rule set grants it.
+
+`document.delete` is distinct from `document.remove`: `remove` only detaches a document from this collection, while `delete` authorizes destroying the whole document (`client.documents.delete`) when the caller isn't the document's owner or the app owner — the delete endpoint checks every collection containing the document and allows the delete if any one collection's `document.delete` rule passes. Because that check runs per collection, granting `document.add` on a collection can extend who is able to delete documents placed in it — configure `document.add` and `document.delete` together with that reach in mind.
 
 ### CEL context for collection rule sets
 

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.swift.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.swift.md
@@ -1205,6 +1205,8 @@ Receive endpoint: `POST /app/{appId}/webhook/{webhookKey}`. The platform verifie
 
 CLI: `primitive webhooks list | get | create | update | delete | rotate-secret | test | events <webhook-key>` — `events` lists recent deliveries (accepted / rejected / duplicate / `workflow_not_active`). `active` and `paused` are the settable statuses (`create` and `update` reject anything else, and `create` defaults to `active`); `archived` is reserved for delete and only appears on read — `list --status` filters by `active`, `paused`, or `archived`.
 
+`webhooks test <webhook-key> --payload '<json>'` delivers and signs that JSON object exactly as given — pass the event directly (e.g. `'{"type":"charge.succeeded","data":{"id":"ch_1"}}'`), not wrapped in `{"payload": ...}`. Omitting `--payload` (or passing a non-object) sends a canned `{"type":"webhook.test", ...}` ping instead.
+
 A `workflow_not_active` delivery means the bound workflow was draft or archived when the event arrived: the request is acked with HTTP 202 `{ received: true }` (so the sender doesn't retry) but the workflow is **not dispatched**. Activate the workflow and resend — these events are excluded from deduplication, so the resend isn't dropped as a duplicate. Binding a webhook to a not-yet-active workflow succeeds and returns a non-blocking `warning` carrying `WORKFLOW_NOT_ACTIVE`.
 
 ## Cron triggers

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md
@@ -1205,6 +1205,8 @@ Receive endpoint: `POST /app/{appId}/webhook/{webhookKey}`. The platform verifie
 
 CLI: `primitive webhooks list | get | create | update | delete | rotate-secret | test | events <webhook-key>` — `events` lists recent deliveries (accepted / rejected / duplicate / `workflow_not_active`). `active` and `paused` are the settable statuses (`create` and `update` reject anything else, and `create` defaults to `active`); `archived` is reserved for delete and only appears on read — `list --status` filters by `active`, `paused`, or `archived`.
 
+`webhooks test <webhook-key> --payload '<json>'` delivers and signs that JSON object exactly as given — pass the event directly (e.g. `'{"type":"charge.succeeded","data":{"id":"ch_1"}}'`), not wrapped in `{"payload": ...}`. Omitting `--payload` (or passing a non-object) sends a canned `{"type":"webhook.test", ...}` ping instead.
+
 A `workflow_not_active` delivery means the bound workflow was draft or archived when the event arrived: the request is acked with HTTP 202 `{ received: true }` (so the sender doesn't retry) but the workflow is **not dispatched**. Activate the workflow and resend — these events are excluded from deduplication, so the resend isn't dropped as a duplicate. Binding a webhook to a not-yet-active workflow succeeds and returns a non-blocking `warning` carrying `WORKFLOW_NOT_ACTIVE`.
 
 ## Cron triggers

--- a/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.ts.md
+++ b/guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.ts.md
@@ -1205,6 +1205,8 @@ Receive endpoint: `POST /app/{appId}/webhook/{webhookKey}`. The platform verifie
 
 CLI: `primitive webhooks list | get | create | update | delete | rotate-secret | test | events <webhook-key>` — `events` lists recent deliveries (accepted / rejected / duplicate / `workflow_not_active`). `active` and `paused` are the settable statuses (`create` and `update` reject anything else, and `create` defaults to `active`); `archived` is reserved for delete and only appears on read — `list --status` filters by `active`, `paused`, or `archived`.
 
+`webhooks test <webhook-key> --payload '<json>'` delivers and signs that JSON object exactly as given — pass the event directly (e.g. `'{"type":"charge.succeeded","data":{"id":"ch_1"}}'`), not wrapped in `{"payload": ...}`. Omitting `--payload` (or passing a non-object) sends a canned `{"type":"webhook.test", ...}` ping instead.
+
 A `workflow_not_active` delivery means the bound workflow was draft or archived when the event arrived: the request is acked with HTTP 202 `{ received: true }` (so the sender doesn't retry) but the workflow is **not dispatched**. Activate the workflow and resend — these events are excluded from deduplication, so the resend isn't dropped as a duplicate. Binding a webhook to a not-yet-active workflow succeeds and returns a non-blocking `warning` carrying `WORKFLOW_NOT_ACTIVE`.
 
 ## Cron triggers

--- a/guides/latest/guides.json
+++ b/guides/latest/guides.json
@@ -15,7 +15,7 @@
     }
   },
   "builtAgainst": {
-    "stampedAt": "2026-07-14",
+    "stampedAt": "2026-07-15",
     "channel": "next",
     "packages": {
       "js-bao-wss-client": "2.0.4",


### PR DESCRIPTION
Automated `docs-next-sync` pass against the library main tips, triggered by the nightly release js-bao-wss#1595.



> **Delta PR.** This PR covers only the library window since the previous sync PR (or since the last merge, if none is open) — it does not contain earlier open sync PRs' content. Merge sync PRs **oldest first**; consecutive ones conflict on the stamp/submodule pin by construction, and `docs-pr-sweep` knows how to rebase and land the chain.

SYNC_STATUS: ready

# docs-next-sync report — 2026-07-15

Truing window: `js-bao-wss` `ae9f096d..2bc33033` (13 commits, seeded from the newest already-open sync PR's stamp; this is the delta nobody had trued yet). `primitive-app-dev` and `swift-primitive-app-dev`: 0 commits, no action.

## Commit disposition

| Commits | PR | Disposition |
|---|---|---|
| `3de297f9`, `ea9724d1`, `11947269`, `ffc66f09`, `52867aa2`, `8f1dc5bb`, `9ac3d6f2`, `2bc33033` (merge) | #1531 — privileged non-owner document delete via collection CEL rule (closes #1429) | **Updated docs.** New `document.delete` collection-rule op (default `"false"`, non-owner/non-app-owner document deletion authorized per-collection, OR semantics). Updated: `guides/latest/AGENT_GUIDE_TO_PRIMITIVE_DOCUMENTS.template.md` ("Deleting Documents" — added the collection-rule exception to the owner/app-owner-only statement) and `guides/latest/AGENT_GUIDE_TO_PRIMITIVE_USERS_AND_GROUPS.template.md` ("Rule Sets for Collection Management" — added `document.delete` to the category-ops list and the defaults table, plus a note on the `document.add`/`document.delete` reach implication). No corresponding human-doc (`docs/`) statement existed to correct — whole-document deletion and collection rule-set enumeration are reference-dense content that only lives in the agent guides today; `docs/getting-started/access-control.md` and `users-and-groups.md` stay at concept altitude and don't enumerate this op, so no human-doc edit was needed for sync. |
| `7e844df8`, `a2ada9ad`, `54814b1c` (merge), `0be0e097`, `5bc3ccb3` (merge) | #1282 — fix: honor top-level webhooks test payload (closes #1236) | **Updated docs.** Bug fix makes `primitive webhooks test <id> --payload '<json>'` actually honor a top-level (un-wrapped) payload instead of silently falling back to the canned ping — previously undocumented anywhere in this doc set, so this is new-capability documentation for an already-shipped flag, not a stale-fact correction. Added a `--payload` example + one-line semantics note to `docs/getting-started/workflows.md` ("Via Inbound Webhooks"), `docs/getting-started/primitive-cli.md` ("Webhooks"), and the mirrored CLI line in `guides/latest/AGENT_GUIDE_TO_PRIMITIVE_WORKFLOWS.template.md` ("Inbound webhooks"). |

No other commits in the window (the remainder are the same two PRs' review-feedback and merge-from-main commits, already covered above).

## Issues

Checked all open `primitive-docs` issues (#271, #265) for blockers landing in this window — both are gated on `js-bao-wss#1451` and `#1470` respectively (Swift parity for `initialMetadata` and typed workflow invocation), neither of which is in `ae9f096d..2bc33033`. Both remain deferred, unchanged this pass. No issue in this window names #1429 or #1236 as a blocker, so nothing to close. No parity/platform-gap issues filed — both changes in this window are server + CLI behavior with no JS/Swift asymmetry (rules JSON is opaque to clients; the CLI fix needed no client change).

No `Fixes #NN` lines — no open docs issue was resolved by this pass.

## Gates

- `pnpm check:examples` — ✅ green (TS compile 161/163 against source-built `js-bao-wss-client`/`js-bao`; Swift compile skipped, no macOS host, per the gate's documented behavior; guide render/registry sync clean; 213 TOML blocks valid; 490 CLI invocations validated against source-built `primitive-admin`, including the new `webhooks test --payload` line; source-stamp gate matches)
- `npx vitepress build docs` — ✅ green, no dead links
- `node scripts/check-example-parity.mjs` — ✅ informational only, no new lone-language fences introduced by this pass
- `pnpm render:guides` — ✅ re-run after edits, 20 templates / 36 builds current
- `pnpm stamp:sources` — ✅ restamped to `2026-07-15` / `js-bao-wss@2bc33033`

## Scope note

Stayed within the surfaced window: two logical changes, both trued. No whole-set audit (reserved for publish time / `docs-pr-sweep`). No larger drafted changes (new pages, restructures, removals) this pass — both edits are small additions to existing sections.

---
Review the doc changes and the disposition above, then merge into `next`. Publishing to `main` happens separately at a production release.

> Generated unattended by the Claude Code CLI. Verify facts against source before merging.